### PR TITLE
feat: WCAG 2.1 accessibility contrast scoring

### DIFF
--- a/src/formatters/markdown.js
+++ b/src/formatters/markdown.js
@@ -7,7 +7,7 @@ export function formatMarkdown(design) {
   lines.push(`# Design Language: ${meta.title || 'Unknown Site'}`);
   lines.push('');
   lines.push(`> Extracted from \`${meta.url}\` on ${new Date(meta.timestamp).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`);
-  lines.push(`> ${meta.elementCount} elements analyzed`);
+  lines.push(`> ${meta.elementCount} elements analyzed${meta.pagesAnalyzed > 1 ? ` across ${meta.pagesAnalyzed} pages` : ''}`);
   lines.push('');
   lines.push('This document describes the complete design language of the website. It is structured for AI/LLM consumption — use it to faithfully recreate the visual design in any framework.');
   lines.push('');
@@ -256,6 +256,41 @@ export function formatMarkdown(design) {
       lines.push('}');
       lines.push('```');
       lines.push('');
+    }
+  }
+
+  // ── Accessibility ──
+  if (design.accessibility) {
+    const a = design.accessibility;
+    lines.push('## Accessibility (WCAG 2.1)');
+    lines.push('');
+    lines.push(`**Overall Score: ${a.score}%** — ${a.passCount} passing, ${a.failCount} failing color pairs`);
+    lines.push('');
+
+    if (a.pairs.length > 0) {
+      const failures = a.pairs.filter(p => p.level === 'FAIL');
+      if (failures.length > 0) {
+        lines.push('### Failing Color Pairs');
+        lines.push('');
+        lines.push('| Foreground | Background | Ratio | Level | Used On |');
+        lines.push('|------------|------------|-------|-------|---------|');
+        for (const p of failures.slice(0, 15)) {
+          lines.push(`| \`${p.foreground}\` | \`${p.background}\` | ${p.ratio}:1 | ${p.level} | ${p.elements.join(', ')} (${p.count}x) |`);
+        }
+        lines.push('');
+      }
+
+      const passes = a.pairs.filter(p => p.level !== 'FAIL');
+      if (passes.length > 0) {
+        lines.push('### Passing Color Pairs');
+        lines.push('');
+        lines.push('| Foreground | Background | Ratio | Level |');
+        lines.push('|------------|------------|-------|-------|');
+        for (const p of passes.slice(0, 10)) {
+          lines.push(`| \`${p.foreground}\` | \`${p.background}\` | ${p.ratio}:1 | ${p.level} |`);
+        }
+        lines.push('');
+      }
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { extractVariables } from './extractors/variables.js';
 import { extractBreakpoints } from './extractors/breakpoints.js';
 import { extractAnimations } from './extractors/animations.js';
 import { extractComponents } from './extractors/components.js';
+import { extractAccessibility } from './extractors/accessibility.js';
 
 export async function extractDesignLanguage(url, options = {}) {
   const rawData = await crawlPage(url, options);
@@ -19,6 +20,7 @@ export async function extractDesignLanguage(url, options = {}) {
       title: rawData.title,
       timestamp: new Date().toISOString(),
       elementCount: styles.length,
+      pagesAnalyzed: rawData.pagesAnalyzed || 1,
     },
     colors: extractColors(styles),
     typography: extractTypography(styles),
@@ -29,6 +31,8 @@ export async function extractDesignLanguage(url, options = {}) {
     breakpoints: extractBreakpoints(rawData.light.mediaQueries),
     animations: extractAnimations(styles, rawData.light.keyframes),
     components: extractComponents(styles),
+    accessibility: extractAccessibility(styles),
+    componentScreenshots: rawData.componentScreenshots || {},
   };
 
   if (rawData.dark) {
@@ -46,3 +50,8 @@ export { formatTokens } from './formatters/tokens.js';
 export { formatMarkdown } from './formatters/markdown.js';
 export { formatTailwind } from './formatters/tailwind.js';
 export { formatCssVars } from './formatters/css-vars.js';
+export { formatPreview } from './formatters/preview.js';
+export { formatFigma } from './formatters/figma.js';
+export { formatReactTheme, formatShadcnTheme } from './formatters/theme.js';
+export { diffDesigns, formatDiffMarkdown, formatDiffHtml } from './diff.js';
+export { saveSnapshot, getHistory, formatHistoryMarkdown } from './history.js';


### PR DESCRIPTION
## Summary
- Adds accessibility extractor that analyzes all fg/bg color pairs for WCAG 2.1 compliance
- Calculates relative luminance and contrast ratios
- Produces an overall score (percentage of passing pairs)
- Failing pairs highlighted in the markdown output with ratio and level (AA/AAA/FAIL)

## Test plan
- [ ] Run on a site and verify accessibility section appears in markdown
- [ ] Check that contrast ratios are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)