### PR TITLE
feat: v2.0 — complete feature suite (8 new capabilities)

### DIFF
--- a/bin/design-extract.js
+++ b/bin/design-extract.js
@@ -10,6 +10,11 @@ import { formatMarkdown } from '../src/formatters/markdown.js';
 import { formatTokens } from '../src/formatters/tokens.js';
 import { formatTailwind } from '../src/formatters/tailwind.js';
 import { formatCssVars } from '../src/formatters/css-vars.js';
+import { formatPreview } from '../src/formatters/preview.js';
+import { formatFigma } from '../src/formatters/figma.js';
+import { formatReactTheme, formatShadcnTheme } from '../src/formatters/theme.js';
+import { diffDesigns, formatDiffMarkdown, formatDiffHtml } from '../src/diff.js';
+import { saveSnapshot, getHistory, formatHistoryMarkdown } from '../src/history.js';
 import { nameFromUrl } from '../src/utils.js';
 
 const program = new Command();
@@ -17,40 +22,47 @@ const program = new Command();
 program
   .name('designlang')
   .description('Extract the complete design language from any website')
-  .version('1.0.0')
+  .version('2.0.0');
+
+// ── Main command: extract ──────────────────────────────────────
+program
   .argument('<url>', 'URL to extract design language from')
   .option('-o, --out <dir>', 'output directory', './design-extract-output')
   .option('-n, --name <name>', 'output file prefix (default: derived from URL)')
   .option('-w, --width <px>', 'viewport width', parseInt, 1280)
-  .option('-h, --height <px>', 'viewport height', parseInt, 800)
+  .option('--height <px>', 'viewport height', parseInt, 800)
   .option('--wait <ms>', 'wait after page load (ms)', parseInt, 0)
   .option('--dark', 'also extract dark mode styles')
+  .option('--depth <n>', 'number of internal pages to also crawl', parseInt, 0)
+  .option('--screenshots', 'capture component screenshots')
+  .option('--framework <type>', 'generate framework theme (react, shadcn)')
+  .option('--no-history', 'skip saving to history')
   .option('--verbose', 'show detailed progress')
   .action(async (url, opts) => {
-    // Ensure URL has protocol
     if (!url.startsWith('http')) url = `https://${url}`;
-
     const prefix = opts.name || nameFromUrl(url);
     const outDir = resolve(opts.out);
 
     console.log('');
-    console.log(chalk.bold('  design-extract'));
-    console.log(chalk.gray(`  ${url}`));
+    console.log(chalk.bold('  designlang'));
+    console.log(chalk.gray(`  ${url}${opts.depth > 0 ? ` (+ ${opts.depth} pages)` : ''}`));
     console.log('');
 
     const spinner = ora('Launching browser...').start();
 
     try {
-      spinner.text = 'Crawling page and extracting styles...';
+      spinner.text = `Crawling${opts.depth > 0 ? ` (depth: ${opts.depth})` : ''}...`;
       const design = await extractDesignLanguage(url, {
         width: opts.width,
-        height: opts.height,
+        height: parseInt(opts.height) || 800,
         wait: opts.wait,
         dark: opts.dark,
+        depth: opts.depth,
+        screenshots: opts.screenshots,
+        outDir,
       });
 
-      spinner.text = 'Generating output files...';
-
+      spinner.text = 'Generating outputs...';
       mkdirSync(outDir, { recursive: true });
 
       const files = [
@@ -58,10 +70,29 @@ program
         { name: `${prefix}-design-tokens.json`, content: formatTokens(design), label: 'Design Tokens (W3C)' },
         { name: `${prefix}-tailwind.config.js`, content: formatTailwind(design), label: 'Tailwind Config' },
         { name: `${prefix}-variables.css`, content: formatCssVars(design), label: 'CSS Variables' },
+        { name: `${prefix}-preview.html`, content: formatPreview(design), label: 'Visual Preview' },
+        { name: `${prefix}-figma-variables.json`, content: formatFigma(design), label: 'Figma Variables' },
       ];
+
+      // Framework-specific themes
+      if (opts.framework === 'react') {
+        files.push({ name: `${prefix}-theme.js`, content: formatReactTheme(design), label: 'React Theme' });
+      } else if (opts.framework === 'shadcn') {
+        files.push({ name: `${prefix}-shadcn-theme.css`, content: formatShadcnTheme(design), label: 'shadcn/ui Theme' });
+      } else {
+        // Generate both by default
+        files.push({ name: `${prefix}-theme.js`, content: formatReactTheme(design), label: 'React Theme' });
+        files.push({ name: `${prefix}-shadcn-theme.css`, content: formatShadcnTheme(design), label: 'shadcn/ui Theme' });
+      }
 
       for (const file of files) {
         writeFileSync(join(outDir, file.name), file.content, 'utf-8');
+      }
+
+      // Save to history
+      if (opts.history !== false) {
+        const histInfo = saveSnapshot(design);
+        if (opts.verbose) spinner.info(`Snapshot #${histInfo.snapshotCount} saved for ${histInfo.hostname}`);
       }
 
       spinner.succeed('Extraction complete!');
@@ -72,12 +103,20 @@ program
         const sizeStr = size > 1024 ? `${(size / 1024).toFixed(1)}KB` : `${size}B`;
         console.log(`  ${chalk.green('✓')} ${chalk.cyan(file.name)} ${chalk.gray(`(${sizeStr})`)} — ${file.label}`);
       }
+      if (opts.screenshots && design.componentScreenshots && Object.keys(design.componentScreenshots).length > 0) {
+        for (const [, info] of Object.entries(design.componentScreenshots)) {
+          console.log(`  ${chalk.green('✓')} ${chalk.cyan(info.path)} — ${info.label} screenshot`);
+        }
+      }
       console.log('');
       console.log(chalk.gray(`  Saved to ${outDir}`));
 
-      // Summary stats
+      // Summary
       console.log('');
       console.log(chalk.bold('  Summary:'));
+      if (design.meta.pagesAnalyzed > 1) {
+        console.log(`  ${chalk.gray('Pages:')} ${design.meta.pagesAnalyzed} pages analyzed`);
+      }
       console.log(`  ${chalk.gray('Colors:')} ${design.colors.all.length} unique colors`);
       console.log(`  ${chalk.gray('Fonts:')} ${design.typography.families.map(f => f.name).join(', ') || 'none detected'}`);
       console.log(`  ${chalk.gray('Spacing:')} ${design.spacing.scale.length} values${design.spacing.base ? ` (base: ${design.spacing.base}px)` : ''}`);
@@ -86,6 +125,13 @@ program
       console.log(`  ${chalk.gray('Breakpoints:')} ${design.breakpoints.length} breakpoints`);
       console.log(`  ${chalk.gray('Components:')} ${Object.keys(design.components).length} patterns detected`);
       console.log(`  ${chalk.gray('CSS Vars:')} ${Object.values(design.variables).reduce((s, v) => s + Object.keys(v).length, 0)} custom properties`);
+
+      // Accessibility summary
+      if (design.accessibility) {
+        const a = design.accessibility;
+        const scoreColor = a.score >= 80 ? chalk.green : a.score >= 50 ? chalk.yellow : chalk.red;
+        console.log(`  ${chalk.gray('A11y:')} ${scoreColor(`${a.score}% WCAG score`)} (${a.failCount} failing pairs)`);
+      }
       console.log('');
 
     } catch (err) {
@@ -99,6 +145,75 @@ program
       }
       process.exit(1);
     }
+  });
+
+// ── Diff command ──────────────────────────────────────────────
+program
+  .command('diff <urlA> <urlB>')
+  .description('Compare design languages of two websites')
+  .option('-o, --out <dir>', 'output directory', './design-diff-output')
+  .action(async (urlA, urlB, opts) => {
+    if (!urlA.startsWith('http')) urlA = `https://${urlA}`;
+    if (!urlB.startsWith('http')) urlB = `https://${urlB}`;
+
+    console.log('');
+    console.log(chalk.bold('  designlang diff'));
+    console.log(chalk.gray(`  ${urlA}`));
+    console.log(chalk.gray(`  ${urlB}`));
+    console.log('');
+
+    const spinner = ora('Extracting Site A...').start();
+
+    try {
+      const designA = await extractDesignLanguage(urlA);
+      spinner.text = 'Extracting Site B...';
+      const designB = await extractDesignLanguage(urlB);
+
+      spinner.text = 'Comparing...';
+      const diff = diffDesigns(designA, designB);
+
+      const outDir = resolve(opts.out);
+      mkdirSync(outDir, { recursive: true });
+
+      const mdContent = formatDiffMarkdown(diff);
+      const htmlContent = formatDiffHtml(diff);
+
+      writeFileSync(join(outDir, 'diff.md'), mdContent, 'utf-8');
+      writeFileSync(join(outDir, 'diff.html'), htmlContent, 'utf-8');
+
+      spinner.succeed('Comparison complete!');
+      console.log('');
+      console.log(`  ${chalk.green('✓')} ${chalk.cyan('diff.md')} — Markdown comparison`);
+      console.log(`  ${chalk.green('✓')} ${chalk.cyan('diff.html')} — Visual comparison`);
+      console.log('');
+      console.log(chalk.gray(`  Saved to ${outDir}`));
+
+      // Quick summary
+      for (const s of diff.sections) {
+        if (s.changed && s.changed.length > 0) {
+          for (const c of s.changed) {
+            console.log(`  ${chalk.yellow('≠')} ${s.name} — ${c.property}: ${c.a} → ${c.b}`);
+          }
+        }
+      }
+      console.log('');
+
+    } catch (err) {
+      spinner.fail('Comparison failed');
+      console.error(chalk.red(`\n  ${err.message}\n`));
+      process.exit(1);
+    }
+  });
+
+// ── History command ──────────────────────────────────────────
+program
+  .command('history <url>')
+  .description('View design history for a website')
+  .action(async (url) => {
+    if (!url.startsWith('http')) url = `https://${url}`;
+    const history = getHistory(url);
+    console.log('');
+    console.log(formatHistoryMarkdown(url, history));
   });
 
 program.parse();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designlang",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Extract the complete design language from any website — colors, typography, spacing, shadows, and more. Outputs AI-optimized markdown, W3C design tokens, Tailwind config, and CSS variables.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Major v2.0 release adding 8 differentiating features:

- **Visual HTML preview** — gorgeous dark-themed report with color swatches, type scale visualization, shadow cards, spacing bars, and accessibility score
- **Component screenshots** — Playwright captures representative buttons, cards, inputs, navigation, and hero sections as PNG files
- **Framework themes** — generates both React/CSS-in-JS theme object and shadcn/ui CSS variables
- **Figma Variables JSON** — export to Figma-compatible format with light/dark mode support
- **Design diff** — `designlang diff <A> <B>` compares two sites side-by-side (MD + HTML output)
- **Historical tracking** — `designlang history <url>` shows how a site's design evolves over time
- **WCAG accessibility scoring** — contrast ratio analysis for all color pairs
- **Multi-page crawling** — `--depth` flag for site-wide design extraction

## Output files (8 per run, up from 4)
1. `*-design-language.md` — AI-optimized markdown
2. `*-design-tokens.json` — W3C format
3. `*-tailwind.config.js` — Tailwind theme
4. `*-variables.css` — CSS custom properties
5. `*-preview.html` — Visual preview report
6. `*-figma-variables.json` — Figma import
7. `*-theme.js` — React theme
8. `*-shadcn-theme.css` — shadcn/ui theme

## Test plan
- [x] Tested on vercel.com — all 8 files + 5 screenshots generated
- [x] Tested diff between vercel.com and stripe.com
- [x] Tested history command
- [x] Accessibility scoring: 94% WCAG score on vercel.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)