### PR TITLE
v7.0 part 2: MCP server + agent rules emitter

### DIFF
--- a/bin/design-extract.js
+++ b/bin/design-extract.js
@@ -186,6 +186,17 @@ program
       // WordPress theme (always generated)
       files.push({ name: `${prefix}-wordpress-theme.json`, content: formatWordPress(design), label: 'WordPress Theme' });
 
+      // MCP companion — the subset of `design` the MCP server serves when a
+      // user runs `designlang mcp --output-dir <dir>` later.
+      const mcpPayload = {
+        colors: { all: design.colors?.all || [] },
+        regions: design.regions || [],
+        componentClusters: design.componentClusters || [],
+        accessibility: { remediation: design.accessibility?.remediation || [] },
+        cssHealth: design.cssHealth || null,
+      };
+      files.push({ name: `${prefix}-mcp.json`, content: JSON.stringify(mcpPayload, null, 2), label: 'MCP companion' });
+
       for (const file of files) {
         writeFileSync(join(outDir, file.name), file.content, 'utf-8');
       }

--- a/bin/design-extract.js
+++ b/bin/design-extract.js
@@ -750,4 +750,14 @@ program
     }
   });
 
+// ── MCP server command ─────────────────────────────────────
+program
+  .command('mcp')
+  .description('Launch designlang MCP server over stdio (exposes latest extraction as resources + tools)')
+  .option('--output-dir <path>', 'Source extraction directory', './design-extract-output')
+  .action(async (opts) => {
+    const { run } = await import('../src/mcp/server.js');
+    await run(opts);
+  });
+
 program.parse();

--- a/bin/design-extract.js
+++ b/bin/design-extract.js
@@ -20,6 +20,7 @@ import { formatAndroidCompose } from '../src/formatters/android-compose.js';
 import { formatFlutterDart } from '../src/formatters/flutter-dart.js';
 import { formatVueTheme } from '../src/formatters/vue-theme.js';
 import { formatSvelteTheme } from '../src/formatters/svelte-theme.js';
+import { formatAgentRules } from '../src/formatters/agent-rules.js';
 import { loadConfig, mergeConfig } from '../src/config.js';
 import { diffDesigns, formatDiffMarkdown, formatDiffHtml } from '../src/diff.js';
 import { saveSnapshot, getHistory, formatHistoryMarkdown } from '../src/history.js';
@@ -68,6 +69,7 @@ program
   .option('--ignore <selectors...>', 'CSS selectors to remove before extraction')
   .option('--tokens-legacy', 'Emit pre-v7 flat token JSON (backward compat)')
   .option('--platforms <csv>', 'Additional platforms: web,ios,android,flutter,wordpress,all (web is always emitted)', 'web')
+  .option('--emit-agent-rules', 'Emit Cursor/Claude Code/generic agent rules')
   .option('--json', 'output raw JSON to stdout (for CI/CD)')
   .option('--json-pretty', 'output formatted JSON to stdout')
   .option('--no-history', 'skip saving to history')
@@ -225,6 +227,17 @@ program
           mkdirSync(join(p, '..'), { recursive: true });
           writeFileSync(p, out[name], 'utf-8');
           platformFiles.push({ path: p, label: `WordPress (${name})` });
+        }
+      }
+
+      // Agent rules (opt-in, also enabled by --full)
+      if (merged.emitAgentRules || merged.full) {
+        const agentFiles = formatAgentRules({ design, tokens: dtcgTokens, url });
+        for (const rel of Object.keys(agentFiles)) {
+          const p = join(outDir, rel);
+          mkdirSync(join(p, '..'), { recursive: true });
+          writeFileSync(p, agentFiles[rel], 'utf-8');
+          platformFiles.push({ path: p, label: `Agent rules (${rel})` });
         }
       }
 

--- a/src/config.js
+++ b/src/config.js
@@ -34,6 +34,7 @@ export function mergeConfig(cliOpts, config) {
     out: cliOpts.out || config.out || './design-extract-output',
     tokensLegacy: cliOpts.tokensLegacy || config.tokensLegacy || false,
     platforms: parsePlatforms(cliOpts.platforms ?? config.platforms ?? 'web'),
+    emitAgentRules: cliOpts.emitAgentRules || config.emitAgentRules || false,
   };
 }
 

--- a/src/formatters/agent-rules.js
+++ b/src/formatters/agent-rules.js
@@ -1,0 +1,116 @@
+// Agent rules emitter. Produces ready-to-drop files that teach coding agents
+// (Cursor, Claude Code, generic) to prefer the extracted design tokens
+// instead of inventing new colors/typography.
+//
+// Output: { relativePath: fileContent } — caller is responsible for writing.
+
+import { resolveRef } from './_token-ref.js';
+
+function hostFromUrl(url) {
+  try { return new URL(url).hostname; } catch { return url || 'unknown'; }
+}
+
+// Resolve a semantic token path to its concrete leaf value, or fall back.
+function resolveSemantic(tokens, path, fallback) {
+  const v = resolveRef(tokens, path);
+  return (typeof v === 'string' && v) ? v : fallback;
+}
+
+function firstFontFamily(tokens) {
+  const fam = tokens?.primitive?.fontFamily || {};
+  const keys = Object.keys(fam);
+  if (!keys.length) return 'system-ui';
+  const v = fam[keys[0]]?.$value;
+  return typeof v === 'string' ? v : 'system-ui';
+}
+
+function buildBody({ url, tokens, design, iso }) {
+  const actionPrimary = resolveSemantic(tokens, 'semantic.color.action.primary', '#000000');
+  const surfaceDefault = resolveSemantic(tokens, 'semantic.color.surface.default', '#ffffff');
+  const textBody = resolveSemantic(tokens, 'semantic.color.text.body', '#111111');
+  const radiusControl = resolveSemantic(tokens, 'semantic.radius.control', '0px');
+  const fontFamily = firstFontFamily(tokens);
+
+  const lines = [];
+  lines.push(`Source: ${url}`);
+  lines.push(`Extracted by designlang v7.0.0 on ${iso}`);
+  lines.push('');
+  lines.push('## Semantic tokens (use these)');
+  lines.push(`- color.action.primary: ${actionPrimary}`);
+  lines.push(`- color.surface.default: ${surfaceDefault}`);
+  lines.push(`- color.text.body: ${textBody}`);
+  lines.push(`- radius.control: ${radiusControl}`);
+  lines.push(`- typography.body.fontFamily: ${fontFamily}`);
+
+  const regions = Array.isArray(design?.regions) ? design.regions : [];
+  if (regions.length) {
+    lines.push('');
+    lines.push('## Regions');
+    const names = regions.map(r => r.role || r.name).filter(Boolean);
+    for (const n of names) lines.push(`- ${n}`);
+  }
+
+  lines.push('');
+  lines.push('## How to use');
+  lines.push('- Prefer `semantic.*` tokens over `primitive.*`.');
+  lines.push('- Never invent new tokens or hex values; reuse the ones above.');
+  lines.push('- When a value is missing, pick the closest existing semantic token and flag the gap.');
+  lines.push('- Reference tokens by their dotted path (e.g. `semantic.color.action.primary`).');
+
+  return { body: lines.join('\n'), actionPrimary };
+}
+
+function cursorFile({ url, body }) {
+  const front = [
+    '---',
+    `description: Design system extracted from ${url} — use these tokens, do not invent new ones.`,
+    'globs: **/*.{ts,tsx,jsx,js,css,scss,html,vue,svelte,swift,kt,dart,php}',
+    'alwaysApply: true',
+    '---',
+    '',
+    '# Design system reference',
+  ].join('\n');
+  return `${front}\n${body}\n`;
+}
+
+function claudeSkillFile({ url, body }) {
+  const host = hostFromUrl(url);
+  const front = [
+    '---',
+    'name: designlang-tokens',
+    `description: Use when styling UI for ${host} — references the extracted design system tokens instead of inventing colors, spacing, or typography.`,
+    '---',
+    '',
+    '# designlang tokens',
+  ].join('\n');
+  return `${front}\n${body}\n`;
+}
+
+function claudeFragmentFile({ url, body }) {
+  // Plain H2 section ready to append to a project's CLAUDE.md (no frontmatter).
+  return `## Design system (via designlang)\n\n${body}\n`;
+}
+
+function agentsMdFile({ url, body }) {
+  const head = [
+    '# Agent instructions — design system',
+    '',
+    `This project follows the design system extracted from ${url}.`,
+    'Any coding agent working here must use the tokens below and avoid inventing new ones.',
+    '',
+  ].join('\n');
+  return `${head}${body}\n`;
+}
+
+export function formatAgentRules({ design, tokens, url }) {
+  const resolvedUrl = url || tokens?.$metadata?.source || design?.meta?.url || 'unknown';
+  const iso = tokens?.$metadata?.generatedAt || new Date().toISOString();
+  const { body } = buildBody({ url: resolvedUrl, tokens, design: design || {}, iso });
+
+  return {
+    '.cursor/rules/designlang.mdc': cursorFile({ url: resolvedUrl, body }),
+    '.claude/skills/designlang/SKILL.md': claudeSkillFile({ url: resolvedUrl, body }),
+    'CLAUDE.md.fragment': claudeFragmentFile({ url: resolvedUrl, body }),
+    'agents.md': agentsMdFile({ url: resolvedUrl, body }),
+  };
+}

--- a/src/mcp/resources.js
+++ b/src/mcp/resources.js
@@ -1,0 +1,64 @@
+// MCP resources builder. Pure/testable — returns { list, read } over the
+// loaded design + tokens. No transport concerns here.
+
+const URIS = {
+  'designlang://tokens/primitive': {
+    name: 'Primitive tokens',
+    description: 'DTCG primitive tier (raw colors, spacing, fonts, etc.)',
+  },
+  'designlang://tokens/semantic': {
+    name: 'Semantic tokens',
+    description: 'DTCG semantic tier (aliases like action.primary, surface.default)',
+  },
+  'designlang://regions': {
+    name: 'Semantic regions',
+    description: 'Detected page regions (hero, nav, footer, etc.) with bounds',
+  },
+  'designlang://components': {
+    name: 'Component clusters',
+    description: 'Clustered component instances with variant CSS',
+  },
+  'designlang://health': {
+    name: 'CSS health',
+    description: 'Coverage, dead-rule, and z-index-stack diagnostics',
+  },
+};
+
+function rpcError(code, message) {
+  const e = new Error(message);
+  e.code = code;
+  return e;
+}
+
+export function buildResources({ design, tokens }) {
+  function payloadFor(uri) {
+    switch (uri) {
+      case 'designlang://tokens/primitive': return tokens?.primitive ?? null;
+      case 'designlang://tokens/semantic':  return tokens?.semantic ?? null;
+      case 'designlang://regions':          return design?.regions ?? [];
+      case 'designlang://components':       return design?.componentClusters ?? [];
+      case 'designlang://health':           return design?.cssHealth ?? null;
+      default: return undefined;
+    }
+  }
+
+  return {
+    list() {
+      return Object.keys(URIS).map((uri) => ({
+        uri,
+        name: URIS[uri].name,
+        description: URIS[uri].description,
+        mimeType: 'application/json',
+      }));
+    },
+    read(uri) {
+      const payload = payloadFor(uri);
+      if (payload === undefined) throw rpcError(-32602, `Unknown resource URI: ${uri}`);
+      return {
+        uri,
+        mimeType: 'application/json',
+        text: JSON.stringify(payload),
+      };
+    },
+  };
+}

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -39,15 +39,21 @@ function loadExtraction(outputDir) {
     return { tokens: null, design: {} };
   }
 
-  // We have no single dump of the full design object on disk today, so we
-  // build a minimal one sufficient for the tools we expose. Anything not
-  // present simply produces empty arrays / null returns.
+  // Load the MCP companion written at extraction time (`*-mcp.json`).
+  // Falls back to empty shape if absent — older extractions stay usable for
+  // token resources/tools even without regions/components/health.
+  const companionPath = join(outputDir, `${latest.prefix}-mcp.json`);
+  let companion = null;
+  if (existsSync(companionPath)) {
+    try { companion = JSON.parse(readFileSync(companionPath, 'utf-8')); } catch { /* ignore */ }
+  }
+
   const design = {
-    colors: { all: [] },
-    regions: [],
-    componentClusters: [],
-    accessibility: { remediation: [] },
-    cssHealth: null,
+    colors: { all: companion?.colors?.all || [] },
+    regions: companion?.regions || [],
+    componentClusters: companion?.componentClusters || [],
+    accessibility: { remediation: companion?.accessibility?.remediation || [] },
+    cssHealth: companion?.cssHealth ?? null,
   };
 
   return { tokens, design };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -1,0 +1,104 @@
+// Thin stdio MCP server glue. Loads the latest extraction from the given
+// output directory and wires buildResources + buildTools into the SDK.
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { join, resolve } from 'path';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { buildResources } from './resources.js';
+import { buildTools } from './tools.js';
+
+// Best-effort reconstruction of a design object from the files on disk.
+// We only need what the tools/resources consume: tokens + regions +
+// componentClusters + accessibility.remediation + cssHealth + colors.all.
+function loadExtraction(outputDir) {
+  if (!existsSync(outputDir)) return null;
+  const entries = readdirSync(outputDir);
+  const tokenFiles = entries
+    .filter((f) => f.endsWith('-design-tokens.json'))
+    .map((f) => {
+      const p = join(outputDir, f);
+      return { path: p, mtime: statSync(p).mtimeMs, prefix: f.replace(/-design-tokens\.json$/, '') };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+
+  if (!tokenFiles.length) return null;
+  const latest = tokenFiles[0];
+
+  let tokens;
+  try { tokens = JSON.parse(readFileSync(latest.path, 'utf-8')); } catch { return null; }
+
+  // Legacy (pre-v7) tokens don't have primitive/semantic. Skip silently.
+  if (!tokens?.primitive || !tokens?.semantic) {
+    return { tokens: null, design: {} };
+  }
+
+  // We have no single dump of the full design object on disk today, so we
+  // build a minimal one sufficient for the tools we expose. Anything not
+  // present simply produces empty arrays / null returns.
+  const design = {
+    colors: { all: [] },
+    regions: [],
+    componentClusters: [],
+    accessibility: { remediation: [] },
+    cssHealth: null,
+  };
+
+  return { tokens, design };
+}
+
+export async function run({ outputDir }) {
+  const resolved = resolve(outputDir || './design-extract-output');
+  const loaded = loadExtraction(resolved);
+  const tokens = loaded?.tokens ?? null;
+  const design = loaded?.design ?? {};
+
+  const resources = buildResources({ design, tokens });
+  const tools = buildTools({ design, tokens });
+
+  const server = new Server(
+    { name: 'designlang', version: '7.0.0' },
+    { capabilities: { resources: {}, tools: {} } },
+  );
+
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    resources: tokens ? resources.list() : [],
+  }));
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (req) => {
+    if (!tokens) throw Object.assign(new Error('no extraction loaded'), { code: -32002 });
+    const { uri } = req.params;
+    const r = resources.read(uri);
+    return { contents: [r] };
+  });
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: tools.list() }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    if (!tokens) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: 'no extraction loaded' }],
+      };
+    }
+    const { name, arguments: args } = req.params;
+    try {
+      const result = await tools.call(name, args);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    } catch (err) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: err?.message || String(err) }],
+      };
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -1,0 +1,149 @@
+// MCP tools builder. Pure/testable — returns { list, call } over the
+// loaded design + tokens. No transport concerns here.
+
+import { remediateFailingPairs } from '../extractors/a11y-remediation.js';
+
+function rpcError(code, message) {
+  const e = new Error(message);
+  e.code = code;
+  return e;
+}
+
+// Flatten a DTCG token tree to [{ path, $type, $value }] leaves.
+function flattenTokens(tree, prefix, out) {
+  if (tree == null || typeof tree !== 'object') return;
+  if ('$value' in tree) {
+    out.push({ path: prefix, $type: tree.$type, $value: tree.$value });
+    return;
+  }
+  for (const key of Object.keys(tree)) {
+    const next = prefix ? `${prefix}.${key}` : key;
+    flattenTokens(tree[key], next, out);
+  }
+}
+
+function paletteHexes(design) {
+  const all = design?.colors?.all || [];
+  const out = [];
+  for (const entry of all) {
+    if (!entry) continue;
+    if (typeof entry === 'string') out.push(entry);
+    else if (typeof entry === 'object' && typeof entry.hex === 'string') out.push(entry.hex);
+  }
+  return out;
+}
+
+const TOOL_DEFS = [
+  {
+    name: 'search_tokens',
+    description: 'Case-insensitive substring match over all token dot-paths.',
+    inputSchema: {
+      type: 'object',
+      properties: { query: { type: 'string', description: 'substring to search for' } },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'find_nearest_color',
+    description: 'Find the nearest palette color that passes the requested WCAG contrast rule against the given hex.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        hex: { type: 'string', description: 'background hex (e.g. #ffffff)' },
+        level: { type: 'string', enum: ['AA-normal', 'AA-large', 'AAA-normal', 'AAA-large'] },
+      },
+      required: ['hex', 'level'],
+    },
+  },
+  {
+    name: 'get_region',
+    description: 'Return the region with the given role (e.g. hero, nav, footer).',
+    inputSchema: {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'get_component',
+    description: 'Return the component cluster with matching kind, optionally narrowed to a variant index.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        variant: { type: 'number' },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'list_failing_contrast_pairs',
+    description: 'Return the accessibility remediation array (failing fg/bg pairs with suggestions).',
+    inputSchema: { type: 'object', properties: {} },
+  },
+];
+
+export function buildTools({ design, tokens }) {
+  // Pre-flatten for search.
+  const flat = [];
+  flattenTokens(tokens?.primitive, 'primitive', flat);
+  flattenTokens(tokens?.semantic, 'semantic', flat);
+
+  async function searchTokens(args) {
+    if (!args || typeof args.query !== 'string') throw rpcError(-32602, 'search_tokens: query must be a string');
+    const q = args.query.toLowerCase();
+    const matches = flat.filter(t => t.path.toLowerCase().includes(q));
+    return { matches };
+  }
+
+  async function findNearestColor(args) {
+    if (!args || typeof args.hex !== 'string') throw rpcError(-32602, 'find_nearest_color: hex must be a string');
+    const validLevels = new Set(['AA-normal', 'AA-large', 'AAA-normal', 'AAA-large']);
+    if (!validLevels.has(args.level)) throw rpcError(-32602, 'find_nearest_color: level must be one of AA-normal|AA-large|AAA-normal|AAA-large');
+    const palette = paletteHexes(design);
+    const [res] = remediateFailingPairs(
+      [{ fg: '#000000', bg: args.hex, ratio: 0, rule: args.level }],
+      palette,
+    );
+    if (!res?.suggestion) return { color: null, newRatio: null };
+    return { color: res.suggestion.color, newRatio: res.suggestion.newRatio, replace: res.suggestion.replace };
+  }
+
+  async function getRegion(args) {
+    if (!args || typeof args.name !== 'string') throw rpcError(-32602, 'get_region: name must be a string');
+    const regions = design?.regions || [];
+    return regions.find(r => r && (r.role === args.name || r.name === args.name)) || null;
+  }
+
+  async function getComponent(args) {
+    if (!args || typeof args.name !== 'string') throw rpcError(-32602, 'get_component: name must be a string');
+    const clusters = design?.componentClusters || [];
+    const found = clusters.find(c => c && c.kind === args.name);
+    if (!found) return null;
+    if (typeof args.variant === 'number' && Array.isArray(found.variants)) {
+      return found.variants[args.variant] ?? null;
+    }
+    return found;
+  }
+
+  async function listFailing() {
+    return design?.accessibility?.remediation || [];
+  }
+
+  const dispatch = {
+    search_tokens: searchTokens,
+    find_nearest_color: findNearestColor,
+    get_region: getRegion,
+    get_component: getComponent,
+    list_failing_contrast_pairs: listFailing,
+  };
+
+  return {
+    list() { return TOOL_DEFS.slice(); },
+    async call(name, args) {
+      const fn = dispatch[name];
+      if (!fn) throw rpcError(-32602, `Unknown tool: ${name}`);
+      return await fn(args || {});
+    },
+  };
+}

--- a/tests/formatters.test.js
+++ b/tests/formatters.test.js
@@ -13,6 +13,7 @@ import { formatIosSwiftUI } from '../src/formatters/ios-swiftui.js';
 import { formatAndroidCompose } from '../src/formatters/android-compose.js';
 import { formatFlutterDart } from '../src/formatters/flutter-dart.js';
 import { formatWordPressTheme } from '../src/formatters/wordpress.js';
+import { formatAgentRules } from '../src/formatters/agent-rules.js';
 
 // ── Shared mock design object ───────────────────────────────────
 
@@ -662,5 +663,47 @@ describe('formatWordPressTheme', () => {
 
   it('functions.php starts with <?php', () => {
     assert.ok(out['functions.php'].startsWith('<?php'));
+  });
+});
+
+// ── formatAgentRules ────────────────────────────────────────────
+
+describe('formatAgentRules', () => {
+  const tokens = formatDtcgTokens(mockDesign);
+  const url = 'https://example.com';
+  const designWithRegions = { ...mockDesign, regions: [{ role: 'hero' }, { role: 'footer' }] };
+  const out = formatAgentRules({ design: designWithRegions, tokens, url });
+
+  it('emits all four files, each non-empty', () => {
+    for (const key of [
+      '.cursor/rules/designlang.mdc',
+      '.claude/skills/designlang/SKILL.md',
+      'CLAUDE.md.fragment',
+      'agents.md',
+    ]) {
+      assert.ok(typeof out[key] === 'string' && out[key].length > 0, `missing ${key}`);
+    }
+  });
+
+  it('Cursor .mdc begins with frontmatter containing alwaysApply: true', () => {
+    const mdc = out['.cursor/rules/designlang.mdc'];
+    assert.ok(mdc.startsWith('---'), 'expected frontmatter start');
+    const fm = mdc.split('---')[1];
+    assert.ok(fm.includes('alwaysApply: true'), 'expected alwaysApply: true');
+  });
+
+  it('all four files reference the source URL', () => {
+    for (const key of Object.keys(out)) {
+      assert.ok(out[key].includes(url), `${key} missing url`);
+    }
+  });
+
+  it('all four files contain resolved hex for semantic.color.action.primary', () => {
+    // mockDesign primary is #0066cc — resolved value should appear verbatim,
+    // and the raw DTCG reference must not leak.
+    for (const key of Object.keys(out)) {
+      assert.ok(out[key].toLowerCase().includes('#0066cc'), `${key} missing resolved hex`);
+      assert.ok(!out[key].includes('{primitive.color.brand.primary}'), `${key} leaked raw DTCG ref`);
+    }
   });
 });

--- a/tests/mcp.test.js
+++ b/tests/mcp.test.js
@@ -1,0 +1,68 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildResources } from '../src/mcp/resources.js';
+import { buildTools } from '../src/mcp/tools.js';
+
+const tokens = {
+  $metadata: { source: 'https://x.com' },
+  primitive: { color: { brand: { primary: { $value: '#3b82f6', $type: 'color' } } } },
+  semantic: { color: { action: { primary: { $value: '{primitive.color.brand.primary}', $type: 'color' } } } },
+};
+const design = {
+  colors: { all: ['#000', '#111', '#555', '#fff'] },
+  regions: [{ role: 'hero', bounds: { x:0,y:0,w:1280,h:600 }, heading: 'Build' }],
+  componentClusters: [{ kind: 'button', instanceCount: 5, variants: [{ css: { bg: '#3b82f6' }, instanceCount: 3 }] }],
+  accessibility: { remediation: [{ fg:'#eee', bg:'#fff', ratio:1.1, rule:'AA-normal', suggestion:{replace:'fg',color:'#000',newRatio:21}}] },
+  cssHealth: null,
+};
+
+describe('MCP resources', () => {
+  it('lists five URIs', () => {
+    const r = buildResources({ design, tokens });
+    assert.equal(r.list().length, 5);
+    assert.ok(r.list().find(x => x.uri === 'designlang://tokens/semantic'));
+  });
+  it('reads semantic tokens', () => {
+    const r = buildResources({ design, tokens });
+    const out = r.read('designlang://tokens/semantic');
+    const body = JSON.parse(out.text);
+    assert.ok(body.color?.action?.primary);
+  });
+  it('throws for unknown uri', () => {
+    const r = buildResources({ design, tokens });
+    assert.throws(() => r.read('designlang://nope'));
+  });
+});
+
+describe('MCP tools', () => {
+  it('search_tokens finds semantic token by substring', async () => {
+    const t = buildTools({ design, tokens });
+    const res = await t.call('search_tokens', { query: 'action.primary' });
+    assert.ok(JSON.stringify(res.matches).includes('action.primary'));
+  });
+  it('find_nearest_color returns a palette color passing AA', async () => {
+    const t = buildTools({ design, tokens });
+    const res = await t.call('find_nearest_color', { hex: '#ffffff', level: 'AA-normal' });
+    assert.ok(res.color);
+    assert.ok(res.newRatio >= 4.5);
+  });
+  it('get_region returns hero', async () => {
+    const t = buildTools({ design, tokens });
+    const res = await t.call('get_region', { name: 'hero' });
+    assert.equal(res.role, 'hero');
+  });
+  it('get_component returns button cluster', async () => {
+    const t = buildTools({ design, tokens });
+    const res = await t.call('get_component', { name: 'button' });
+    assert.equal(res.kind, 'button');
+  });
+  it('list_failing_contrast_pairs returns remediation array', async () => {
+    const t = buildTools({ design, tokens });
+    const res = await t.call('list_failing_contrast_pairs');
+    assert.equal(res.length, 1);
+  });
+  it('throws on unknown tool', async () => {
+    const t = buildTools({ design, tokens });
+    await assert.rejects(() => t.call('nope', {}));
+  });
+});


### PR DESCRIPTION
## Summary

Part 2 of v7.0 — designlang is now a first-class MCP server and emits project rules for Cursor, Claude Code, and generic agents. Builds on [#18](https://github.com/Manavarya09/design-extract/pull/18).

## What's in this PR

### Agent rules emitter
- `src/formatters/agent-rules.js` — exports `formatAgentRules({ design, tokens, url })` returning a file-map:
  - `.cursor/rules/designlang.mdc` — Cursor project rule with `alwaysApply: true`
  - `.claude/skills/designlang/SKILL.md` — Claude Code skill with frontmatter
  - `CLAUDE.md.fragment` — append-ready section for root CLAUDE.md
  - `agents.md` — AGENTS.md-style generic prompt
- All four reference the same resolved semantic tokens (concrete hex values, not `{primitive.x.y}` strings), source URL, and region names.
- New CLI flag: `--emit-agent-rules` (also implied by `--full`).

### MCP server
- `src/mcp/resources.js` — five resources: `designlang://tokens/{primitive,semantic}`, `regions`, `components`, `health`.
- `src/mcp/tools.js` — five tools: `search_tokens`, `find_nearest_color`, `get_region`, `get_component`, `list_failing_contrast_pairs`.
- `src/mcp/server.js` — stdio transport glue using `@modelcontextprotocol/sdk`.
- New CLI subcommand: `designlang mcp --output-dir <dir>`.

### Persistence fix
- Extraction now writes a companion `*-mcp.json` alongside the other outputs, holding the subset of `design` the MCP server needs (regions, componentClusters, a11y remediation, cssHealth, palette). Server loads this at startup so regions/components/health resources and their tools work correctly from prior extractions on disk, not just in-memory.

## Tests

241/241 green (228 baseline + 4 agent-rules + 9 mcp). No regressions.

## Smoke tests verified

- `designlang <url> --emit-agent-rules` writes all 4 files under the output dir, resolved hex values present.
- `designlang mcp --output-dir <dir>` responds to JSON-RPC `initialize` and `resources/read` over stdio.

## Follow-up

- Part 3: README update, CHANGELOG with DTCG migration guide, version bump to 7.0.0, npm publish.

## Test plan

- [x] `node --test tests/*.test.js` — 241/241
- [x] `--emit-agent-rules` produces all 4 files
- [x] `designlang mcp` responds to initialize + resources/read
- [x] `*-mcp.json` companion written during extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)