### PR TITLE
v7.0 part 3: release — README, CHANGELOG, version 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+## [7.0.0] — 2026-04-18
+
+### Breaking
+
+- **Design token JSON format** — the default `*-design-tokens.json` now follows the W3C Design Tokens Community Group (DTCG) v1 spec: every leaf is `{ "$value": ..., "$type": ... }`, with two layers (`primitive.*` and `semantic.*`) and composite tokens for typography, shadow, border, and gradient. If a downstream consumer expects the pre-v7 flat shape, pass `--tokens-legacy` to preserve it.
+
+  Before (v6):
+  ```json
+  { "color": { "primary": "#3b82f6" }, "fontFamily": { "sans": "Inter" } }
+  ```
+
+  After (v7, default):
+  ```json
+  {
+    "$metadata": { "generator": "designlang", "version": "7.0.0" },
+    "primitive": { "color": { "brand": { "primary": { "$value": "#3b82f6", "$type": "color" } } } },
+    "semantic":  { "color": { "action": { "primary": { "$value": "{primitive.color.brand.primary}", "$type": "color" } } } }
+  }
+  ```
+
+  Migration: either (a) update consumers to read the DTCG shape (recommended — long-term stable, ecosystem-compatible), or (b) add `--tokens-legacy` to the CLI invocation.
+
+### Added
+
+- **MCP server** — new `designlang mcp --output-dir <dir>` subcommand. Stdio JSON-RPC. Resources: `designlang://tokens/primitive`, `designlang://tokens/semantic`, `designlang://regions`, `designlang://components`, `designlang://health`. Tools: `search_tokens`, `find_nearest_color`, `get_region`, `get_component`, `list_failing_contrast_pairs`.
+- **Agent rules emitter** — `--emit-agent-rules` writes `.cursor/rules/designlang.mdc`, `.claude/skills/designlang/SKILL.md`, `CLAUDE.md.fragment`, and `agents.md`. All four template from the resolved semantic tokens.
+- **Multi-platform emitters** — `--platforms <csv>` (values `web`, `ios`, `android`, `flutter`, `wordpress`, `all`). Additive to default web output. Emits iOS SwiftUI, Android Compose + XML, Flutter Dart + ThemeData, and a full WordPress block-theme skeleton (`theme.json` v3, `style.css`, `functions.php`, `index.php`, `templates/index.html`).
+- **Stack + Tailwind fingerprint** — framework detection, Tailwind utility-class frequency map, analytics stack inventory. Surfaced on `design.stack`.
+- **CSS health audit** — specificity distribution, `!important` count, duplicate declarations, unused CSS via Playwright Coverage API, `@keyframes` catalog, vendor-prefix audit. Surfaced on `design.cssHealth` and added as an additive `cssHealth` dimension in the design score.
+- **A11y remediation** — for every failing WCAG contrast pair, suggests the nearest palette color that passes AA (4.5:1 / 3:1) or AAA (7:1 / 4.5:1). Surfaced on `design.accessibility.remediation`.
+- **Semantic regions** — classifies page sections into `nav`, `hero`, `features`, `pricing`, `testimonials`, `cta`, `footer`, `sidebar`, `content`. Surfaced on `design.regions`.
+- **Reusable component detection** — DOM subtree structural hash + cosine-similarity style vector clustering with variant detection. Surfaced on `design.componentClusters` and rendered in the markdown output.
+- **MCP companion file** — `*-mcp.json` written at extract time so later `designlang mcp` invocations can serve regions / components / health / remediation from disk, not just memory.
+
+### Dependencies
+
+- Added `@modelcontextprotocol/sdk` (runtime).
+
+### Tests
+
+- 241/241 passing (baseline 186 + 55 new tests).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ npx designlang https://stripe.com --full
 
 The markdown output has **19 sections**: Color Palette, Typography, Spacing, Border Radii, Box Shadows, CSS Custom Properties, Breakpoints, Transitions & Animations, Component Patterns (with full CSS snippets), Layout System, Responsive Design, Interaction States, Accessibility (WCAG 2.1), Gradients, Z-Index Map, SVG Icons, Font Files, Image Style Patterns, and Quick Start.
 
+In v7 a companion `*-mcp.json` file is also written alongside the 8 outputs so that `designlang mcp` can serve regions, components, and health data from disk on later invocations. Opting into `--platforms <csv>` additively emits `ios/`, `android/`, `flutter/`, and/or `wordpress-theme/` directories in the output folder, and `--emit-agent-rules` adds a `.cursor/`, `.claude/`, `CLAUDE.md.fragment`, and `agents.md` set.
+
 ## Install
 
 ```bash
@@ -215,6 +217,101 @@ Compare light and dark mode side-by-side — see exactly which colors change and
 designlang https://vercel.com --dark
 ```
 
+### 17. MCP Server (NEW in v7)
+
+One-command integration with any MCP-aware AI agent (Cursor, Claude Code, Windsurf, and more):
+
+```bash
+designlang mcp --output-dir ./design-extract-output
+```
+
+Launches a stdio JSON-RPC server that exposes the extracted design as MCP resources and tools.
+
+**Resources:**
+
+- `designlang://tokens/primitive` — primitive token layer
+- `designlang://tokens/semantic` — semantic token layer (with DTCG alias references)
+- `designlang://regions` — classified page regions (nav, hero, pricing, etc.)
+- `designlang://components` — reusable component clusters with variants
+- `designlang://health` — CSS health audit
+
+**Tools:**
+
+- `search_tokens` — query tokens by name, value, or type
+- `find_nearest_color` — snap any color to the nearest palette token
+- `get_region` — fetch a classified region by name
+- `get_component` — fetch a component cluster by id
+- `list_failing_contrast_pairs` — list every WCAG-failing fg/bg pair with remediation suggestions
+
+### 18. Multi-Platform Output (NEW in v7)
+
+Emit iOS SwiftUI, Android Compose, Flutter, and WordPress block-theme files in a single run, in addition to the default web output:
+
+```bash
+designlang https://stripe.com --platforms all
+```
+
+Resulting tree:
+
+```
+design-extract-output/
+├── stripe-com-*.{md,json,css,js,html}    (default web output)
+├── ios/
+│   └── DesignTokens.swift
+├── android/
+│   ├── Theme.kt
+│   ├── colors.xml
+│   └── dimens.xml
+├── flutter/
+│   └── design_tokens.dart               (+ buildDesignlangTheme())
+└── wordpress-theme/
+    ├── theme.json
+    ├── style.css
+    ├── functions.php
+    ├── index.php
+    └── templates/index.html
+```
+
+Values for `--platforms` are any comma-separated subset of `web,ios,android,flutter,wordpress,all`. The flag is additive — the default web output is always emitted.
+
+### 19. Agent Rules Emitter (NEW in v7)
+
+Write agent-facing rule files generated from the resolved semantic tokens:
+
+```bash
+designlang https://stripe.com --emit-agent-rules
+```
+
+Writes:
+
+- `.cursor/rules/designlang.mdc` — Cursor rule
+- `.claude/skills/designlang/SKILL.md` — Claude Code skill
+- `CLAUDE.md.fragment` — snippet you can paste into your project's CLAUDE.md
+- `agents.md` — generic, vendor-neutral agent guidance
+
+Each file is templated from the semantic layer of the extracted token set, so the agent sees real token names and values — not placeholders.
+
+### 20. Stack + Tailwind Fingerprint (NEW in v7)
+
+Automatic framework, utility-class, and analytics detection surfaced on `design.stack`:
+
+- **Framework**: Next.js, Nuxt, Gatsby, Remix, Astro, Shopify, WordPress, Framer, Webflow, and more.
+- **Tailwind**: when Tailwind is in use, records utility-class frequency so you see which utilities drive the design.
+- **Analytics**: inventory of analytics scripts — GA4, Plausible, PostHog, Segment, Mixpanel, Amplitude, and friends.
+
+### 21. CSS Health Audit (NEW in v7)
+
+A dedicated audit pass surfaced on `design.cssHealth`:
+
+- Specificity graph (distribution, hotspots)
+- `!important` count
+- Duplicate declarations
+- Unused CSS via the Playwright Coverage API
+- `@keyframes` catalog
+- Vendor-prefix audit
+
+Also contributes a `cssHealth` dimension to the overall design score.
+
 ## All Features
 
 | Feature | Flag / Command | Description |
@@ -243,6 +340,15 @@ designlang https://vercel.com --dark
 | Multi-brand | `designlang brands <urls...>` | N-site comparison matrix |
 | Sync | `designlang sync <url>` | Update local tokens from live site |
 | History | `designlang history <url>` | Track design changes over time |
+| MCP server | `designlang mcp` | Expose extraction as MCP resources + tools |
+| Multi-platform | `--platforms <csv>` | Emit iOS / Android / Flutter / WordPress outputs |
+| Agent rules | `--emit-agent-rules` | Cursor, Claude Code, generic agent rule files |
+| Stack fingerprint | automatic | Framework + Tailwind + analytics detection |
+| CSS health | automatic | Specificity, !important, unused CSS, keyframes |
+| A11y remediation | automatic | Nearest palette color passing AA / AAA for every failing pair |
+| Semantic regions | automatic | nav / hero / pricing / testimonials / cta / footer classification |
+| Reusable components | automatic | DOM subtree + style-vector clustering with variants |
+| DTCG tokens | default | W3C Design Tokens v1 with semantic + composite layers (`--tokens-legacy` for pre-v7) |
 
 ## Full CLI Reference
 
@@ -264,6 +370,9 @@ Options:
   --cookie <cookies...>   Cookies for authenticated pages (name=value)
   --header <headers...>   Custom headers (name:value)
   --framework <type>      Only generate specific theme (react, shadcn)
+  --platforms <csv>       Additional platforms: web,ios,android,flutter,wordpress,all (additive)
+  --emit-agent-rules      Emit Cursor / Claude Code / CLAUDE.md / agents.md rule files
+  --tokens-legacy         Emit pre-v7 flat design-tokens.json shape (backward compat)
   --no-history            Skip saving to history
   --verbose               Detailed progress output
 
@@ -276,6 +385,7 @@ Commands:
   brands <urls...>        Multi-brand comparison matrix
   sync <url>              Sync local tokens with live site
   history <url>           View design change history
+  mcp                     Launch stdio MCP server (--output-dir <dir>)
 ```
 
 ## Example Output

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "designlang",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "designlang",
-      "version": "6.0.0",
+      "version": "7.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designlang",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Extract the complete design language from any website — colors, typography, spacing, shadows, and more. Outputs AI-optimized markdown, W3C design tokens, Tailwind config, and CSS variables.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Final part of v7.0 — docs and version bump. Ships behind [#18](https://github.com/Manavarya09/design-extract/pull/18) and [#19](https://github.com/Manavarya09/design-extract/pull/19).

## What's in this PR

- **README** — five new "What Makes This Different" sections (MCP server, multi-platform output, agent rules, stack fingerprint, CSS health audit), nine new rows in the All Features table, and CLI reference updates.
- **CHANGELOG.md** — new file, Keep-a-Changelog style. Documents the one breaking change (DTCG default token shape, with before/after and `--tokens-legacy` migration) and the full additions list.
- **package.json** — version bumped to `7.0.0` (no tag; tag is cut after `npm publish`).

## Verification

- 241/241 tests green.
- Final smoke: `designlang https://vercel.com --platforms all --emit-agent-rules` produced all web + ios + android + flutter + wordpress-theme + agent rules files + MCP companion.

## After merge

- `npm publish --access public`
- `git tag v7.0.0 && git push --tags`

Both run manually by repo owner. This PR does not publish or tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)