### PR TITLE
Wave 2 foundation — paper+ink editorial system

### DIFF
--- a/docs/superpowers/specs/2026-04-18-website-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-18-website-redesign-design.md
@@ -1,0 +1,120 @@
+# designlang website redesign — Wave 2
+
+**Date:** 2026-04-18
+**Status:** Approved for implementation
+**Direction:** Live Design DNA — the site embodies what designlang does.
+
+## Non-negotiables (from user)
+
+- No "AI slop" aesthetic. No purple/blue gradients. No glassmorphism. No floating hero cards.
+- **No emoji. No icon libraries** (Lucide, Heroicons, Phosphor). Iconography only as intent-drawn inline SVG, numerals, or letterforms.
+- No Framer Motion bloat, no fade-up-on-every-element scroll theatrics.
+- Copy must be earned, not templated.
+- Designer voice visible — marginalia, footnotes, document-feel.
+
+## Visual system
+
+**Base:** warm paper `#F3F1EA`, ink `#0A0908`, accent `#FF4800` (used once per screen, maximum).
+**Grays (warm):** `#D8D3C5`, `#8B8778`, `#403C34`.
+**Type:** Fraunces (display, optical 9pt, massive sizes), Instrument Sans (body), JetBrains Mono (mono/tokens).
+**Grid:** 12-col, 24px gutters, deliberately broken by marginalia and side notes.
+**Rules:** 1px solid ink hairlines everywhere (document feel), no soft dividers.
+**Shadow:** one hard offset shadow (`6px 6px 0 #FF4800`) on the primary CTA only.
+**Dark mode:** deferred. Paper-first matches design-system/archival feel.
+**Motion:** prefers-reduced-motion strict. All motion is content-matched (see §Signature Interactions).
+
+## Page structure
+
+Single-page scroll. Numbered sections like a monograph: `§00`…`§09`.
+
+- §00 `HERO` — URL input + live extraction stream; tokens paint on screen as they compute.
+- §01 `DTCG BROWSER` — interactive alias resolver. Click a semantic token, the line flies to its primitive.
+- §02 `MCP` — split: Cursor/Claude Code rule panel on left, real terminal transcript on right.
+- §03 `MULTI-PLATFORM` — tabs Web / iOS / Android / Flutter / WordPress; same token in 5 languages.
+- §04 `CSS HEALTH` — big numerals (unused %, `!important` count, duplicates) set against real specificity plot.
+- §05 `A11Y REMEDIATION` — before/after contrast slider with live ratio.
+- §06 `REGIONS + COMPONENTS` — annotated screenshot; button cluster animates into variants.
+- §07 `FEATURED SPECIMENS` — stripe / vercel / linear / github / figma / apple; each extracted and displayed like a museum specimen. Page accent shifts as you scroll between them.
+- §08 `COMPARISON` — transparent, opinionated table vs. v0, Builder.io, Style Dictionary, Subframe, Project Wallace.
+- §09 `INSTALL & FOOTER` — `npx designlang`, MCP config, Cursor rule install, GitHub/npm/Discussions/sponsor.
+
+## Signature interactions (motion only where content-matched)
+
+1. **Hero stream** — user submits URL, server streams back tokens in extraction order; swatches paint from left to right as server events arrive.
+2. **DTCG alias flight** — click `{primitive.color.brand.primary}` string, an SVG line animates from the semantic token to the primitive, primitive highlights, hex resolves inline.
+3. **Accent shift scroll** — as the Featured Specimens section scrolls, page accent CSS var transitions to each specimen's extracted primary.
+4. **A11y slider** — handle drag shows contrast ratio updating live above the color pair.
+5. **MCP terminal transcript** — real JSON-RPC lines, typed at realistic speed, showing `search_tokens` → result.
+6. **Component cluster unfold** — a single button card unfolds into its detected variants on scroll-into-view.
+
+No other motion.
+
+## Backend
+
+**Existing:** `/api/extract` route using `@sparticuz/chromium` + `playwright-core` + designlang `extractDesignLanguage`.
+
+**Changes required:**
+
+1. **v7.0 output parity** — currently the API returns v6 shape. Add DTCG tokens, agent rules, MCP companion JSON, multi-platform outputs.
+2. **Streaming response** — the extraction produces tokens progressively; stream them over an HTTP stream (Next.js 16 streaming response) so the hero demo paints live. If extraction is atomic today (single `page.evaluate`), we stream the *stages*: crawl → colors → typography → spacing → components → a11y → done.
+3. **Rate limiting** — Vercel Edge Config or in-memory map keyed by IP. 3 extractions per IP per day for anonymous, soft 429 with helpful copy. No login.
+4. **URL validation** — reject `localhost`, `127.x`, `169.254.x`, `10.x`, `172.16–31.x`, `192.168.x`, `file://`, non-http(s). Reject URLs whose DNS resolves to private ranges.
+5. **Timeout cap** — hard 45s; abort Playwright if exceeded.
+6. **Caching** — cache extraction result by URL in Vercel Blob for 24h. Collision: same URL within 24h returns cached zip + a small "cached" annotation.
+7. **Bot detection** — Vercel BotID (free, platform-native).
+8. **Output:** downloadable `.zip` of all generated files (same set the CLI would produce for `--platforms all --emit-agent-rules`) plus a JSON summary for the on-screen preview.
+
+**New/changed files:**
+- `website/app/api/extract/route.js` — streaming + rate limit + caching + v7.0 outputs
+- `website/lib/rate-limit.js` (new)
+- `website/lib/url-safety.js` (new)
+- `website/lib/cache.js` (new, Vercel Blob-backed)
+
+## Frontend components (new)
+
+Kept flat in `website/app/components/`. Each is a self-contained section:
+
+- `Hero.js` — URL input + live stream renderer
+- `TokenBrowser.js` — DTCG alias resolver
+- `McpSection.js` — split editor + terminal
+- `PlatformTabs.js` — multi-platform code viewer
+- `CssHealth.js` — numerals + specificity plot (hand-drawn SVG scatter)
+- `A11ySlider.js` — contrast before/after
+- `RegionsComponents.js` — annotated image + cluster unfold
+- `Specimens.js` — featured site grid; orchestrates accent shift
+- `Comparison.js` — opinionated feature matrix
+- `InstallFooter.js` — closing section
+- `Marginalia.js` — shared side-column component for footnotes and command labels
+- `Rule.js` — 1px hairline divider with section label
+
+New lib:
+- `website/lib/token-helpers.js` — DTCG alias resolution shared with components
+- `website/lib/specimens.json` — pre-extracted data for the featured section (generated at build time from the CLI so specimens are real)
+
+## Deferred (explicit non-goals for Wave 2)
+
+- Login / user accounts / saved extractions
+- Paid tiers
+- Dark mode
+- Blog / changelog page
+- i18n
+- Sharable `/x/<slug>` permalinks (nice-to-have but not Wave 2)
+
+## Test / verification plan
+
+- Lighthouse: LCP ≤ 2.0s on the hero at 3G-Fast, CLS 0, accessibility ≥ 95.
+- `prefers-reduced-motion: reduce` — verify all motion stops or substitutes with non-motion reveal.
+- Keyboard navigation through every interactive element.
+- Extractor end-to-end: submit real URL, receive streamed tokens, download zip, verify zip contains v7.0 shape.
+- Rate limit: 4th request from same IP returns 429 with copy.
+- URL safety: localhost, private IPs, `file://` all rejected with 400.
+
+## Implementation chunks (PR per chunk)
+
+Each chunk is one PR. Merge before starting the next, same pattern as v7.0 release.
+
+- **PR A: Foundation** — fonts, base CSS, grid primitives, `Rule`, `Marginalia`, new `globals.css`, `layout.js`, clean `page.js` scaffold.
+- **PR B: Hero + streaming extraction API** — hero component, API streaming, URL safety, rate limit, basic Blob cache.
+- **PR C: Core showcase sections** — DTCG browser, MCP section, multi-platform tabs.
+- **PR D: Analytics sections** — CSS health, a11y slider, regions + components.
+- **PR E: Specimens + comparison + install + footer + deploy** — pre-extract data at build time, accent-shift scroll, comparison table, final polish, Vercel deploy.

--- a/website/.claude/launch.json
+++ b/website/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "website",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/website/app/components/Marginalia.js
+++ b/website/app/components/Marginalia.js
@@ -1,0 +1,3 @@
+export default function Marginalia({ children }) {
+  return <aside className="marginalia">{children}</aside>;
+}

--- a/website/app/components/Rule.js
+++ b/website/app/components/Rule.js
@@ -1,0 +1,13 @@
+export default function Rule({ number, label }) {
+  return (
+    <div className="rule" role="separator" aria-label={label}>
+      <div className="rule-line" />
+      {(number || label) && (
+        <div className="rule-label">
+          {number && <span className="rule-number">§{number}</span>}
+          {label}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -1,723 +1,303 @@
+/* ─────────────────────────────────────────────────────────────
+   designlang website — foundation
+   Direction: Live Design DNA. Paper-first, one accent.
+   ───────────────────────────────────────────────────────────── */
+
 :root {
-  --red: #ffffff;
-  --black: #0a0a0a;
-  --white: #ffffff;
-  --cream: #ffffff;
-  --yellow: #ffffff;
-  --gray: #333;
+  /* Palette */
+  --paper: #f3f1ea;
+  --paper-2: #ece8dd;
+  --paper-3: #d8d3c5;
+  --ink: #0a0908;
+  --ink-2: #403c34;
+  --ink-3: #8b8778;
+  --accent: #ff4800;
+
+  /* Type */
+  --font-body: var(--font-body), -apple-system, 'Segoe UI', system-ui, sans-serif;
+  --font-mono: var(--font-mono), 'SF Mono', ui-monospace, Menlo, monospace;
+  --font-display: var(--font-display), Georgia, serif;
+
+  /* Rhythm */
+  --r1: 4px;
+  --r2: 8px;
+  --r3: 12px;
+  --r4: 16px;
+  --r5: 24px;
+  --r6: 32px;
+  --r7: 48px;
+  --r8: 64px;
+  --r9: 96px;
+  --r10: 144px;
+
+  /* Grid */
+  --page-max: 1440px;
+  --page-pad-x: clamp(20px, 4vw, 56px);
+  --col-count: 12;
+  --col-gap: 24px;
+
+  /* Hairline */
+  --hair: 1px solid var(--ink);
+  --hair-soft: 1px solid var(--ink-3);
 }
 
-* { margin: 0; padding: 0; box-sizing: border-box; }
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
 
-html { scroll-behavior: smooth; }
+html {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  scroll-behavior: smooth;
+}
 
 body {
-  background: var(--black);
-  color: var(--white);
-  font-family: 'Inter', sans-serif;
+  min-height: 100dvh;
   overflow-x: hidden;
-  cursor: crosshair;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid currentColor;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+a:hover {
+  color: var(--accent);
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: 0;
+  cursor: pointer;
+}
+
+input, textarea, select {
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  outline: 0;
 }
 
 ::selection {
-  background: var(--red);
-  color: var(--black);
+  background: var(--ink);
+  color: var(--paper);
 }
 
-a { color: inherit; }
+img, svg { display: block; max-width: 100%; }
 
-/* ── HERO ── */
-.hero {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-  border-bottom: 4px solid var(--red);
-  overflow: hidden;
+/* ── Typography ─────────────────────────────────────────────── */
+
+.display {
+  font-family: var(--font-display);
+  font-weight: 400;
+  letter-spacing: -0.03em;
+  line-height: 0.92;
+  font-variation-settings: 'opsz' 144, 'SOFT' 30;
 }
 
-.hero::before {
-  content: 'DESIGNLANG DESIGNLANG DESIGNLANG DESIGNLANG DESIGNLANG ';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 300%;
-  font-family: 'Unbounded', sans-serif;
-  font-size: 14vw;
-  font-weight: 900;
-  color: rgba(255, 255, 255, 0.03);
-  white-space: nowrap;
-  pointer-events: none;
-  animation: scroll-text 20s linear infinite;
-  line-height: 1;
+.mono {
+  font-family: var(--font-mono);
+  font-feature-settings: 'zero' 1, 'ss01' 1;
 }
 
-@keyframes scroll-text {
-  0% { transform: translateX(0); }
-  100% { transform: translateX(-33.33%); }
-}
-
-.hero-title {
-  font-family: 'Unbounded', sans-serif;
-  font-size: clamp(4rem, 12vw, 10rem);
-  font-weight: 900;
-  text-transform: uppercase;
-  letter-spacing: -0.04em;
-  line-height: 0.9;
-  text-align: center;
-  position: relative;
-  z-index: 1;
-}
-
-.hero-title span {
-  display: block;
-  color: var(--red);
-  font-size: 0.4em;
-  letter-spacing: 0.2em;
-  margin-top: 16px;
-}
-
-.hero-sub {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: clamp(14px, 1.5vw, 18px);
-  color: #888;
-  margin-top: 32px;
-  text-align: center;
-  max-width: 600px;
-  line-height: 1.6;
-  z-index: 1;
-}
-
-.hero-cmd {
-  margin-top: 48px;
-  background: #111;
-  border: 2px solid var(--red);
-  padding: 20px 40px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: clamp(16px, 2vw, 22px);
-  color: var(--yellow);
-  position: relative;
-  z-index: 1;
-  transition: all 0.2s;
-  text-decoration: none;
-  display: inline-block;
-}
-
-.hero-cmd:hover {
-  background: var(--red);
-  color: var(--black);
-  transform: translate(-4px, -4px);
-  box-shadow: 4px 4px 0 var(--yellow);
-}
-
-.hero-cmd::before {
-  content: '$ ';
-  color: var(--red);
-}
-
-.hero-cmd:hover::before {
-  color: var(--black);
-}
-
-.scroll-hint {
-  position: absolute;
-  bottom: 40px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  color: #444;
-  letter-spacing: 0.3em;
-  text-transform: uppercase;
-  animation: pulse 2s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 0.3; }
-  50% { opacity: 1; }
-}
-
-/* ── SECTION LAYOUT ── */
-section {
-  padding: 100px 24px;
-  max-width: 1400px;
-  margin: 0 auto;
-}
-
-.section-red {
-  background: var(--red);
-  color: var(--black);
-  max-width: 100%;
-  padding: 80px 24px;
-}
-
-.section-cream {
-  background: var(--cream);
-  color: var(--black);
-  max-width: 100%;
-  padding: 80px 24px;
-}
-
-.section-inner {
-  max-width: 1400px;
-  margin: 0 auto;
-}
-
-.section-title {
-  font-family: 'Unbounded', sans-serif;
-  font-size: clamp(2rem, 5vw, 4rem);
-  font-weight: 900;
-  text-transform: uppercase;
-  letter-spacing: -0.02em;
-  margin-bottom: 48px;
-  line-height: 1;
-}
-
-.section-title::after {
-  content: ' ///';
-  color: var(--red);
-}
-
-.section-red .section-title::after {
-  color: var(--black);
-}
-
-.section-cream .section-title::after {
-  color: var(--red);
-}
-
-/* ── OUTPUT FILES ── */
-.files-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 2px;
-}
-
-.file-card {
-  background: #111;
-  border: 2px solid #222;
-  padding: 28px;
-  transition: all 0.15s;
-  position: relative;
-  overflow: hidden;
-}
-
-.file-card:hover {
-  border-color: var(--red);
-  transform: translate(-2px, -2px);
-  box-shadow: 2px 2px 0 var(--red);
-}
-
-.file-card::before {
-  content: attr(data-num);
-  position: absolute;
-  top: -10px;
-  right: 10px;
-  font-family: 'Unbounded', sans-serif;
-  font-size: 80px;
-  font-weight: 900;
-  color: rgba(255, 255, 255, 0.06);
-  line-height: 1;
-}
-
-.file-name {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 15px;
-  color: var(--yellow);
-  margin-bottom: 8px;
-}
-
-.file-desc {
-  font-size: 14px;
-  color: #888;
-  line-height: 1.5;
-}
-
-/* ── FEATURES ── */
-.features-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
-  gap: 0;
-}
-
-.feature {
-  padding: 32px;
-  border: 1px solid #222;
-  transition: all 0.15s;
-}
-
-.feature:hover {
-  background: #111;
-  border-color: var(--red);
-}
-
-.feature-name {
-  font-family: 'Unbounded', sans-serif;
-  font-size: 18px;
-  font-weight: 700;
-  text-transform: uppercase;
-  margin-bottom: 8px;
-}
-
-.feature-cmd {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 13px;
-  color: var(--yellow);
-  margin-bottom: 12px;
-}
-
-.feature-desc {
-  font-size: 14px;
-  color: #888;
-  line-height: 1.5;
-}
-
-/* ── SCORE DEMO ── */
-.score-demo {
-  background: #111;
-  border: 2px solid var(--red);
-  padding: 40px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 14px;
-  line-height: 2;
-  overflow-x: auto;
-  color: #ccc;
-}
-
-.score-grade {
-  font-family: 'Unbounded', sans-serif;
-  font-size: 64px;
-  font-weight: 900;
-  color: var(--red);
-  display: inline;
-}
-
-/* ── COMMANDS ── */
-.commands-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-  gap: 2px;
-}
-
-.command-card {
-  background: var(--black);
-  padding: 32px;
-  border: 2px solid rgba(255,255,255,0.3);
-  transition: all 0.15s;
-}
-
-.command-card:hover {
-  border-color: var(--red);
-  background: rgba(255, 255, 255, 0.05);
-}
-
-.command-name {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--yellow);
-  margin-bottom: 12px;
-}
-
-.command-desc {
-  font-size: 14px;
-  color: #ccc;
-  line-height: 1.5;
-}
-
-/* ── STATS STRIP ── */
-.stats-strip {
-  display: flex;
-  flex-wrap: wrap;
-  border-top: 2px solid var(--red);
-  border-bottom: 2px solid var(--red);
-}
-
-.stat {
-  flex: 1;
-  min-width: 150px;
-  padding: 32px 24px;
-  text-align: center;
-  border-right: 1px solid #222;
-}
-
-.stat:last-child { border-right: none; }
-
-.stat-value {
-  font-family: 'Unbounded', sans-serif;
-  font-size: 48px;
-  font-weight: 900;
-  color: var(--red);
-  line-height: 1;
-}
-
-.stat-label {
-  font-family: 'JetBrains Mono', monospace;
+.eyebrow {
+  font-family: var(--font-mono);
   font-size: 11px;
-  color: #666;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  letter-spacing: 0.15em;
-  margin-top: 8px;
+  color: var(--ink-2);
 }
 
-/* ── FOOTER ── */
-footer {
-  padding: 60px 24px;
-  text-align: center;
-  border-top: 4px solid var(--red);
-}
-
-footer a {
-  text-decoration: underline;
-  text-underline-offset: 4px;
-}
-
-footer a:hover {
-  color: var(--red);
-}
-
-.footer-title {
-  font-family: 'Unbounded', sans-serif;
-  font-size: 24px;
-  font-weight: 900;
-  text-transform: uppercase;
-  margin-bottom: 16px;
-}
-
-.footer-links {
-  display: flex;
-  gap: 32px;
-  justify-content: center;
-  margin-top: 24px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 14px;
-}
-
-.footer-copy {
-  margin-top: 48px;
+.section-label {
+  font-family: var(--font-mono);
   font-size: 12px;
-  color: #444;
-}
-
-/* ── MARQUEE ── */
-.marquee {
-  overflow: hidden;
-  white-space: nowrap;
-  border-top: 2px solid #222;
-  border-bottom: 2px solid #222;
-  padding: 12px 0;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 13px;
-  color: #444;
-}
-
-.marquee-inner {
-  display: inline-block;
-  animation: marquee 30s linear infinite;
-}
-
-@keyframes marquee {
-  0% { transform: translateX(0); }
-  100% { transform: translateX(-50%); }
-}
-
-/* ── EXTRACTOR ── */
-.extractor {
-  max-width: 800px;
-}
-
-.extractor-form {
-  display: flex;
-  gap: 0;
-}
-
-.extractor-input {
-  flex: 1;
-  background: var(--black);
-  border: 2px solid var(--black);
-  border-right: none;
-  padding: 16px 20px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 16px;
-  color: var(--yellow);
-  outline: none;
-}
-
-.extractor-input::placeholder {
-  color: #555;
-}
-
-.extractor-input:focus {
-  border-color: var(--yellow);
-}
-
-.extractor-btn {
-  background: var(--black);
-  border: 2px solid var(--black);
-  padding: 16px 32px;
-  font-family: 'Unbounded', sans-serif;
-  font-size: 14px;
-  font-weight: 700;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--red);
-  cursor: pointer;
-  transition: all 0.15s;
-  white-space: nowrap;
+  color: var(--ink-2);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 10px;
 }
 
-.extractor-btn:hover:not(:disabled) {
-  background: var(--yellow);
-  color: var(--black);
-  border-color: var(--yellow);
-}
-
-.extractor-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.extractor-loading {
-  margin-top: 32px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 14px;
-}
-
-.extractor-loading p {
-  color: var(--black);
-}
-
-.extractor-loading-sub {
-  color: #333 !important;
-  font-size: 12px;
-  margin-top: 4px;
-}
-
-.extractor-spinner {
+.section-label::before {
+  content: '';
   width: 24px;
-  height: 24px;
-  border: 3px solid var(--black);
-  border-top-color: transparent;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  margin-bottom: 12px;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-.extractor-error {
-  margin-top: 24px;
-  background: var(--black);
-  border: 2px solid var(--yellow);
-  padding: 16px 20px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 14px;
-  color: var(--yellow);
-}
-
-.extractor-error-hint {
-  margin-top: 12px;
-  font-size: 12px;
-  color: #888;
-  line-height: 1.8;
-}
-
-.extractor-error-hint code {
+  height: 1px;
+  background: var(--ink);
   display: inline-block;
-  margin-top: 4px;
-  background: #1a1a1a;
-  padding: 6px 12px;
-  color: var(--yellow);
-  font-size: 13px;
+  transform: translateY(-4px);
 }
 
-.extractor-results {
-  margin-top: 32px;
-  background: var(--black);
-  border: 2px solid var(--black);
+.prose p { max-width: 62ch; }
+.prose p + p { margin-top: 1em; }
+
+/* ── Layout primitives ──────────────────────────────────────── */
+
+.page {
+  max-width: var(--page-max);
+  margin: 0 auto;
+  padding-inline: var(--page-pad-x);
 }
 
-.extractor-results-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 20px 24px;
-  border-bottom: 1px solid #222;
-  flex-wrap: wrap;
-  gap: 12px;
-}
+.stack-lg > * + * { margin-top: var(--r8); }
+.stack-md > * + * { margin-top: var(--r5); }
+.stack-sm > * + * { margin-top: var(--r3); }
 
-.extractor-results-header h3 {
-  font-family: 'Unbounded', sans-serif;
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--white);
-  text-transform: uppercase;
-}
-
-.extractor-download {
-  background: var(--red);
-  border: none;
-  padding: 10px 20px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--black);
-  cursor: pointer;
-  text-transform: uppercase;
-  transition: all 0.15s;
-}
-
-.extractor-download:hover {
-  background: var(--yellow);
-  transform: translate(-2px, -2px);
-  box-shadow: 2px 2px 0 var(--red);
-}
-
-.extractor-stats-grid {
+.grid-12 {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  border-bottom: 1px solid #222;
+  grid-template-columns: repeat(var(--col-count), minmax(0, 1fr));
+  gap: var(--col-gap);
 }
 
-.extractor-stat {
-  padding: 20px 24px;
-  border-right: 1px solid #222;
-  border-bottom: 1px solid #222;
+/* Rule — a hairline with optional section label inline at left edge. */
+.rule {
+  position: relative;
+  display: flex;
+  align-items: baseline;
+  gap: var(--r4);
+  padding-block: var(--r4);
 }
 
-.extractor-stat:nth-child(3n) {
-  border-right: none;
+.rule-line {
+  flex: 1 1 auto;
+  height: 1px;
+  background: var(--ink);
 }
 
-.extractor-stat-value {
-  font-family: 'Unbounded', sans-serif;
-  font-size: 28px;
-  font-weight: 900;
-  color: var(--red);
-  line-height: 1;
-}
-
-.extractor-stat-label {
-  font-family: 'JetBrains Mono', monospace;
+.rule-label {
+  font-family: var(--font-mono);
   font-size: 11px;
-  color: #666;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  margin-top: 6px;
+  color: var(--ink);
+  white-space: nowrap;
 }
 
-.extractor-section {
-  padding: 20px 24px;
-  border-bottom: 1px solid #222;
+.rule-number {
+  color: var(--ink-3);
+  margin-right: var(--r2);
 }
 
-.extractor-section:last-child {
-  border-bottom: none;
+/* Marginalia — side-column notes; collapse to block on small screens. */
+.with-margin {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, 240px);
+  gap: var(--col-gap);
+  align-items: start;
 }
 
-.extractor-section-title {
-  font-family: 'Unbounded', sans-serif;
+.marginalia {
+  font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--red);
-  margin-bottom: 12px;
+  line-height: 1.5;
+  color: var(--ink-2);
+  border-left: var(--hair);
+  padding-left: var(--r4);
 }
 
-.extractor-colors {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+.marginalia .foot { color: var(--ink-3); }
+.marginalia code { color: var(--ink); }
+
+@media (max-width: 860px) {
+  .with-margin {
+    grid-template-columns: 1fr;
+  }
+  .marginalia {
+    border-left: 0;
+    border-top: var(--hair);
+    padding-left: 0;
+    padding-top: var(--r3);
+  }
 }
 
-.extractor-swatch {
-  text-align: center;
-}
+/* ── Controls ───────────────────────────────────────────────── */
 
-.extractor-swatch-color {
-  width: 40px;
-  height: 40px;
-  border: 1px solid #333;
-}
-
-.extractor-swatch-hex {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 9px;
-  color: #666;
-  margin-top: 4px;
-}
-
-.extractor-fonts {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 14px;
-  color: #ccc;
-}
-
-.extractor-a11y {
-  display: flex;
+.cta {
+  display: inline-flex;
   align-items: center;
-  gap: 16px;
-}
-
-.extractor-a11y-score {
-  font-family: 'Unbounded', sans-serif;
-  font-size: 18px;
-  font-weight: 700;
-}
-
-.extractor-a11y-score.good { color: #ffffff; }
-.extractor-a11y-score.ok { color: #aaaaaa; }
-.extractor-a11y-score.bad { color: #666666; }
-
-.extractor-a11y-fails {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  color: #888;
-}
-
-.extractor-files {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.extractor-file {
-  display: flex;
-  justify-content: space-between;
-  padding: 6px 0;
-  border-bottom: 1px solid #1a1a1a;
-}
-
-.extractor-file:last-child {
-  border-bottom: none;
-}
-
-.extractor-file-name {
-  font-family: 'JetBrains Mono', monospace;
+  gap: 10px;
+  padding: 14px 22px 15px;
+  background: var(--ink);
+  color: var(--paper);
+  border: var(--hair);
+  box-shadow: 6px 6px 0 var(--accent);
+  font-family: var(--font-mono);
   font-size: 13px;
-  color: var(--yellow);
+  letter-spacing: 0.04em;
+  transition: transform 120ms ease, box-shadow 120ms ease;
 }
 
-.extractor-file-size {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  color: #555;
+.cta:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 8px 8px 0 var(--accent);
+  color: var(--paper);
 }
 
-/* ── RESPONSIVE ── */
-@media (max-width: 768px) {
-  .features-list { grid-template-columns: 1fr; }
-  .commands-grid { grid-template-columns: 1fr; }
-  .files-grid { grid-template-columns: 1fr; }
-  .stats-strip { flex-direction: column; }
-  .stat { border-right: none; border-bottom: 1px solid #222; }
-  .hero-cmd { font-size: 14px; padding: 16px 24px; }
-  .extractor-form { flex-direction: column; }
-  .extractor-input { border-right: 2px solid var(--black); border-bottom: none; }
-  .extractor-stats-grid { grid-template-columns: repeat(2, 1fr); }
-  .extractor-stat:nth-child(3n) { border-right: 1px solid #222; }
-  .extractor-stat:nth-child(2n) { border-right: none; }
+.cta:active {
+  transform: translate(4px, 4px);
+  box-shadow: 2px 2px 0 var(--accent);
+}
+
+/* Chip — used for small tag/label pieces. */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px 4px;
+  border: var(--hair);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+/* ── Accessibility ──────────────────────────────────────────── */
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0s !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0s !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ── Section scaffold ───────────────────────────────────────── */
+
+section {
+  padding-block: var(--r9);
+}
+
+section + section {
+  border-top: var(--hair);
+}
+
+h1, h2, h3, h4, h5, h6 { font-weight: 400; }
+
+h2.display {
+  font-size: clamp(40px, 6vw, 88px);
+}
+
+h3.display {
+  font-size: clamp(28px, 3.5vw, 48px);
 }

--- a/website/app/layout.js
+++ b/website/app/layout.js
@@ -1,18 +1,47 @@
-import "./globals.css";
+import { Fraunces, Instrument_Sans, JetBrains_Mono } from 'next/font/google';
+import './globals.css';
+
+const fraunces = Fraunces({
+  subsets: ['latin'],
+  variable: '--font-display',
+  display: 'swap',
+});
+
+const instrumentSans = Instrument_Sans({
+  subsets: ['latin'],
+  variable: '--font-body',
+  display: 'swap',
+});
+
+const mono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-mono',
+  display: 'swap',
+});
 
 export const metadata = {
-  title: "DESIGNLANG — Reverse-Engineer Any Website's Design System",
-  description: "One command. 8 output files. Colors, typography, spacing, layout, accessibility, interactions, and more. npx designlang",
+  title: 'designlang — reads a website the way a developer reads a stylesheet',
+  description:
+    'Extracts the complete design system from any live website. DTCG tokens, multi-platform emitters, MCP server, agent rules. One URL in, a design system out.',
+  metadataBase: new URL('https://designlang.dev'),
+  openGraph: {
+    title: 'designlang',
+    description: 'Extracts the complete design system from any live website.',
+    type: 'website',
+  },
+  robots: { index: true, follow: true },
+};
+
+export const viewport = {
+  themeColor: '#F3F1EA',
 };
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
-      <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-        <link href="https://fonts.googleapis.com/css2?family=Unbounded:wght@400;700;900&family=JetBrains+Mono:wght@400;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
-      </head>
+    <html
+      lang="en"
+      className={`${fraunces.variable} ${instrumentSans.variable} ${mono.variable}`}
+    >
       <body>{children}</body>
     </html>
   );

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -1,175 +1,232 @@
-import Extractor from './components/Extractor';
+import Rule from './components/Rule';
+import Marginalia from './components/Marginalia';
 
 export default function Home() {
-  const marqueeText = "COLORS // TYPOGRAPHY // SPACING // LAYOUT // SHADOWS // ACCESSIBILITY // COMPONENTS // ANIMATIONS // BREAKPOINTS // CSS VARIABLES // INTERACTIONS // RESPONSIVE // FIGMA // TAILWIND // REACT // SHADCN // ";
-
   return (
-    <>
-      {/* ── HERO ── */}
-      <section className="hero">
-        <h1 className="hero-title">
-          DESIGN
-          <br />
-          LANG
-          <span>reverse-engineer any website</span>
-        </h1>
-        <p className="hero-sub">
-          One command extracts the complete design language from any live website.
-          8 output files. 15 sections. 12 extractors. No other tool does this.
-        </p>
-        <a href="https://github.com/Manavarya09/design-extract" className="hero-cmd">
-          npx designlang https://vercel.com
-        </a>
-        <div className="scroll-hint">scroll down</div>
-      </section>
-
-      {/* ── STATS ── */}
-      <div className="stats-strip">
-        <div className="stat"><div className="stat-value">8</div><div className="stat-label">Output Files</div></div>
-        <div className="stat"><div className="stat-value">12</div><div className="stat-label">Extractors</div></div>
-        <div className="stat"><div className="stat-value">11</div><div className="stat-label">Component Types</div></div>
-        <div className="stat"><div className="stat-value">15</div><div className="stat-label">Markdown Sections</div></div>
-        <div className="stat"><div className="stat-value">7</div><div className="stat-label">Score Categories</div></div>
-        <div className="stat"><div className="stat-value">4</div><div className="stat-label">Viewports Crawled</div></div>
-      </div>
-
-      {/* ── MARQUEE ── */}
-      <div className="marquee">
-        <div className="marquee-inner">
-          {marqueeText}{marqueeText}{marqueeText}{marqueeText}
+    <main className="page">
+      {/* ── HEAD SLUG ─────────────────────────────────────── */}
+      <header style={{ paddingTop: 'var(--r6)', paddingBottom: 'var(--r7)' }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'baseline',
+            gap: 'var(--r5)',
+            borderBottom: 'var(--hair)',
+            paddingBottom: 'var(--r3)',
+          }}
+        >
+          <span className="mono" style={{ fontSize: 13, letterSpacing: '0.02em' }}>
+            designlang
+            <span style={{ color: 'var(--ink-3)', marginLeft: 12 }}>v7.0</span>
+          </span>
+          <nav
+            className="mono"
+            style={{ display: 'flex', gap: 'var(--r5)', fontSize: 12, textTransform: 'uppercase', letterSpacing: '0.1em' }}
+          >
+            <a href="#extract" style={{ borderBottom: 0 }}>Extract</a>
+            <a href="#features" style={{ borderBottom: 0 }}>Features</a>
+            <a href="#specimens" style={{ borderBottom: 0 }}>Specimens</a>
+            <a href="#install" style={{ borderBottom: 0 }}>Install</a>
+            <a href="https://github.com/Manavarya09/design-extract" style={{ borderBottom: 0 }}>GitHub</a>
+            <a href="https://www.npmjs.com/package/designlang" style={{ borderBottom: 0 }}>npm</a>
+          </nav>
         </div>
-      </div>
+      </header>
 
-      {/* ── OUTPUT FILES ── */}
-      <section>
-        <h2 className="section-title">8 Output Files</h2>
-        <div className="files-grid">
-          {[
-            { num: '01', name: '*-design-language.md', desc: 'AI-optimized markdown — feed it to any LLM and it recreates the design from scratch. 15 sections covering every aspect.' },
-            { num: '02', name: '*-preview.html', desc: 'Gorgeous dark-themed visual report with color swatches, type scale rendering, shadow cards, and accessibility score.' },
-            { num: '03', name: '*-tailwind.config.js', desc: 'Drop-in Tailwind CSS theme extension with colors, fonts, spacing, radii, shadows, and screens.' },
-            { num: '04', name: '*-variables.css', desc: 'CSS custom properties organized by category. Import directly into any project.' },
-            { num: '05', name: '*-figma-variables.json', desc: 'Figma Variables import format with light/dark mode support. Hand off to designers instantly.' },
-            { num: '06', name: '*-theme.js', desc: 'React/CSS-in-JS theme object compatible with Chakra UI, Stitches, and Vanilla Extract.' },
-            { num: '07', name: '*-shadcn-theme.css', desc: 'shadcn/ui theme variables in the exact format it expects. Paste into globals.css.' },
-            { num: '08', name: '*-design-tokens.json', desc: 'W3C Design Tokens community group format for tooling integration.' },
-          ].map(f => (
-            <div key={f.num} className="file-card" data-num={f.num}>
-              <div className="file-name">{f.name}</div>
-              <div className="file-desc">{f.desc}</div>
+      {/* ── §00 HERO ──────────────────────────────────────── */}
+      <section id="extract" style={{ paddingBlock: 'var(--r10) var(--r9)', borderTop: 0 }}>
+        <div className="with-margin">
+          <div>
+            <div className="section-label" style={{ marginBottom: 'var(--r6)' }}>
+              <span>§00 — Entry</span>
             </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ── WHAT IT EXTRACTS ── */}
-      <section className="section-red">
-        <div className="section-inner">
-          <h2 className="section-title">What It Extracts</h2>
-          <div className="features-list">
-            {[
-              { name: 'Colors', cmd: 'automatic', desc: 'Full palette with primary/secondary/accent/neutral classification. Gradients. Background and text colors with usage context.' },
-              { name: 'Typography', cmd: 'automatic', desc: 'Font families, type scale, heading/body styles, weight distribution, line heights, letter spacing.' },
-              { name: 'Spacing', cmd: 'automatic', desc: 'All unique values with automatic base-unit detection. Identifies 4px/8px grids.' },
-              { name: 'Layout System', cmd: 'automatic', desc: 'Grid column patterns, flex direction usage, container widths, gap values, justify/align patterns. The skeleton, not just the paint.' },
-              { name: 'Shadows', cmd: 'automatic', desc: 'All box-shadows parsed and classified by visual weight (xs through xl).' },
-              { name: 'Components', cmd: 'automatic', desc: '11 types: buttons, cards, inputs, links, navbars, footers, modals, dropdowns, tables, badges, avatars.' },
-              { name: 'Accessibility', cmd: 'automatic', desc: 'WCAG 2.1 contrast ratios for every fg/bg color pair. Overall score and failing pairs.' },
-              { name: 'Responsive', cmd: '--responsive', desc: 'Crawls at 4 viewports. Maps what changes between breakpoints — fonts, nav, columns, hamburger.' },
-              { name: 'Interactions', cmd: '--interactions', desc: 'Hovers and focuses interactive elements. Records actual style transitions — hover colors, focus rings, active states.' },
-              { name: 'CSS Variables', cmd: 'automatic', desc: 'All :root custom properties categorized by type — colors, spacing, typography, shadows, radii.' },
-              { name: 'Animations', cmd: 'automatic', desc: 'Transitions, easing functions, durations, and @keyframes rules.' },
-              { name: 'Design Score', cmd: 'automatic', desc: '7-category quality rating (A-F) — color discipline, typography, spacing, shadows, radii, accessibility, tokenization.' },
-            ].map(f => (
-              <div key={f.name} className="feature">
-                <div className="feature-name">{f.name}</div>
-                <div className="feature-cmd">{f.cmd}</div>
-                <div className="feature-desc">{f.desc}</div>
-              </div>
-            ))}
+            <h1
+              className="display"
+              style={{
+                fontSize: 'clamp(64px, 11vw, 200px)',
+                marginBottom: 'var(--r7)',
+              }}
+            >
+              A website<br />
+              reads as a<br />
+              <em style={{ fontStyle: 'italic', color: 'var(--accent)' }}>design system</em>.
+            </h1>
+            <p className="prose" style={{ fontSize: 20, lineHeight: 1.4, maxWidth: '46ch' }}>
+              designlang crawls any URL and returns its complete design language —
+              tokens, typography, spacing, shadows, components, regions, health,
+              remediations — in W3C DTCG format, with native emitters for iOS,
+              Android, Flutter and WordPress, and a live MCP server your editor can read.
+            </p>
           </div>
-        </div>
-      </section>
-
-      {/* ── COMMANDS ── */}
-      <section>
-        <h2 className="section-title">Commands</h2>
-        <div className="commands-grid">
-          {[
-            { name: 'designlang <url>', desc: 'Extract the full design language. Generates 8 output files.' },
-            { name: 'designlang <url> --full', desc: 'Everything at once — screenshots, responsive, interactions.' },
-            { name: 'designlang diff <A> <B>', desc: 'Compare two sites side-by-side. Outputs markdown and HTML.' },
-            { name: 'designlang brands <urls...>', desc: 'Multi-brand comparison matrix. Color overlap, typography, a11y scores.' },
-            { name: 'designlang clone <url>', desc: 'Generate a working Next.js starter with the extracted design applied.' },
-            { name: 'designlang score <url>', desc: 'Rate design system quality. 7 categories, A-F grade, actionable issues.' },
-            { name: 'designlang watch <url>', desc: 'Monitor a site for design changes on a configurable interval.' },
-            { name: 'designlang sync <url>', desc: 'Update local token files from the live site. Code-first source of truth.' },
-            { name: 'designlang history <url>', desc: 'View how a site\'s design has evolved over time.' },
-          ].map(c => (
-            <div key={c.name} className="command-card">
-              <div className="command-name">{c.name}</div>
-              <div className="command-desc">{c.desc}</div>
+          <Marginalia>
+            <div>extraction runtime</div>
+            <div>
+              <code>Playwright 1.59</code>
+              <br />
+              <code>@sparticuz/chromium</code>
             </div>
-          ))}
+            <hr style={{ margin: '12px 0', border: 0, borderTop: '1px solid var(--ink-3)' }} />
+            <div>default invocation</div>
+            <div><code>$ npx designlang &lt;url&gt;</code></div>
+            <p className="foot" style={{ marginTop: 12 }}>
+              Works without install. Playwright fetches Chromium on first run;
+              ≈ 3–6 seconds per page on a modern laptop.
+            </p>
+          </Marginalia>
         </div>
-      </section>
 
-      {/* ── SCORE DEMO ── */}
-      <section className="section-cream">
-        <div className="section-inner">
-          <h2 className="section-title">Design System Scoring</h2>
-          <div className="score-demo">
-            <div>$ designlang score https://vercel.com</div>
-            <br />
-            <div>&nbsp;&nbsp;<span className="score-grade">68</span>/100&nbsp;&nbsp;Grade: D</div>
-            <br />
-            <div>&nbsp;&nbsp;Color Discipline&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;██████████░░░░░░░░░░ 50</div>
-            <div>&nbsp;&nbsp;Typography&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;██████████████░░░░░░ 70</div>
-            <div>&nbsp;&nbsp;Spacing System&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;████████████████░░░░ 80</div>
-            <div>&nbsp;&nbsp;Shadows&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;██████████░░░░░░░░░░ 50</div>
-            <div>&nbsp;&nbsp;Border Radii&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;████████░░░░░░░░░░░░ 40</div>
-            <div>&nbsp;&nbsp;Accessibility&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;███████████████████░ 94</div>
-            <div>&nbsp;&nbsp;Tokenization&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;████████████████████ 100</div>
-          </div>
-        </div>
-      </section>
-
-      {/* ── AGENT SKILL ── */}
-      <section>
-        <h2 className="section-title">Agent Skill</h2>
-        <p style={{ fontSize: '18px', lineHeight: '1.7', color: '#aaa', maxWidth: '700px', marginBottom: '32px' }}>
-          Works with <strong style={{ color: '#fff' }}>Claude Code, Cursor, Codex, and 40+ AI coding agents</strong> via the skills ecosystem.
+        {/* Entry form — wired in PR B. Static scaffold for now. */}
+        <form
+          style={{
+            marginTop: 'var(--r8)',
+            display: 'flex',
+            alignItems: 'stretch',
+            gap: 0,
+            maxWidth: 720,
+            border: 'var(--hair)',
+          }}
+        >
+          <label htmlFor="url" style={{ display: 'none' }}>URL</label>
+          <input
+            id="url"
+            name="url"
+            type="url"
+            placeholder="https://stripe.com"
+            defaultValue="https://stripe.com"
+            className="mono"
+            style={{
+              flex: 1,
+              padding: '18px 20px',
+              fontSize: 16,
+              color: 'var(--ink)',
+              background: 'transparent',
+              borderRight: 'var(--hair)',
+            }}
+          />
+          <button type="button" className="cta" style={{ boxShadow: 'none' }}>
+            Extract
+            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--ink-3)' }}>↵</span>
+          </button>
+        </form>
+        <p className="mono" style={{ marginTop: 14, fontSize: 11, color: 'var(--ink-3)' }}>
+          Free, rate-limited to 3 extractions per day. Private IPs rejected. No accounts.
         </p>
-        <div className="hero-cmd" style={{ display: 'inline-block' }}>
-          npx skills add Manavarya09/design-extract
-        </div>
       </section>
 
-      {/* ── TRY IT ── */}
-      <section className="section-red" id="try">
-        <div className="section-inner">
-          <h2 className="section-title">Try It</h2>
-          <p style={{ fontSize: '18px', lineHeight: '1.6', marginBottom: '32px', maxWidth: '600px' }}>
-            Paste any URL. We&apos;ll extract the full design language and let you download all 8 files as a ZIP.
+      {/* ── §01 DTCG BROWSER ──────────────────────────────── */}
+      <section id="features">
+        <Rule number="01" label="DTCG token browser" />
+        <div style={{ padding: 'var(--r6) 0' }}>
+          <h2 className="display">Aliases, not values.</h2>
+          <p className="prose" style={{ marginTop: 'var(--r4)', fontSize: 18 }}>
+            v7.0 writes tokens in W3C DTCG. Semantic paths resolve to primitive
+            hexes through <code className="mono">{'{primitive.color.brand.primary}'}</code>.
+            Interactive browser ships in the next pass.
           </p>
-          <Extractor />
         </div>
       </section>
 
-      {/* ── FOOTER ── */}
-      <footer>
-        <div className="footer-title">DESIGNLANG</div>
-        <p style={{ color: '#888', fontSize: '14px' }}>
-          Built by Manavarya Singh. MIT Licensed. Open Source.
-        </p>
-        <div className="footer-links">
-          <a href="https://github.com/Manavarya09/design-extract">GitHub</a>
-          <a href="https://www.npmjs.com/package/designlang">npm</a>
+      {/* ── §02 MCP ───────────────────────────────────────── */}
+      <section>
+        <Rule number="02" label="MCP server" />
+        <div style={{ padding: 'var(--r6) 0' }}>
+          <h2 className="display">Your editor reads this.</h2>
+          <p className="prose" style={{ marginTop: 'var(--r4)', fontSize: 18 }}>
+            <code className="mono">designlang mcp --output-dir ./design-extract-output</code> exposes
+            the last extraction as MCP resources and tools. Claude Code, Cursor,
+            Windsurf. Terminal demo ships next pass.
+          </p>
         </div>
-        <div className="footer-copy">
-          No other tool extracts layout patterns, responsive behavior, interaction states, and scores design quality from a single command.
+      </section>
+
+      {/* ── §03 MULTI-PLATFORM ────────────────────────────── */}
+      <section>
+        <Rule number="03" label="Multi-platform emitters" />
+        <div style={{ padding: 'var(--r6) 0' }}>
+          <h2 className="display">One token. Five languages.</h2>
+          <p className="prose" style={{ marginTop: 'var(--r4)', fontSize: 18 }}>
+            <code className="mono">--platforms all</code> writes SwiftUI, Compose,
+            Flutter, WordPress, plus the existing web outputs. Interactive tabs
+            in the next pass.
+          </p>
         </div>
+      </section>
+
+      {/* ── §04 HEALTH ────────────────────────────────────── */}
+      <section>
+        <Rule number="04" label="CSS health audit" />
+      </section>
+
+      {/* ── §05 REMEDIATION ───────────────────────────────── */}
+      <section>
+        <Rule number="05" label="A11y remediation" />
+      </section>
+
+      {/* ── §06 REGIONS + COMPONENTS ──────────────────────── */}
+      <section>
+        <Rule number="06" label="Regions and components" />
+      </section>
+
+      {/* ── §07 SPECIMENS ─────────────────────────────────── */}
+      <section id="specimens">
+        <Rule number="07" label="Specimens" />
+      </section>
+
+      {/* ── §08 COMPARISON ────────────────────────────────── */}
+      <section>
+        <Rule number="08" label="Compared" />
+      </section>
+
+      {/* ── §09 INSTALL ───────────────────────────────────── */}
+      <section id="install" style={{ paddingBottom: 'var(--r10)' }}>
+        <Rule number="09" label="Install" />
+        <div className="with-margin" style={{ marginTop: 'var(--r5)' }}>
+          <div>
+            <pre
+              className="mono"
+              style={{
+                padding: 'var(--r4) var(--r5)',
+                background: 'var(--ink)',
+                color: 'var(--paper)',
+                fontSize: 14,
+                overflowX: 'auto',
+              }}
+            >{`$ npx designlang https://stripe.com
+$ npx designlang https://stripe.com --platforms all
+$ npx designlang https://stripe.com --emit-agent-rules
+$ designlang mcp --output-dir ./design-extract-output`}</pre>
+          </div>
+          <Marginalia>
+            <div>Node</div>
+            <div><code>≥ 20</code></div>
+            <div style={{ marginTop: 10 }}>License</div>
+            <div><code>MIT</code></div>
+          </Marginalia>
+        </div>
+      </section>
+
+      {/* ── FOOTER ───────────────────────────────────────── */}
+      <footer
+        className="mono"
+        style={{
+          borderTop: 'var(--hair)',
+          padding: 'var(--r5) 0 var(--r7)',
+          fontSize: 12,
+          color: 'var(--ink-2)',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 'var(--r6)',
+          justifyContent: 'space-between',
+        }}
+      >
+        <span>designlang / built in Node, Playwright, and opinion.</span>
+        <span>
+          <a href="https://github.com/Manavarya09/design-extract">github</a> ·{' '}
+          <a href="https://www.npmjs.com/package/designlang">npm</a> ·{' '}
+          <a href="https://github.com/Manavarya09/design-extract/discussions">discussions</a>
+        </span>
       </footer>
-    </>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary

Foundation pass of the Wave 2 website redesign. Direction: *Live Design DNA*, paper-first editorial.

Sets up the visual system; content sections still scaffolds. Subsequent PRs fill the hero extractor (B), showcase sections (C, D), specimens + comparison (E).

## What's in this PR

- **Typography stack** — Fraunces (display), Instrument Sans (body), JetBrains Mono (code / tokens). Loaded via `next/font/google` with CSS variables.
- **Palette** — paper `#F3F1EA`, ink `#0A0908`, warm stone grays, single accent molten orange `#FF4800` (used sparingly).
- **Primitives** — `.page`, `.grid-12`, `.with-margin`, `.rule`, `.marginalia`, `.cta`, `.chip`, rhythm scale, 1px hairline dividers.
- **Components** — `Rule.js` (numbered hairline with section label), `Marginalia.js` (side-column for footnotes).
- **Page scaffold** — §00–§09 section layout matching the spec. Hero renders the display heading with marginalia. Subsequent sections are stubbed for the next PRs.
- **No emoji, no icon libraries, no gradients, no glassmorphism.** One hard offset shadow on the primary CTA only.
- `prefers-reduced-motion` honored site-wide.

## Verified

- Dev server renders; no warnings in console.
- Hero visible at desktop and mobile viewports.
- `next/font` loading cleanly.

## Spec

See `docs/superpowers/specs/2026-04-18-website-redesign-design.md`.

## Follow-ups

- PR B — hero extraction form wired to streaming `/api/extract` + URL safety + rate limit + Blob cache.
- PR C — DTCG browser, MCP split, multi-platform tabs.
- PR D — CSS health, a11y slider, regions + components.
- PR E — specimens (accent-shift scroll), comparison, install polish, deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)