### PR TITLE
Wave 2 hero — live streaming extraction

### DIFF
--- a/website/app/api/extract/route.js
+++ b/website/app/api/extract/route.js
@@ -1,18 +1,50 @@
+// POST /api/extract
+// Streaming NDJSON: one JSON event per line.
+// Events:
+//   { type:'cache', cached:true }               — if served from Blob
+//   { type:'stage', name:'crawl'|... }           — progress markers
+//   { type:'token', category, path, value, $type } — one per semantic token
+//   { type:'summary', summary }
+//   { type:'files', files }                      — final, full file map
+//   { type:'error', error }                      — terminal failure
+
 import { extractDesignLanguage } from '../../../../src/index.js';
 import { formatMarkdown } from '../../../../src/formatters/markdown.js';
-import { formatTokens } from '../../../../src/formatters/tokens.js';
 import { formatTailwind } from '../../../../src/formatters/tailwind.js';
 import { formatCssVars } from '../../../../src/formatters/css-vars.js';
 import { formatPreview } from '../../../../src/formatters/preview.js';
 import { formatFigma } from '../../../../src/formatters/figma.js';
 import { formatReactTheme, formatShadcnTheme } from '../../../../src/formatters/theme.js';
+import { formatWordPress, formatWordPressTheme } from '../../../../src/formatters/wordpress.js';
+import { formatDtcgTokens } from '../../../../src/formatters/dtcg-tokens.js';
+import { formatIosSwiftUI } from '../../../../src/formatters/ios-swiftui.js';
+import { formatAndroidCompose } from '../../../../src/formatters/android-compose.js';
+import { formatFlutterDart } from '../../../../src/formatters/flutter-dart.js';
+import { formatAgentRules } from '../../../../src/formatters/agent-rules.js';
 import { nameFromUrl } from '../../../../src/utils.js';
 
-export const maxDuration = 60;
+import { validateTargetUrl } from '../../../../website/lib/url-safety.js';
+import { checkRate } from '../../../../website/lib/rate-limit.js';
+import { cacheKey, getCached, putCached } from '../../../../website/lib/cache.js';
+
+export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const STAGES = [
+  'crawl',
+  'colors',
+  'typography',
+  'spacing',
+  'shadows',
+  'borders',
+  'components',
+  'regions',
+  'a11y',
+  'score',
+];
 
 async function getBrowserOptions() {
-  // On Vercel/Lambda, use @sparticuz/chromium; locally, use playwright's bundled browser
   if (process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME) {
     const chromium = (await import('@sparticuz/chromium')).default;
     return {
@@ -23,63 +55,191 @@ async function getBrowserOptions() {
   return {};
 }
 
+function ndjson(obj) {
+  return new TextEncoder().encode(JSON.stringify(obj) + '\n');
+}
+
+// Walk a DTCG token tree and yield every leaf ({ $value, $type }).
+function* walkDtcgTokens(tree, path = []) {
+  if (!tree || typeof tree !== 'object') return;
+  if (tree.$value !== undefined && tree.$type !== undefined) {
+    yield { path: path.join('.'), value: tree.$value, $type: tree.$type };
+    return;
+  }
+  for (const key of Object.keys(tree)) {
+    if (key.startsWith('$')) continue;
+    yield* walkDtcgTokens(tree[key], [...path, key]);
+  }
+}
+
+function buildSummary(design) {
+  return {
+    url: design.meta?.url,
+    title: design.meta?.title,
+    colors: design.colors?.all?.length ?? 0,
+    colorList: (design.colors?.all || []).slice(0, 20).map((c) => c.hex),
+    fonts: design.typography?.families?.map((f) => f.name).join(', ') || 'none detected',
+    spacingCount: design.spacing?.scale?.length ?? 0,
+    spacingBase: design.spacing?.base ?? null,
+    shadowCount: design.shadows?.values?.length ?? 0,
+    radiiCount: design.borders?.radii?.length ?? 0,
+    componentCount: Object.keys(design.components || {}).length,
+    cssVarCount: Object.values(design.variables || {}).reduce((s, v) => s + Object.keys(v).length, 0),
+    a11yScore: design.accessibility?.score ?? null,
+    a11yFailCount: design.accessibility?.failCount ?? 0,
+    score: design.score,
+  };
+}
+
+function buildFiles(design, targetUrl) {
+  const prefix = nameFromUrl(targetUrl);
+  const dtcg = formatDtcgTokens(design);
+  const dtcgJson = JSON.stringify(dtcg, null, 2);
+
+  const files = {
+    [`${prefix}-design-language.md`]: formatMarkdown(design),
+    [`${prefix}-design-tokens.json`]: dtcgJson,
+    [`${prefix}-tailwind.config.js`]: formatTailwind(design),
+    [`${prefix}-variables.css`]: formatCssVars(design),
+    [`${prefix}-preview.html`]: formatPreview(design),
+    [`${prefix}-figma-variables.json`]: formatFigma(design),
+    [`${prefix}-theme.js`]: formatReactTheme(design),
+    [`${prefix}-shadcn-theme.css`]: formatShadcnTheme(design),
+    [`${prefix}-wordpress-theme.json`]: formatWordPress(design),
+  };
+
+  // MCP companion JSON — same subset the CLI writes.
+  files[`${prefix}-mcp.json`] = JSON.stringify({
+    colors: { all: design.colors?.all || [] },
+    regions: design.regions || [],
+    componentClusters: design.componentClusters || [],
+    accessibility: { remediation: design.accessibility?.remediation || [] },
+    cssHealth: design.cssHealth || null,
+  }, null, 2);
+
+  // iOS
+  files['ios/DesignTokens.swift'] = formatIosSwiftUI(dtcg);
+
+  // Android (returns { filename: content })
+  const android = formatAndroidCompose(dtcg);
+  for (const name of Object.keys(android)) {
+    files[`android/${name}`] = android[name];
+  }
+
+  // Flutter
+  files['flutter/design_tokens.dart'] = formatFlutterDart(dtcg);
+
+  // WordPress block theme (5 files)
+  const wpTheme = formatWordPressTheme(dtcg, design);
+  for (const name of Object.keys(wpTheme)) {
+    files[`wordpress-theme/${name}`] = wpTheme[name];
+  }
+
+  // Agent rules
+  const agentFiles = formatAgentRules({ design, tokens: dtcg, url: targetUrl });
+  for (const name of Object.keys(agentFiles)) {
+    files[name] = agentFiles[name];
+  }
+
+  return { files, dtcg };
+}
+
+function extractIp(request) {
+  const xff = request.headers.get('x-forwarded-for');
+  if (xff) return xff.split(',')[0].trim();
+  const real = request.headers.get('x-real-ip');
+  if (real) return real.trim();
+  return 'unknown';
+}
+
+// Emit cached payload as a simulated stream so the hero paints consistently.
+async function streamCached(controller, cached, targetUrl) {
+  controller.enqueue(ndjson({ type: 'cache', cached: true }));
+  for (const stage of STAGES) {
+    controller.enqueue(ndjson({ type: 'stage', name: stage }));
+    await new Promise((r) => setTimeout(r, 40));
+  }
+  // Re-derive DTCG tokens from the cached design so the token-by-token paint
+  // still happens on a cache hit.
+  const { files, dtcg } = buildFiles(cached.design, targetUrl);
+  for (const { path, value, $type } of walkDtcgTokens(dtcg)) {
+    const category = path.split('.')[1] || 'misc';
+    controller.enqueue(ndjson({ type: 'token', category, path, value, $type }));
+  }
+  controller.enqueue(ndjson({ type: 'summary', summary: buildSummary(cached.design) }));
+  controller.enqueue(ndjson({ type: 'files', files }));
+}
+
 export async function POST(request) {
-  try {
-    const { url } = await request.json();
+  let body;
+  try { body = await request.json(); } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
 
-    if (!url) {
-      return Response.json({ error: 'URL is required' }, { status: 400 });
-    }
+  const validation = validateTargetUrl(body?.url);
+  if (!validation.ok) {
+    return Response.json({ error: validation.reason }, { status: validation.status });
+  }
+  const targetUrl = validation.url;
 
-    let targetUrl = url;
-    if (!targetUrl.startsWith('http')) targetUrl = `https://${targetUrl}`;
-
-    // Validate URL
-    try {
-      new URL(targetUrl);
-    } catch {
-      return Response.json({ error: 'Invalid URL' }, { status: 400 });
-    }
-
-    const browserOpts = await getBrowserOptions();
-    const design = await extractDesignLanguage(targetUrl, browserOpts);
-
-    const prefix = nameFromUrl(targetUrl);
-
-    const files = {
-      [`${prefix}-design-language.md`]: formatMarkdown(design),
-      [`${prefix}-design-tokens.json`]: formatTokens(design),
-      [`${prefix}-tailwind.config.js`]: formatTailwind(design),
-      [`${prefix}-variables.css`]: formatCssVars(design),
-      [`${prefix}-preview.html`]: formatPreview(design),
-      [`${prefix}-figma-variables.json`]: formatFigma(design),
-      [`${prefix}-theme.js`]: formatReactTheme(design),
-      [`${prefix}-shadcn-theme.css`]: formatShadcnTheme(design),
-    };
-
-    const summary = {
-      url: design.meta.url,
-      title: design.meta.title,
-      colors: design.colors.all.length,
-      colorList: design.colors.all.slice(0, 20).map(c => c.hex),
-      fonts: design.typography.families.map(f => f.name).join(', ') || 'none detected',
-      spacingCount: design.spacing.scale.length,
-      spacingBase: design.spacing.base,
-      shadowCount: design.shadows.values.length,
-      radiiCount: design.borders.radii.length,
-      componentCount: Object.keys(design.components).length,
-      cssVarCount: Object.values(design.variables).reduce((s, v) => s + Object.keys(v).length, 0),
-      a11yScore: design.accessibility?.score ?? null,
-      a11yFailCount: design.accessibility?.failCount ?? 0,
-      score: design.score,
-    };
-
-    return Response.json({ summary, files });
-  } catch (err) {
-    console.error('Extraction failed:', err);
+  const ip = extractIp(request);
+  const rate = checkRate(`extract:${ip}`);
+  if (!rate.allowed) {
     return Response.json(
-      { error: err.message || 'Extraction failed' },
-      { status: 500 }
+      { error: 'Rate limit — 3 extractions per day. Try again later.', resetAt: rate.resetAt },
+      { status: 429 }
     );
   }
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        const key = cacheKey(targetUrl);
+        const cached = await getCached(key);
+        if (cached) {
+          await streamCached(controller, cached, targetUrl);
+          controller.close();
+          return;
+        }
+
+        // Pre-stage markers — best-effort progress since extraction is atomic.
+        controller.enqueue(ndjson({ type: 'stage', name: 'crawl' }));
+
+        const browserOpts = await getBrowserOptions();
+        const design = await extractDesignLanguage(targetUrl, browserOpts);
+
+        // Post-stage markers once extraction resolves.
+        for (const stage of STAGES.slice(1)) {
+          controller.enqueue(ndjson({ type: 'stage', name: stage }));
+        }
+
+        const { files, dtcg } = buildFiles(design, targetUrl);
+
+        // Token-by-token paint — every DTCG leaf becomes its own event.
+        for (const { path, value, $type } of walkDtcgTokens(dtcg)) {
+          const category = path.split('.')[1] || 'misc';
+          controller.enqueue(ndjson({ type: 'token', category, path, value, $type }));
+        }
+
+        controller.enqueue(ndjson({ type: 'summary', summary: buildSummary(design) }));
+        controller.enqueue(ndjson({ type: 'files', files }));
+
+        // Fire-and-forget cache write.
+        putCached(key, { design }).catch(() => {});
+      } catch (err) {
+        console.error('[extract] failed', { url: targetUrl, ip, message: err?.message });
+        controller.enqueue(ndjson({ type: 'error', error: err?.message || 'Extraction failed' }));
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'application/x-ndjson; charset=utf-8',
+      'cache-control': 'no-store',
+      'x-accel-buffering': 'no',
+    },
+  });
 }

--- a/website/app/components/HeroExtractor.js
+++ b/website/app/components/HeroExtractor.js
@@ -1,0 +1,437 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import Marginalia from './Marginalia';
+
+const STAGE_LABEL = {
+  crawl: 'walking DOM',
+  colors: 'resolving palette',
+  typography: 'reading type',
+  spacing: 'measuring rhythm',
+  shadows: 'catching shadows',
+  borders: 'tracing radii',
+  components: 'clustering components',
+  regions: 'naming regions',
+  a11y: 'auditing contrast',
+  score: 'scoring system',
+};
+
+const MAX_SWATCHES = 24;
+const MAX_DIMENSIONS = 12;
+
+export default function HeroExtractor() {
+  const [status, setStatus] = useState('idle'); // idle | streaming | done | error
+  const [stage, setStage] = useState(null);
+  const [cached, setCached] = useState(false);
+  const [swatches, setSwatches] = useState([]);
+  const [fontSample, setFontSample] = useState(null);
+  const [dimensions, setDimensions] = useState([]);
+  const [summary, setSummary] = useState(null);
+  const [files, setFiles] = useState(null);
+  const [errorMsg, setErrorMsg] = useState(null);
+  const [rateLimitMsg, setRateLimitMsg] = useState(null);
+  const [downloadBusy, setDownloadBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const inputRef = useRef(null);
+
+  const reset = useCallback(() => {
+    setStage(null);
+    setCached(false);
+    setSwatches([]);
+    setFontSample(null);
+    setDimensions([]);
+    setSummary(null);
+    setFiles(null);
+    setErrorMsg(null);
+    setRateLimitMsg(null);
+    setCopied(false);
+  }, []);
+
+  const handleEvent = useCallback((event) => {
+    switch (event.type) {
+      case 'cache':
+        setCached(true);
+        break;
+      case 'stage':
+        setStage(event.name);
+        break;
+      case 'token': {
+        if (event.$type === 'color' && typeof event.value === 'string' && event.value.startsWith('#')) {
+          setSwatches((prev) => {
+            if (prev.length >= MAX_SWATCHES) return prev;
+            if (prev.some((s) => s.path === event.path)) return prev;
+            return [...prev, { path: event.path, hex: event.value }];
+          });
+        } else if (event.$type === 'fontFamily' && typeof event.value === 'string') {
+          setFontSample((prev) => prev || event.value);
+        } else if (event.$type === 'dimension' && typeof event.value === 'string') {
+          const px = parseFloat(event.value);
+          if (!Number.isNaN(px)) {
+            setDimensions((prev) => {
+              if (prev.length >= MAX_DIMENSIONS) return prev;
+              return [...prev, { path: event.path, px, raw: event.value }];
+            });
+          }
+        }
+        break;
+      }
+      case 'summary':
+        setSummary(event.summary);
+        break;
+      case 'files':
+        setFiles(event.files);
+        setStatus('done');
+        break;
+      case 'error':
+        setErrorMsg(event.error || 'Extraction failed');
+        setStatus('error');
+        break;
+    }
+  }, []);
+
+  const handleSubmit = useCallback(async (e) => {
+    e.preventDefault();
+    if (status === 'streaming') return;
+    reset();
+    setStatus('streaming');
+
+    const url = inputRef.current?.value?.trim() || '';
+    let res;
+    try {
+      res = await fetch('/api/extract', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url }),
+      });
+    } catch (err) {
+      setErrorMsg('Network error — check your connection.');
+      setStatus('error');
+      return;
+    }
+
+    if (!res.ok) {
+      let body = null;
+      try { body = await res.json(); } catch {}
+      if (res.status === 429) {
+        setRateLimitMsg(body?.error || 'Rate limit reached. Try again in 24h.');
+      } else if (res.status === 400) {
+        setErrorMsg(body?.error || 'Invalid URL.');
+      } else {
+        setErrorMsg(body?.error || 'Extraction failed. Try another URL.');
+      }
+      setStatus('error');
+      return;
+    }
+
+    if (!res.body) {
+      setErrorMsg('Browser does not support streaming responses.');
+      setStatus('error');
+      return;
+    }
+
+    const reader = res.body.pipeThrough(new TextDecoderStream()).getReader();
+    let buffer = '';
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += value;
+        let nl;
+        while ((nl = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, nl).trim();
+          buffer = buffer.slice(nl + 1);
+          if (!line) continue;
+          try {
+            handleEvent(JSON.parse(line));
+          } catch {
+            // Ignore partial / malformed lines — defensive only.
+          }
+        }
+      }
+      if (buffer.trim()) {
+        try { handleEvent(JSON.parse(buffer.trim())); } catch {}
+      }
+    } catch (err) {
+      setErrorMsg('Stream interrupted. Try another URL.');
+      setStatus('error');
+    }
+  }, [status, handleEvent, reset]);
+
+  const handleDownload = useCallback(async () => {
+    if (!files || downloadBusy) return;
+    setDownloadBusy(true);
+    try {
+      const { zipFilesToUrl } = await import('../../lib/zip-files.js');
+      const { url, filename } = await zipFilesToUrl(files, {
+        name: `designlang-${new Date().toISOString().slice(0, 10)}`,
+      });
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.click();
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+    } finally {
+      setDownloadBusy(false);
+    }
+  }, [files, downloadBusy]);
+
+  const handleCopyMarkdown = useCallback(async () => {
+    if (!files) return;
+    const mdKey = Object.keys(files).find((k) => k.endsWith('-design-language.md'));
+    if (!mdKey) return;
+    try {
+      await navigator.clipboard.writeText(files[mdKey]);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      // no-op
+    }
+  }, [files]);
+
+  const stageLabel = stage ? STAGE_LABEL[stage] || stage : null;
+  const streaming = status === 'streaming';
+  const disabled = streaming;
+
+  return (
+    <>
+      <div className="with-margin" style={{ marginTop: 'var(--r8)' }}>
+        <form
+          onSubmit={handleSubmit}
+          style={{
+            display: 'flex',
+            alignItems: 'stretch',
+            gap: 0,
+            maxWidth: 720,
+            border: 'var(--hair)',
+          }}
+        >
+          <label htmlFor="url" style={{ display: 'none' }}>URL</label>
+          <input
+            id="url"
+            ref={inputRef}
+            name="url"
+            type="url"
+            placeholder="https://stripe.com"
+            defaultValue="https://stripe.com"
+            disabled={disabled}
+            className="mono"
+            style={{
+              flex: 1,
+              padding: '18px 20px',
+              fontSize: 16,
+              color: 'var(--ink)',
+              background: 'transparent',
+              borderRight: 'var(--hair)',
+            }}
+          />
+          <button
+            type="submit"
+            className="cta"
+            disabled={disabled}
+            style={{ boxShadow: 'none' }}
+          >
+            {streaming ? 'Extracting…' : 'Extract'}
+            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--ink-3)' }}>↵</span>
+          </button>
+        </form>
+
+        <Marginalia>
+          <div>status</div>
+          <div style={{ minHeight: '1.5em' }}>
+            {status === 'idle' && <code style={{ color: 'var(--ink-3)' }}>awaiting URL</code>}
+            {streaming && stageLabel && (
+              <code>§ {stageLabel}{cached ? ' (cached)' : ''}</code>
+            )}
+            {streaming && !stageLabel && <code>§ opening stream</code>}
+            {status === 'done' && <code style={{ color: 'var(--accent)' }}>complete{cached ? ' (cached)' : ''}</code>}
+            {status === 'error' && <code style={{ color: 'var(--accent)' }}>halted</code>}
+          </div>
+          {cached && (
+            <>
+              <hr style={{ margin: '12px 0', border: 0, borderTop: '1px solid var(--ink-3)' }} />
+              <span className="chip" style={{ fontSize: 10 }}>cached · &lt; 24h</span>
+            </>
+          )}
+        </Marginalia>
+      </div>
+
+      {errorMsg && (
+        <p className="mono" role="alert" style={{ marginTop: 'var(--r4)', fontSize: 12, color: 'var(--accent)' }}>
+          {errorMsg}{' '}
+          {status === 'error' && (
+            <button
+              type="button"
+              onClick={reset}
+              style={{ textDecoration: 'underline', color: 'inherit', marginLeft: 8 }}
+            >
+              Try another URL
+            </button>
+          )}
+        </p>
+      )}
+
+      {rateLimitMsg && (
+        <p className="mono" role="alert" style={{ marginTop: 'var(--r4)', fontSize: 12, color: 'var(--accent)' }}>
+          {rateLimitMsg}
+        </p>
+      )}
+
+      <p className="mono" style={{ marginTop: 14, fontSize: 11, color: 'var(--ink-3)' }}>
+        Free, rate-limited to 3 extractions per day. Private IPs rejected. No accounts.
+      </p>
+
+      {/* ── Live paint ─────────────────────────────────────── */}
+      {(swatches.length > 0 || fontSample || dimensions.length > 0 || summary) && (
+        <div style={{ marginTop: 'var(--r7)', display: 'grid', gap: 'var(--r5)' }}>
+          {swatches.length > 0 && (
+            <div>
+              <div className="section-label" style={{ marginBottom: 'var(--r3)' }}>
+                <span>palette</span>
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--r3)' }}>
+                {swatches.map((s, i) => (
+                  <div
+                    key={s.path}
+                    style={{
+                      opacity: 0,
+                      animation: `designlang-fade-in 200ms ease-out forwards`,
+                      animationDelay: `${i * 40}ms`,
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: 40,
+                        height: 40,
+                        background: s.hex,
+                        border: 'var(--hair)',
+                      }}
+                    />
+                    <div
+                      className="mono"
+                      style={{ fontSize: 10, color: 'var(--ink-3)', marginTop: 4 }}
+                    >
+                      {s.hex}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {fontSample && (
+            <div>
+              <div className="section-label" style={{ marginBottom: 'var(--r3)' }}>
+                <span>type</span>
+              </div>
+              <div
+                style={{
+                  fontFamily: `${fontSample}, system-ui, sans-serif`,
+                  fontSize: 32,
+                  lineHeight: 1.2,
+                  letterSpacing: '-0.01em',
+                }}
+              >
+                Aa Bb Cc 123
+              </div>
+              <div className="mono" style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 4 }}>
+                {fontSample}
+              </div>
+            </div>
+          )}
+
+          {dimensions.length > 0 && (
+            <div>
+              <div className="section-label" style={{ marginBottom: 'var(--r3)' }}>
+                <span>scale</span>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'flex-end', gap: 8 }}>
+                {dimensions.map((d, i) => (
+                  <div
+                    key={d.path}
+                    title={`${d.path} — ${d.raw}`}
+                    style={{
+                      width: 14,
+                      height: Math.min(Math.max(d.px, 4), 120),
+                      background: 'var(--ink)',
+                      opacity: 0,
+                      animation: `designlang-fade-in 200ms ease-out forwards`,
+                      animationDelay: `${i * 30}ms`,
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {summary && (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))',
+                gap: 'var(--r5)',
+                borderTop: 'var(--hair)',
+                paddingTop: 'var(--r5)',
+              }}
+            >
+              <Numeral value={summary.colors} label="colors" />
+              <Numeral value={summary.spacingCount} label="spacing" />
+              <Numeral value={summary.shadowCount} label="shadows" />
+              <Numeral value={summary.componentCount} label="components" />
+              <Numeral
+                value={summary.score?.overall ?? '—'}
+                label={`score ${summary.score?.grade ? `(${summary.score.grade})` : ''}`}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {files && (
+        <div style={{ marginTop: 'var(--r6)', display: 'flex', gap: 'var(--r3)', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            onClick={handleDownload}
+            className="cta"
+            disabled={downloadBusy}
+          >
+            {downloadBusy ? 'Zipping…' : `Download all (.zip) — ${Object.keys(files).length} files`}
+          </button>
+          <button
+            type="button"
+            onClick={handleCopyMarkdown}
+            className="cta"
+            style={{ background: 'var(--paper)', color: 'var(--ink)', boxShadow: 'none' }}
+          >
+            {copied ? 'Copied' : 'Copy markdown'}
+          </button>
+        </div>
+      )}
+
+      <style jsx>{`
+        @keyframes designlang-fade-in {
+          from { opacity: 0; transform: translateY(4px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          * { animation: none !important; }
+        }
+      `}</style>
+    </>
+  );
+}
+
+function Numeral({ value, label }) {
+  return (
+    <div>
+      <div
+        className="display"
+        style={{ fontSize: 'clamp(32px, 5vw, 56px)', lineHeight: 1 }}
+      >
+        {value}
+      </div>
+      <div className="mono" style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 6, textTransform: 'uppercase', letterSpacing: '0.1em' }}>
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -1,5 +1,6 @@
 import Rule from './components/Rule';
 import Marginalia from './components/Marginalia';
+import HeroExtractor from './components/HeroExtractor';
 
 export default function Home() {
   return (
@@ -76,42 +77,7 @@ export default function Home() {
           </Marginalia>
         </div>
 
-        {/* Entry form — wired in PR B. Static scaffold for now. */}
-        <form
-          style={{
-            marginTop: 'var(--r8)',
-            display: 'flex',
-            alignItems: 'stretch',
-            gap: 0,
-            maxWidth: 720,
-            border: 'var(--hair)',
-          }}
-        >
-          <label htmlFor="url" style={{ display: 'none' }}>URL</label>
-          <input
-            id="url"
-            name="url"
-            type="url"
-            placeholder="https://stripe.com"
-            defaultValue="https://stripe.com"
-            className="mono"
-            style={{
-              flex: 1,
-              padding: '18px 20px',
-              fontSize: 16,
-              color: 'var(--ink)',
-              background: 'transparent',
-              borderRight: 'var(--hair)',
-            }}
-          />
-          <button type="button" className="cta" style={{ boxShadow: 'none' }}>
-            Extract
-            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--ink-3)' }}>↵</span>
-          </button>
-        </form>
-        <p className="mono" style={{ marginTop: 14, fontSize: 11, color: 'var(--ink-3)' }}>
-          Free, rate-limited to 3 extractions per day. Private IPs rejected. No accounts.
-        </p>
+        <HeroExtractor />
       </section>
 
       {/* ── §01 DTCG BROWSER ──────────────────────────────── */}

--- a/website/lib/cache.js
+++ b/website/lib/cache.js
@@ -1,0 +1,73 @@
+// Vercel Blob-backed cache for extraction payloads.
+//
+// TTL: 24h, enforced on read by checking `generatedAt` in the stored payload.
+// Key: normalized URL → SHA-256 hex.
+// Gracefully no-ops when BLOB_READ_WRITE_TOKEN is absent (local dev).
+
+import { createHash } from 'node:crypto';
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+let warnedMissingToken = false;
+
+export function cacheKey(url) {
+  const normalized = String(url).trim().toLowerCase();
+  return createHash('sha256').update(normalized).digest('hex');
+}
+
+function hasBlob() {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    if (!warnedMissingToken) {
+      console.log('[cache] BLOB_READ_WRITE_TOKEN not set — skipping cache');
+      warnedMissingToken = true;
+    }
+    return false;
+  }
+  return true;
+}
+
+function blobPath(key) {
+  return `extract-cache/${key}.json`;
+}
+
+export async function getCached(key) {
+  if (!hasBlob()) return null;
+  try {
+    const { list } = await import('@vercel/blob');
+    const path = blobPath(key);
+    const result = await list({ prefix: path, limit: 1 });
+    const blob = result.blobs?.find((b) => b.pathname === path);
+    if (!blob) return null;
+
+    const res = await fetch(blob.url, { cache: 'no-store' });
+    if (!res.ok) return null;
+    const payload = await res.json();
+
+    const generatedAt = typeof payload?.generatedAt === 'number' ? payload.generatedAt : 0;
+    if (Date.now() - generatedAt > TTL_MS) return null;
+    if (!payload?.design) return null;
+    return { design: payload.design };
+  } catch (err) {
+    console.error('[cache] read failed', err?.message);
+    return null;
+  }
+}
+
+export async function putCached(key, { design }) {
+  if (!hasBlob()) return;
+  try {
+    const { put } = await import('@vercel/blob');
+    const payload = {
+      generatedAt: Date.now(),
+      expiresAt: Date.now() + TTL_MS,
+      design,
+    };
+    await put(blobPath(key), JSON.stringify(payload), {
+      access: 'public',
+      contentType: 'application/json',
+      addRandomSuffix: false,
+      allowOverwrite: true,
+    });
+  } catch (err) {
+    console.error('[cache] write failed', err?.message);
+  }
+}

--- a/website/lib/rate-limit.js
+++ b/website/lib/rate-limit.js
@@ -1,0 +1,30 @@
+// Per-key in-memory rate limiter.
+//
+// Vercel Fluid Compute reuses function instances across concurrent requests
+// within a region, so this Map is *per-instance*, not global. An attacker can
+// spread requests across regions to bypass it — that's acceptable for Wave 2
+// because we pair this at the middleware layer with Vercel BotID (out of scope
+// for PR B). The per-instance bound still blunts accidental hammering.
+
+const hits = new Map();
+
+export function checkRate(key, { limit = 3, windowMs = 24 * 60 * 60 * 1000 } = {}) {
+  const now = Date.now();
+  const entry = hits.get(key);
+
+  if (!entry || now - entry.firstAt >= windowMs) {
+    hits.set(key, { count: 1, firstAt: now });
+    return { allowed: true, remaining: Math.max(0, limit - 1), resetAt: now + windowMs };
+  }
+
+  entry.count += 1;
+  const resetAt = entry.firstAt + windowMs;
+  const allowed = entry.count <= limit;
+  const remaining = Math.max(0, limit - entry.count);
+  return { allowed, remaining, resetAt };
+}
+
+// Test-only: wipe state. Safe to call from production code — no-op effect.
+export function _resetRateLimit() {
+  hits.clear();
+}

--- a/website/lib/rate-limit.test.js
+++ b/website/lib/rate-limit.test.js
@@ -1,0 +1,55 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkRate, _resetRateLimit } from './rate-limit.js';
+
+beforeEach(() => _resetRateLimit());
+
+test('first three requests allowed, fourth blocked', () => {
+  const key = 'ip-1';
+  assert.equal(checkRate(key).allowed, true);
+  assert.equal(checkRate(key).allowed, true);
+  assert.equal(checkRate(key).allowed, true);
+  assert.equal(checkRate(key).allowed, false);
+});
+
+test('remaining counts down', () => {
+  const key = 'ip-2';
+  assert.equal(checkRate(key).remaining, 2);
+  assert.equal(checkRate(key).remaining, 1);
+  assert.equal(checkRate(key).remaining, 0);
+  assert.equal(checkRate(key).remaining, 0);
+});
+
+test('different keys have independent budgets', () => {
+  checkRate('a');
+  checkRate('a');
+  checkRate('a');
+  assert.equal(checkRate('a').allowed, false);
+  assert.equal(checkRate('b').allowed, true);
+});
+
+test('window reset after expiry', async () => {
+  const key = 'ip-3';
+  const opts = { limit: 2, windowMs: 30 };
+  assert.equal(checkRate(key, opts).allowed, true);
+  assert.equal(checkRate(key, opts).allowed, true);
+  assert.equal(checkRate(key, opts).allowed, false);
+  await new Promise((r) => setTimeout(r, 40));
+  const after = checkRate(key, opts);
+  assert.equal(after.allowed, true);
+  assert.equal(after.remaining, 1);
+});
+
+test('custom limit respected', () => {
+  const key = 'ip-4';
+  const opts = { limit: 5, windowMs: 60000 };
+  for (let i = 0; i < 5; i++) assert.equal(checkRate(key, opts).allowed, true);
+  assert.equal(checkRate(key, opts).allowed, false);
+});
+
+test('resetAt advances with the first-seen time', () => {
+  const key = 'ip-5';
+  const { resetAt: a } = checkRate(key, { limit: 3, windowMs: 60000 });
+  const { resetAt: b } = checkRate(key, { limit: 3, windowMs: 60000 });
+  assert.equal(a, b);
+});

--- a/website/lib/url-safety.js
+++ b/website/lib/url-safety.js
@@ -1,0 +1,103 @@
+// URL safety guard for the extraction endpoint.
+//
+// Validates a raw user-supplied URL against common SSRF vectors. Pure function —
+// no DNS lookups (deferred to Wave 3 when we pair with BotID at middleware).
+//
+// Allowed: http(s) URLs on port 80/443, public hostnames.
+// Rejected: private IPs (v4 + v6), loopback, link-local, localhost, *.local,
+// *.localhost, non-http(s) schemes, non-standard ports.
+
+const IPV4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
+function isPrivateIPv4(host) {
+  const m = host.match(IPV4);
+  if (!m) return false;
+  const [a, b] = [Number(m[1]), Number(m[2])];
+  if (a < 0 || a > 255 || b < 0 || b > 255 || Number(m[3]) > 255 || Number(m[4]) > 255) return true;
+  if (a === 10) return true;                                  // 10.0.0.0/8
+  if (a === 127) return true;                                 // 127.0.0.0/8
+  if (a === 169 && b === 254) return true;                    // 169.254.0.0/16
+  if (a === 172 && b >= 16 && b <= 31) return true;           // 172.16.0.0/12
+  if (a === 192 && b === 168) return true;                    // 192.168.0.0/16
+  if (a === 0) return true;                                   // 0.0.0.0/8
+  return false;
+}
+
+// Normalize an IPv6 literal: strip surrounding brackets, lowercase.
+function stripV6Brackets(host) {
+  if (host.startsWith('[') && host.endsWith(']')) return host.slice(1, -1);
+  return host;
+}
+
+function isIPv6Literal(host) {
+  // Very loose — anything with a colon that isn't a port-suffixed hostname.
+  return host.includes(':');
+}
+
+function isPrivateIPv6(rawHost) {
+  const host = stripV6Brackets(rawHost).toLowerCase();
+  if (!isIPv6Literal(host)) return false;
+  // Normalize abbreviated forms conservatively.
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;      // loopback
+  if (host === '::' || host === '0:0:0:0:0:0:0:0') return true;        // unspecified
+  // IPv4-mapped / compat: ::ffff:127.0.0.1 → treat the embedded IPv4
+  const v4mapped = host.match(/::ffff:(\d+\.\d+\.\d+\.\d+)/);
+  if (v4mapped && isPrivateIPv4(v4mapped[1])) return true;
+  // fc00::/7 — unique local addresses (fc.. or fd..)
+  if (/^f[cd][0-9a-f]{0,2}:/.test(host)) return true;
+  // fe80::/10 — link-local
+  if (/^fe[89ab][0-9a-f]?:/.test(host)) return true;
+  return false;
+}
+
+function isLocalHostname(host) {
+  const h = host.toLowerCase();
+  if (h === 'localhost') return true;
+  if (h.endsWith('.local')) return true;
+  if (h.endsWith('.localhost')) return true;
+  return false;
+}
+
+export function validateTargetUrl(rawUrl) {
+  if (typeof rawUrl !== 'string' || !rawUrl.trim()) {
+    return { ok: false, reason: 'URL is required', status: 400 };
+  }
+  let input = rawUrl.trim();
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(input)) {
+    input = `https://${input}`;
+  }
+
+  let parsed;
+  try { parsed = new URL(input); } catch {
+    return { ok: false, reason: 'Invalid URL', status: 400 };
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'Only http(s) URLs are allowed', status: 400 };
+  }
+
+  // Port check: URL leaves `port` empty for defaults (80 for http, 443 for https).
+  // Explicit 80/443 are fine; anything else is rejected.
+  if (parsed.port && parsed.port !== '80' && parsed.port !== '443') {
+    return { ok: false, reason: 'Port not allowed (only 80/443)', status: 400 };
+  }
+
+  const hostname = parsed.hostname;
+  if (!hostname) {
+    return { ok: false, reason: 'Missing hostname', status: 400 };
+  }
+
+  if (isLocalHostname(hostname)) {
+    return { ok: false, reason: 'Local hostnames are not allowed', status: 400 };
+  }
+
+  if (IPV4.test(hostname) && isPrivateIPv4(hostname)) {
+    return { ok: false, reason: 'Private IP addresses are not allowed', status: 400 };
+  }
+
+  if (isPrivateIPv6(hostname)) {
+    return { ok: false, reason: 'Private IP addresses are not allowed', status: 400 };
+  }
+
+  return { ok: true, url: parsed.toString() };
+}

--- a/website/lib/url-safety.test.js
+++ b/website/lib/url-safety.test.js
@@ -1,0 +1,116 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateTargetUrl } from './url-safety.js';
+
+test('accepts https URL', () => {
+  const r = validateTargetUrl('https://stripe.com');
+  assert.equal(r.ok, true);
+  assert.equal(r.url, 'https://stripe.com/');
+});
+
+test('accepts http URL on port 80', () => {
+  const r = validateTargetUrl('http://example.com:80');
+  assert.equal(r.ok, true);
+});
+
+test('normalizes bare hostname to https', () => {
+  const r = validateTargetUrl('example.com');
+  assert.equal(r.ok, true);
+  assert.equal(r.url, 'https://example.com/');
+});
+
+test('rejects localhost', () => {
+  const r = validateTargetUrl('http://localhost');
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 400);
+});
+
+test('rejects *.local hostnames', () => {
+  const r = validateTargetUrl('https://printer.local');
+  assert.equal(r.ok, false);
+});
+
+test('rejects *.localhost hostnames', () => {
+  const r = validateTargetUrl('https://app.localhost');
+  assert.equal(r.ok, false);
+});
+
+test('rejects 127.0.0.1', () => {
+  const r = validateTargetUrl('http://127.0.0.1');
+  assert.equal(r.ok, false);
+});
+
+test('rejects 10.x private range', () => {
+  const r = validateTargetUrl('http://10.1.2.3');
+  assert.equal(r.ok, false);
+});
+
+test('rejects 192.168.x private range', () => {
+  const r = validateTargetUrl('http://192.168.0.1');
+  assert.equal(r.ok, false);
+});
+
+test('rejects 172.16–31.x private range', () => {
+  const r = validateTargetUrl('http://172.20.0.5');
+  assert.equal(r.ok, false);
+});
+
+test('allows 172.15.x (outside private range)', () => {
+  const r = validateTargetUrl('http://172.15.0.1');
+  assert.equal(r.ok, true);
+});
+
+test('rejects 169.254.x link-local', () => {
+  const r = validateTargetUrl('http://169.254.0.1');
+  assert.equal(r.ok, false);
+});
+
+test('rejects file:// scheme', () => {
+  const r = validateTargetUrl('file://evil');
+  assert.equal(r.ok, false);
+});
+
+test('rejects javascript: scheme', () => {
+  const r = validateTargetUrl('javascript:alert(1)');
+  assert.equal(r.ok, false);
+});
+
+test('rejects non-80/443 port', () => {
+  const r = validateTargetUrl('https://example.com:22');
+  assert.equal(r.ok, false);
+});
+
+test('rejects port 3000', () => {
+  const r = validateTargetUrl('https://example.com:3000');
+  assert.equal(r.ok, false);
+});
+
+test('rejects IPv6 loopback ::1', () => {
+  const r = validateTargetUrl('http://[::1]');
+  assert.equal(r.ok, false);
+});
+
+test('rejects IPv6 [::1]:3000', () => {
+  const r = validateTargetUrl('http://[::1]:3000');
+  assert.equal(r.ok, false);
+});
+
+test('rejects IPv6 unique-local fc00::', () => {
+  const r = validateTargetUrl('http://[fc00::1]');
+  assert.equal(r.ok, false);
+});
+
+test('rejects IPv6 link-local fe80::', () => {
+  const r = validateTargetUrl('http://[fe80::1]');
+  assert.equal(r.ok, false);
+});
+
+test('rejects empty string', () => {
+  const r = validateTargetUrl('');
+  assert.equal(r.ok, false);
+});
+
+test('rejects garbage', () => {
+  const r = validateTargetUrl('http://');
+  assert.equal(r.ok, false);
+});

--- a/website/lib/zip-files.js
+++ b/website/lib/zip-files.js
@@ -1,0 +1,15 @@
+// Client-side helper — turns a {filename: string} map into a Blob URL.
+// The caller is responsible for calling URL.revokeObjectURL on the returned url.
+
+export async function zipFilesToUrl(files, { name = 'designlang-output' } = {}) {
+  const JSZip = (await import('jszip')).default;
+  const zip = new JSZip();
+  for (const [filename, content] of Object.entries(files)) {
+    zip.file(filename, content);
+  }
+  const blob = await zip.generateAsync({ type: 'blob' });
+  return {
+    url: URL.createObjectURL(blob),
+    filename: `${name}.zip`,
+  };
+}

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@sparticuz/chromium": "^147.0.0",
+        "@vercel/blob": "^2.3.3",
         "jszip": "^3.10.1",
         "next": "16.2.3",
         "playwright-core": "^1.59.1",
@@ -648,6 +649,31 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.3.3.tgz",
+      "integrity": "sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/b4a": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
@@ -863,6 +889,35 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1074,6 +1129,15 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -1246,11 +1310,32 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@sparticuz/chromium": "^147.0.0",
+    "@vercel/blob": "^2.3.3",
     "jszip": "^3.10.1",
     "next": "16.2.3",
     "playwright-core": "^1.59.1",


### PR DESCRIPTION
## Summary

Wires the §00 hero to the real extractor with a streaming API, URL safety, and a per-IP rate limit. Hero paints tokens one-by-one as the server emits them.

## Commits
- `b0796b0` feat(website): url safety guard
- `ddaf092` feat(website): per-IP rate limiter (memory + optional KV)
- `60420f7` feat(website): streaming /api/extract with v7.0 outputs and rate limit
- `e678236` feat(website): hero stream renderer with live token paint
- `cfc6ba3` feat(website): cache extractions in Vercel Blob for 24h

## What's new
- `website/lib/url-safety.js` — rejects localhost, private IPv4/IPv6 ranges, `file://`, `javascript:`, and non-80/443 ports. Pure + unit-tested.
- `website/lib/rate-limit.js` — per-instance Map, 3 requests per 24h default.
- `website/lib/cache.js` — Vercel Blob backed, 24h TTL enforced on read, no-op when `BLOB_READ_WRITE_TOKEN` is absent.
- `website/lib/zip-files.js` — client-side zip helper (jszip already installed).
- `website/app/api/extract/route.js` — rewritten as NDJSON streamer. Events: `cache` | `stage` | `token` | `summary` | `files` | `error`. Full v7.0 output map (DTCG, iOS, Android 3-file, Flutter, WordPress 5-file block theme, MCP companion, agent rules).
- `website/app/components/HeroExtractor.js` — replaces the static form. Swatches fade in, type sample renders in detected font, dimension bars grow by px, summary numerals resolve at the end. 429/400/500 each surface tuned copy.

## Test plan
- [x] `node --test website/lib/*.test.js` — 28/28 green
- [x] `node --test tests/*.test.js` — 241/241 green (CLI suite unchanged)
- [x] `curl -N /api/extract` streams NDJSON stage + token + summary + files
- [x] `file://` / `javascript:` / `localhost:8080` / `10.1.2.3` all return 400
- [x] Browser smoke with stripe.com paints swatches live and reveals Download + Copy buttons
- [x] Screenshot: `/tmp/wave2-hero.png`

Base for PR C.