### PR TITLE
Wave 2 showcase — DTCG browser, MCP split, platform tabs

### DIFF
--- a/website/app/components/McpSection.js
+++ b/website/app/components/McpSection.js
@@ -1,0 +1,223 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Marginalia from './Marginalia';
+
+const CURSOR_RULE = `---
+description: Design system extracted from https://stripe.com — use these tokens, do not invent new ones.
+globs: **/*.{ts,tsx,jsx,js,css,scss,html,vue,svelte,swift,kt,dart,php}
+alwaysApply: true
+---
+
+# Design system reference
+
+Source: https://stripe.com
+Extracted by designlang v7.0.0 on 2026-04-18T12:00:00Z
+
+## Semantic tokens (use these)
+- color.action.primary: #533afd
+- color.surface.default: #ffffff
+- color.text.body: #0a2540
+- radius.control: 8px
+- typography.body.fontFamily: sohne-var, Helvetica Neue, Arial, sans-serif
+
+## How to use
+- Prefer \`semantic.*\` tokens over \`primitive.*\`.
+- Never invent new tokens or hex values; reuse the ones above.
+- When a value is missing, pick the closest existing semantic token and flag the gap.
+- Reference tokens by their dotted path (e.g. \`semantic.color.action.primary\`).
+`;
+
+// The transcript. Each step is either typed (user input) or printed (server output).
+const TRANSCRIPT = [
+  { kind: 'typed', text: '$ designlang mcp --output-dir ./design-extract-output' },
+  { kind: 'print', text: '{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"designlang","version":"7.0.0"}}}' },
+  { kind: 'typed', text: '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_tokens","arguments":{"query":"action.primary"}}}' },
+  { kind: 'print', text: '{"jsonrpc":"2.0","id":2,"result":{"matches":[{"path":"semantic.color.action.primary","$type":"color","$value":"#533afd"}]}}' },
+];
+
+function Terminal({ reduced }) {
+  const [lines, setLines] = useState(() =>
+    reduced ? TRANSCRIPT.map((t) => ({ ...t, rendered: t.text })) : []
+  );
+  const containerRef = useRef(null);
+  const [inView, setInView] = useState(false);
+
+  // IntersectionObserver to pause when offscreen.
+  useEffect(() => {
+    if (reduced) return;
+    if (!containerRef.current) return;
+    const el = containerRef.current;
+    const io = new IntersectionObserver(
+      ([entry]) => setInView(entry.isIntersecting),
+      { threshold: 0.25 }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [reduced]);
+
+  // Typewriter runner.
+  useEffect(() => {
+    if (reduced) return;
+    if (!inView) return;
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    async function run() {
+      while (!signal.aborted) {
+        setLines([]);
+        for (let i = 0; i < TRANSCRIPT.length; i++) {
+          if (signal.aborted) return;
+          const step = TRANSCRIPT[i];
+          if (step.kind === 'typed') {
+            // ~55 cps ≈ 18ms per char
+            for (let j = 0; j <= step.text.length; j++) {
+              if (signal.aborted) return;
+              await wait(18, signal);
+              setLines((prev) => {
+                const next = [...prev];
+                next[i] = { ...step, rendered: step.text.slice(0, j) };
+                return next;
+              });
+            }
+            await wait(280, signal);
+          } else {
+            await wait(220, signal);
+            if (signal.aborted) return;
+            setLines((prev) => {
+              const next = [...prev];
+              next[i] = { ...step, rendered: step.text };
+              return next;
+            });
+          }
+        }
+        await wait(2000, signal);
+      }
+    }
+
+    run().catch(() => {});
+    return () => controller.abort();
+  }, [inView, reduced]);
+
+  return (
+    <div
+      ref={containerRef}
+      aria-label="designlang MCP terminal transcript"
+      style={{
+        background: 'var(--ink)',
+        color: 'var(--paper)',
+        border: 'var(--hair)',
+        fontFamily: 'var(--font-mono)',
+        fontSize: 12,
+        lineHeight: 1.55,
+        padding: 'var(--r4) var(--r5)',
+        minHeight: 320,
+        overflow: 'auto',
+      }}
+    >
+      <div style={{ color: 'var(--ink-3)', marginBottom: 8 }}>
+        designlang-mcp · stdio
+      </div>
+      {TRANSCRIPT.map((step, i) => {
+        const line = lines[i];
+        const rendered = line?.rendered ?? '';
+        const done = rendered.length === step.text.length;
+        return (
+          <pre
+            key={i}
+            style={{
+              margin: 0,
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-all',
+              color: step.kind === 'typed' ? 'var(--paper)' : 'var(--ink-3)',
+            }}
+          >
+            {step.kind === 'print' && rendered ? <span style={{ color: 'var(--accent)' }}>» </span> : null}
+            {rendered}
+            {!done && !reduced ? <span style={{ opacity: 0.7 }}>▍</span> : null}
+          </pre>
+        );
+      })}
+    </div>
+  );
+}
+
+function wait(ms, signal) {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(resolve, ms);
+    signal.addEventListener('abort', () => {
+      clearTimeout(t);
+      reject(new Error('aborted'));
+    }, { once: true });
+  });
+}
+
+export default function McpSection() {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener?.('change', update);
+    return () => mq.removeEventListener?.('change', update);
+  }, []);
+
+  return (
+    <div>
+      <div style={{ padding: 'var(--r5) 0 var(--r6)' }}>
+        <h2 className="display">Your editor reads this.</h2>
+        <p className="prose" style={{ marginTop: 'var(--r4)', fontSize: 18, maxWidth: '52ch' }}>
+          The MCP server exposes five resources and five tools over stdio, speaking
+          JSON-RPC to Claude Code, Cursor, and Windsurf. See <a href="#install">§09</a> for install.
+        </p>
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(0, 7fr) minmax(0, 5fr)',
+          columnGap: 0,
+          alignItems: 'stretch',
+        }}
+      >
+        {/* Left: rule file */}
+        <div
+          style={{
+            background: 'var(--paper-2)',
+            border: 'var(--hair)',
+            borderRight: 0,
+            padding: 'var(--r4) var(--r5)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            lineHeight: 1.55,
+            overflow: 'auto',
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 'var(--r3)' }}>
+            <span style={{ color: 'var(--ink-3)' }}>.cursor/rules/designlang.mdc</span>
+            <span className="chip" style={{ color: 'var(--accent)', borderColor: 'var(--accent)' }}>
+              alwaysApply: true
+            </span>
+          </div>
+          <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word', color: 'var(--ink)' }}>
+            {CURSOR_RULE}
+          </pre>
+        </div>
+
+        {/* Right: terminal */}
+        <Terminal reduced={reduced} />
+      </div>
+
+      <div style={{ marginTop: 'var(--r6)' }}>
+        <Marginalia>
+          <div>install</div>
+          <div>
+            <code>{'{ "mcpServers": { "designlang": { "command": "npx", "args": ["designlang","mcp"] } } }'}</code>
+          </div>
+          <hr style={{ margin: '12px 0', border: 0, borderTop: '1px solid var(--ink-3)' }} />
+          <div>Zero-config for any MCP-aware agent.</div>
+        </Marginalia>
+      </div>
+    </div>
+  );
+}

--- a/website/app/components/PlatformTabs.js
+++ b/website/app/components/PlatformTabs.js
@@ -1,0 +1,250 @@
+'use client';
+
+import { useRef, useState } from 'react';
+
+const TABS = [
+  {
+    id: 'web',
+    label: 'Web',
+    filename: 'tokens.css',
+    code: `:root {
+  --color-action-primary: #533afd;
+  --radius-control: 8px;
+}`,
+  },
+  {
+    id: 'ios',
+    label: 'iOS',
+    filename: 'DesignTokens.swift',
+    code: `import SwiftUI
+
+extension Color {
+  static let actionPrimary = Color(hex: 0x533AFD)
+}`,
+  },
+  {
+    id: 'android',
+    label: 'Android',
+    filename: 'DesignTokens.kt',
+    code: `import androidx.compose.ui.graphics.Color
+
+val ActionPrimary = Color(0xFF533AFD)
+
+// res/values/colors.xml
+// <color name="action_primary">#FF533AFD</color>`,
+  },
+  {
+    id: 'flutter',
+    label: 'Flutter',
+    filename: 'design_tokens.dart',
+    code: `import 'package:flutter/material.dart';
+
+class DesignTokens {
+  static const Color actionPrimary = Color(0xFF533AFD);
+}`,
+  },
+  {
+    id: 'wordpress',
+    label: 'WordPress',
+    filename: 'theme.json',
+    code: `{
+  "settings": {
+    "color": {
+      "palette": [
+        { "slug": "action-primary", "color": "#533AFD", "name": "Action Primary" }
+      ]
+    }
+  }
+}`,
+  },
+];
+
+export default function PlatformTabs() {
+  const [activeId, setActiveId] = useState(TABS[0].id);
+  const [copied, setCopied] = useState(false);
+  const tabRefs = useRef({});
+
+  const active = TABS.find((t) => t.id === activeId) || TABS[0];
+  const lines = active.code.split('\n');
+
+  const onKeyDown = (e) => {
+    const idx = TABS.findIndex((t) => t.id === activeId);
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      const next = TABS[(idx + 1) % TABS.length];
+      setActiveId(next.id);
+      tabRefs.current[next.id]?.focus();
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const next = TABS[(idx - 1 + TABS.length) % TABS.length];
+      setActiveId(next.id);
+      tabRefs.current[next.id]?.focus();
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setActiveId(TABS[0].id);
+      tabRefs.current[TABS[0].id]?.focus();
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      const last = TABS[TABS.length - 1];
+      setActiveId(last.id);
+      tabRefs.current[last.id]?.focus();
+    }
+  };
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(active.code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    } catch {
+      // noop
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ padding: 'var(--r5) 0 var(--r4)' }}>
+        <div className="eyebrow" style={{ marginBottom: 'var(--r3)' }}>§03 Multi-platform emitters</div>
+        <h2 className="display">One token. Five languages.</h2>
+        <p className="prose" style={{ marginTop: 'var(--r4)', fontSize: 18, maxWidth: '52ch' }}>
+          The same semantic token, emitted in five native dialects. No style leaks,
+          no translation layer.
+        </p>
+      </div>
+
+      {/* Tab strip */}
+      <div
+        role="tablist"
+        aria-label="Platform emitters"
+        onKeyDown={onKeyDown}
+        style={{
+          display: 'flex',
+          gap: 0,
+          borderBottom: 'var(--hair)',
+        }}
+      >
+        {TABS.map((t) => {
+          const selected = t.id === activeId;
+          return (
+            <button
+              key={t.id}
+              ref={(el) => (tabRefs.current[t.id] = el)}
+              role="tab"
+              id={`platform-tab-${t.id}`}
+              aria-selected={selected}
+              aria-controls={`platform-panel-${t.id}`}
+              tabIndex={selected ? 0 : -1}
+              onClick={() => setActiveId(t.id)}
+              style={{
+                padding: '14px 18px 13px',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 12,
+                letterSpacing: '0.08em',
+                textTransform: 'uppercase',
+                color: selected ? 'var(--ink)' : 'var(--ink-2)',
+                borderBottom: selected ? '2px solid var(--accent)' : '2px solid transparent',
+                marginBottom: '-1px',
+                background: 'transparent',
+              }}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Code panel */}
+      <div
+        role="tabpanel"
+        id={`platform-panel-${active.id}`}
+        aria-labelledby={`platform-tab-${active.id}`}
+        style={{
+          position: 'relative',
+          background: 'var(--ink)',
+          color: 'var(--paper)',
+          border: 'var(--hair)',
+          borderTop: 0,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'baseline',
+            padding: '12px 20px',
+            borderBottom: '1px solid var(--ink-2)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            color: 'var(--ink-3)',
+            letterSpacing: '0.04em',
+          }}
+        >
+          <span>{active.filename}</span>
+          <button
+            onClick={onCopy}
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: copied ? 'var(--accent)' : 'var(--paper)',
+              padding: '4px 10px',
+              border: '1px solid var(--ink-3)',
+            }}
+            aria-live="polite"
+          >
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+
+        <div
+          style={{
+            padding: '20px 0',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 13,
+            lineHeight: 1.6,
+            fontFeatureSettings: "'zero' 1, 'ss01' 1",
+          }}
+        >
+          {lines.map((line, i) => (
+            <div
+              key={i}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '3.5rem 1fr',
+                alignItems: 'baseline',
+              }}
+            >
+              <span
+                style={{
+                  color: 'var(--ink-3)',
+                  textAlign: 'right',
+                  paddingRight: 14,
+                  borderRight: '1px solid var(--ink-2)',
+                  userSelect: 'none',
+                }}
+              >
+                {i + 1}
+              </span>
+              <pre style={{ margin: 0, paddingLeft: 20, whiteSpace: 'pre', color: 'var(--paper)' }}>
+                {line || ' '}
+              </pre>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <p
+        className="mono"
+        style={{
+          marginTop: 'var(--r4)',
+          fontSize: 12,
+          color: 'var(--ink-2)',
+        }}
+      >
+        <code>designlang &lt;url&gt; --platforms all</code> writes these files under{' '}
+        <code>./design-extract-output/&lt;platform&gt;/</code>.
+      </p>
+    </div>
+  );
+}

--- a/website/app/components/TokenBrowser.js
+++ b/website/app/components/TokenBrowser.js
@@ -1,0 +1,344 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { resolveRef, flattenTokens } from '../../lib/token-helpers';
+import { sampleTokens, sampleCommand } from './token-browser-sample';
+import Marginalia from './Marginalia';
+
+const REF_PATTERN = /^\{([^}]+)\}$/;
+function refTarget(value) {
+  if (typeof value !== 'string') return null;
+  const m = value.match(REF_PATTERN);
+  return m ? m[1] : null;
+}
+
+function Swatch({ value }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        display: 'inline-block',
+        width: 14,
+        height: 14,
+        border: '1px solid var(--ink)',
+        background: value,
+        verticalAlign: 'middle',
+        marginRight: 8,
+      }}
+    />
+  );
+}
+
+function ValueSample({ row, resolvedHex, highlighted }) {
+  const { $type, $value } = row;
+  if ($type === 'color') {
+    const display = typeof $value === 'string' && $value.startsWith('{')
+      ? (resolvedHex || $value)
+      : $value;
+    return (
+      <span className="mono" style={{ fontSize: 12, display: 'inline-flex', alignItems: 'center' }}>
+        {typeof display === 'string' && display.startsWith('#') ? <Swatch value={display} /> : null}
+        <span style={{ color: highlighted ? 'var(--accent)' : 'var(--ink)' }}>{display}</span>
+      </span>
+    );
+  }
+  if ($type === 'dimension') {
+    return <span className="mono" style={{ fontSize: 12 }}>{String(resolvedHex || $value)}</span>;
+  }
+  if ($type === 'typography' && typeof $value === 'object' && $value) {
+    const { fontFamily, fontSize, lineHeight, fontWeight } = $value;
+    const label = `${String(fontFamily).split(',')[0]} ${fontSize}/${lineHeight} ${fontWeight}`;
+    return (
+      <span
+        style={{
+          fontFamily: String(fontFamily),
+          fontSize: 13,
+          lineHeight: 1.3,
+          fontWeight: Number(fontWeight) || 400,
+        }}
+      >
+        {label}
+      </span>
+    );
+  }
+  return <span className="mono" style={{ fontSize: 12 }}>{JSON.stringify($value)}</span>;
+}
+
+export default function TokenBrowser() {
+  const tokens = sampleTokens;
+  const semanticRows = useMemo(() => flattenTokens(tokens, { layer: 'semantic' }), [tokens]);
+  const primitiveRows = useMemo(() => flattenTokens(tokens, { layer: 'primitive' }), [tokens]);
+
+  const [activeIdx, setActiveIdx] = useState(-1);
+  const [reduced, setReduced] = useState(false);
+  const semanticRefs = useRef([]);
+  const primitiveRefs = useRef([]);
+  const containerRef = useRef(null);
+  const [lineGeom, setLineGeom] = useState(null); // { x1, y1, x2, y2, targetPrimitivePath }
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener?.('change', update);
+    return () => mq.removeEventListener?.('change', update);
+  }, []);
+
+  // Compute line geometry when activeIdx changes.
+  useEffect(() => {
+    if (activeIdx < 0 || !containerRef.current) {
+      setLineGeom(null);
+      return;
+    }
+    const row = semanticRows[activeIdx];
+    if (!row) return setLineGeom(null);
+    const target = refTarget(row.$value);
+    if (!target) return setLineGeom(null);
+
+    const primitiveIdx = primitiveRows.findIndex((p) => p.path === target);
+    if (primitiveIdx < 0) return setLineGeom(null);
+
+    const semEl = semanticRefs.current[activeIdx];
+    const primEl = primitiveRefs.current[primitiveIdx];
+    const box = containerRef.current.getBoundingClientRect();
+    if (!semEl || !primEl) return setLineGeom(null);
+    const a = semEl.getBoundingClientRect();
+    const b = primEl.getBoundingClientRect();
+
+    setLineGeom({
+      x1: a.right - box.left,
+      y1: a.top + a.height / 2 - box.top,
+      x2: b.left - box.left,
+      y2: b.top + b.height / 2 - box.top,
+      targetPrimitivePath: target,
+      width: box.width,
+      height: box.height,
+    });
+  }, [activeIdx, semanticRows, primitiveRows]);
+
+  // Recompute on resize.
+  useEffect(() => {
+    const onResize = () => setActiveIdx((i) => i); // re-trigger
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const activeRow = activeIdx >= 0 ? semanticRows[activeIdx] : null;
+  const activeResolved = activeRow ? resolveRef(tokens, activeRow.path) : null;
+  const activeTargetPath = activeRow ? refTarget(activeRow.$value) : null;
+
+  const handleKey = (e) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIdx((i) => Math.min(semanticRows.length - 1, i < 0 ? 0 : i + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(0, i < 0 ? 0 : i - 1));
+    } else if (e.key === 'Escape') {
+      setActiveIdx(-1);
+    }
+  };
+
+  return (
+    <div className="with-margin">
+      <div>
+        <h2 className="display" style={{ marginBottom: 'var(--r3)' }}>Aliases, not values.</h2>
+        <p className="prose" style={{ fontSize: 18, marginBottom: 'var(--r6)' }}>
+          v7.0 writes tokens in W3C DTCG. Hover a semantic row on the left and watch the
+          alias resolve through to its primitive on the right.
+        </p>
+
+        <div
+          ref={containerRef}
+          role="group"
+          aria-label="DTCG token browser"
+          tabIndex={0}
+          onKeyDown={handleKey}
+          style={{
+            position: 'relative',
+            display: 'grid',
+            gridTemplateColumns: '5fr 2fr 5fr',
+            columnGap: 0,
+            border: 'var(--hair)',
+            background: 'var(--paper-2)',
+          }}
+        >
+          {/* Left: semantic */}
+          <div>
+            <div
+              className="mono"
+              style={{
+                fontSize: 11,
+                letterSpacing: '0.12em',
+                textTransform: 'uppercase',
+                color: 'var(--ink-2)',
+                padding: '10px 14px',
+                borderBottom: 'var(--hair)',
+              }}
+            >
+              semantic
+            </div>
+            {semanticRows.map((row, i) => {
+              const isActive = i === activeIdx;
+              return (
+                <div
+                  key={row.path}
+                  ref={(el) => (semanticRefs.current[i] = el)}
+                  onMouseEnter={() => setActiveIdx(i)}
+                  onFocus={() => setActiveIdx(i)}
+                  tabIndex={-1}
+                  role="row"
+                  aria-selected={isActive}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr auto',
+                    alignItems: 'center',
+                    gap: 12,
+                    padding: '10px 14px',
+                    borderBottom: i === semanticRows.length - 1 ? 0 : '1px solid var(--ink-3)',
+                    background: isActive ? 'var(--paper)' : 'transparent',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <span className="mono" style={{ fontSize: 12, color: 'var(--ink)' }}>
+                    {row.path.replace(/^semantic\./, '')}
+                  </span>
+                  <ValueSample row={row} resolvedHex={isActive ? activeResolved : null} highlighted={isActive} />
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Middle: flight-path */}
+          <div style={{ position: 'relative', borderLeft: '1px solid var(--ink-3)', borderRight: '1px solid var(--ink-3)' }}>
+            {lineGeom && (
+              <svg
+                aria-hidden="true"
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  width: '100%',
+                  height: '100%',
+                  pointerEvents: 'none',
+                  overflow: 'visible',
+                }}
+                viewBox={`0 0 ${lineGeom.width} ${lineGeom.height}`}
+                preserveAspectRatio="none"
+              >
+                <FlightLine geom={lineGeom} reduced={reduced} />
+              </svg>
+            )}
+          </div>
+
+          {/* Right: primitive */}
+          <div>
+            <div
+              className="mono"
+              style={{
+                fontSize: 11,
+                letterSpacing: '0.12em',
+                textTransform: 'uppercase',
+                color: 'var(--ink-2)',
+                padding: '10px 14px',
+                borderBottom: 'var(--hair)',
+              }}
+            >
+              primitive
+            </div>
+            {primitiveRows.map((row, i) => {
+              const isTarget = activeTargetPath === row.path;
+              return (
+                <div
+                  key={row.path}
+                  ref={(el) => (primitiveRefs.current[i] = el)}
+                  role="row"
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr auto',
+                    alignItems: 'center',
+                    gap: 12,
+                    padding: '10px 14px',
+                    borderBottom: i === primitiveRows.length - 1 ? 0 : '1px solid var(--ink-3)',
+                    background: isTarget ? 'var(--paper)' : 'transparent',
+                    boxShadow: isTarget ? 'inset 3px 0 0 var(--accent)' : 'none',
+                  }}
+                >
+                  <span className="mono" style={{ fontSize: 12 }}>
+                    {row.path.replace(/^primitive\./, '')}
+                  </span>
+                  <ValueSample row={row} highlighted={isTarget} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Live region for screen readers */}
+        <div
+          aria-live="polite"
+          style={{
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            overflow: 'hidden',
+            clip: 'rect(0 0 0 0)',
+          }}
+        >
+          {activeRow
+            ? `${activeRow.path} resolves to ${activeTargetPath || activeRow.$value} — ${activeResolved || ''}`
+            : ''}
+        </div>
+      </div>
+
+      <Marginalia>
+        <div>taxonomy</div>
+        <div>
+          Semantic tokens describe intent. Primitive tokens describe values.
+          designlang writes both in W3C DTCG so your consumer can choose which layer to bind to.
+        </div>
+        <hr style={{ margin: '12px 0', border: 0, borderTop: '1px solid var(--ink-3)' }} />
+        <div>produced by</div>
+        <div><code>{sampleCommand}</code></div>
+      </Marginalia>
+    </div>
+  );
+}
+
+function FlightLine({ geom, reduced }) {
+  const { x1, y1, x2, y2 } = geom;
+  // Curve control points for a smooth horizontal flight path.
+  const midX = (x1 + x2) / 2;
+  const d = `M ${x1} ${y1} C ${midX} ${y1}, ${midX} ${y2}, ${x2} ${y2}`;
+
+  const pathRef = useRef(null);
+  const [len, setLen] = useState(0);
+  useEffect(() => {
+    if (pathRef.current) setLen(pathRef.current.getTotalLength());
+  }, [x1, y1, x2, y2]);
+
+  return (
+    <>
+      <path
+        ref={pathRef}
+        d={d}
+        fill="none"
+        stroke="var(--accent)"
+        strokeWidth="1.5"
+        strokeDasharray={reduced ? '0' : len}
+        strokeDashoffset={reduced ? 0 : len}
+        style={{
+          animation: reduced ? 'none' : 'designlang-flight 320ms ease-out forwards',
+        }}
+      />
+      <circle cx={x2} cy={y2} r="3" fill="var(--accent)" />
+      <style>{`
+        @keyframes designlang-flight {
+          to { stroke-dashoffset: 0; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          @keyframes designlang-flight { to { stroke-dashoffset: 0; } }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/website/app/components/token-browser-sample.js
+++ b/website/app/components/token-browser-sample.js
@@ -1,0 +1,65 @@
+// Hand-curated DTCG sample shaped exactly like formatDtcgTokens() output.
+// Derived from the Stripe PR B smoke run; used as seed data for <TokenBrowser />.
+
+export const sampleTokens = {
+  $metadata: {
+    generator: 'designlang',
+    version: '7.0.0',
+    spec: 'https://design-tokens.github.io/community-group/format/',
+    source: 'https://stripe.com',
+  },
+  primitive: {
+    color: {
+      brand: {
+        primary: { $value: '#533afd', $type: 'color' },
+        secondary: { $value: '#0a2540', $type: 'color' },
+      },
+      neutral: {
+        n100: { $value: '#f6f9fc', $type: 'color' },
+        n500: { $value: '#8792a2', $type: 'color' },
+        n900: { $value: '#0a2540', $type: 'color' },
+      },
+      background: {
+        bg0: { $value: '#ffffff', $type: 'color' },
+      },
+    },
+    radius: {
+      r0: { $value: '4px', $type: 'dimension' },
+      r1: { $value: '8px', $type: 'dimension' },
+    },
+    spacing: {
+      s2: { $value: '8px', $type: 'dimension' },
+      s4: { $value: '16px', $type: 'dimension' },
+    },
+  },
+  semantic: {
+    color: {
+      action: {
+        primary: { $value: '{primitive.color.brand.primary}', $type: 'color' },
+      },
+      surface: {
+        default: { $value: '{primitive.color.background.bg0}', $type: 'color' },
+      },
+      text: {
+        body: { $value: '{primitive.color.neutral.n900}', $type: 'color' },
+      },
+    },
+    radius: {
+      control: { $value: '{primitive.radius.r1}', $type: 'dimension' },
+    },
+    typography: {
+      body: {
+        $value: {
+          fontFamily: 'sohne-var, Helvetica Neue, Arial, sans-serif',
+          fontSize: '16px',
+          fontWeight: '400',
+          lineHeight: '1.5',
+        },
+        $type: 'typography',
+      },
+    },
+  },
+};
+
+// The CLI invocation that produced the sample.
+export const sampleCommand = '$ npx designlang https://stripe.com --format dtcg';

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -2,6 +2,7 @@ import Rule from './components/Rule';
 import Marginalia from './components/Marginalia';
 import HeroExtractor from './components/HeroExtractor';
 import TokenBrowser from './components/TokenBrowser';
+import McpSection from './components/McpSection';
 
 export default function Home() {
   return (
@@ -92,14 +93,7 @@ export default function Home() {
       {/* ── §02 MCP ───────────────────────────────────────── */}
       <section>
         <Rule number="02" label="MCP server" />
-        <div style={{ padding: 'var(--r6) 0' }}>
-          <h2 className="display">Your editor reads this.</h2>
-          <p className="prose" style={{ marginTop: 'var(--r4)', fontSize: 18 }}>
-            <code className="mono">designlang mcp --output-dir ./design-extract-output</code> exposes
-            the last extraction as MCP resources and tools. Claude Code, Cursor,
-            Windsurf. Terminal demo ships next pass.
-          </p>
-        </div>
+        <McpSection />
       </section>
 
       {/* ── §03 MULTI-PLATFORM ────────────────────────────── */}

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -1,6 +1,7 @@
 import Rule from './components/Rule';
 import Marginalia from './components/Marginalia';
 import HeroExtractor from './components/HeroExtractor';
+import TokenBrowser from './components/TokenBrowser';
 
 export default function Home() {
   return (
@@ -84,12 +85,7 @@ export default function Home() {
       <section id="features">
         <Rule number="01" label="DTCG token browser" />
         <div style={{ padding: 'var(--r6) 0' }}>
-          <h2 className="display">Aliases, not values.</h2>
-          <p className="prose" style={{ marginTop: 'var(--r4)', fontSize: 18 }}>
-            v7.0 writes tokens in W3C DTCG. Semantic paths resolve to primitive
-            hexes through <code className="mono">{'{primitive.color.brand.primary}'}</code>.
-            Interactive browser ships in the next pass.
-          </p>
+          <TokenBrowser />
         </div>
       </section>
 

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -3,6 +3,7 @@ import Marginalia from './components/Marginalia';
 import HeroExtractor from './components/HeroExtractor';
 import TokenBrowser from './components/TokenBrowser';
 import McpSection from './components/McpSection';
+import PlatformTabs from './components/PlatformTabs';
 
 export default function Home() {
   return (
@@ -99,14 +100,7 @@ export default function Home() {
       {/* ── §03 MULTI-PLATFORM ────────────────────────────── */}
       <section>
         <Rule number="03" label="Multi-platform emitters" />
-        <div style={{ padding: 'var(--r6) 0' }}>
-          <h2 className="display">One token. Five languages.</h2>
-          <p className="prose" style={{ marginTop: 'var(--r4)', fontSize: 18 }}>
-            <code className="mono">--platforms all</code> writes SwiftUI, Compose,
-            Flutter, WordPress, plus the existing web outputs. Interactive tabs
-            in the next pass.
-          </p>
-        </div>
+        <PlatformTabs />
       </section>
 
       {/* ── §04 HEALTH ────────────────────────────────────── */}

--- a/website/lib/token-helpers.js
+++ b/website/lib/token-helpers.js
@@ -1,0 +1,70 @@
+// Browser-friendly DTCG helpers — mirrors src/formatters/_token-ref.js contract.
+// resolveRef: follow {ref} chains, guard cycles.
+// flattenTokens: walk primitive.*/semantic.* into a flat row list.
+
+const REF_PATTERN = /^\{([^}]+)\}$/;
+
+function parseRef(value) {
+  if (typeof value !== 'string') return null;
+  const m = value.match(REF_PATTERN);
+  return m ? m[1] : null;
+}
+
+function getAtPath(tokens, path) {
+  const parts = path.split('.');
+  let node = tokens;
+  for (const part of parts) {
+    if (node == null || typeof node !== 'object') return undefined;
+    node = node[part];
+  }
+  return node;
+}
+
+export function resolveRef(tokens, pathOrRefString, seen = new Set()) {
+  if (pathOrRefString == null) return undefined;
+  const refPath = parseRef(pathOrRefString);
+  const path = refPath != null ? refPath : String(pathOrRefString);
+  if (seen.has(path)) return undefined;
+  seen.add(path);
+
+  const node = getAtPath(tokens, path);
+  if (node == null) return undefined;
+
+  if (typeof node === 'object' && '$value' in node) {
+    const inner = node.$value;
+    const innerRef = parseRef(inner);
+    if (innerRef) return resolveRef(tokens, innerRef, seen);
+    return inner;
+  }
+
+  const innerRef = parseRef(node);
+  if (innerRef) return resolveRef(tokens, innerRef, seen);
+
+  return node;
+}
+
+// Walk a DTCG subtree and collect every leaf token (one with $value).
+function walk(node, prefix, out, layer) {
+  if (node == null || typeof node !== 'object') return;
+  if ('$value' in node) {
+    out.push({ layer, path: prefix, $type: node.$type, $value: node.$value });
+    return;
+  }
+  for (const key of Object.keys(node)) {
+    if (key.startsWith('$')) continue;
+    const next = prefix ? `${prefix}.${key}` : key;
+    walk(node[key], next, out, layer);
+  }
+}
+
+export function flattenTokens(tokens, opts = { layer: 'all' }) {
+  const layer = opts.layer || 'all';
+  const rows = [];
+  if (layer === 'primitive' || layer === 'all') {
+    walk(tokens.primitive, 'primitive', rows, 'primitive');
+  }
+  if (layer === 'semantic' || layer === 'all') {
+    walk(tokens.semantic, 'semantic', rows, 'semantic');
+  }
+  return rows;
+}


### PR DESCRIPTION
## Summary

Replaces the §01–§03 stubs on the Wave 2 homepage with real interactive components. Three commits, scoped to `website/` only.

- `feat(website): DTCG alias browser` (5236389) — §01 two-column semantic/primitive browser with an inline-SVG flight path animating from the hovered/focused alias to its primitive target. Ships `website/lib/token-helpers.js` (`resolveRef` + `flattenTokens`) shaped to match the real `formatDtcgTokens` output so real streamed data will drop in later.
- `feat(website): MCP terminal + Cursor rule split` (c5922d0) — §02 split layout: real `.cursor/rules/designlang.mdc` content on the left with an accent \`alwaysApply: true\` chip, JSON-RPC terminal transcript on the right driven by a setTimeout + AbortController typewriter.
- `feat(website): multi-platform code viewer` (13113aa) — §03 WAI-ARIA tablist with five emitters (Web, iOS, Android, Flutter, WordPress), 2px accent underline on the active tab, line-numbered ink code panel, plain-text Copy → Copied button.

## Motion / accessibility notes

- `prefers-reduced-motion` handled per-component: SVG line appears instantly (no stroke-dashoffset animation), terminal renders the final transcript statically, no typewriter cursor.
- Terminal typewriter is gated by an IntersectionObserver — only runs while §02 is in view, AbortController tears it down on unmount.
- TokenBrowser supports keyboard arrow navigation with an aria-live alias announcement.
- PlatformTabs: \`role=tablist\`, roving tabindex, left/right/Home/End keys, \`aria-selected\`/\`aria-controls\` wired.

## Non-negotiables

No Framer Motion, no icon libraries, no purple/blue AI gradients, no glassmorphism, no drop shadows (the CTA pattern from §00 is untouched). Inline SVG only. No emoji.

## Test plan

- [x] \`node --test website/lib/rate-limit.test.js website/lib/url-safety.test.js\` → 28/28
- [x] \`node --test tests/*.test.js\` → 241/241
- [x] \`npx next build\` compiles clean
- [x] Desktop screenshots captured at /tmp/wave2-c1.png, /tmp/wave2-c2.png, /tmp/wave2-c3.png