### PR TITLE
Wave 2 analytics — CSS health, a11y remediation, regions + components

### DIFF
--- a/website/app/components/A11ySlider.js
+++ b/website/app/components/A11ySlider.js
@@ -1,0 +1,369 @@
+'use client';
+
+// §05 A11y remediation — interactive contrast slider.
+// WCAG relative-luminance formula copied here (~12 lines) so this stays
+// client-side and doesn't import from the CLI package.
+
+import { useMemo, useState } from 'react';
+import Rule from './Rule';
+import Marginalia from './Marginalia';
+
+// ── WCAG helpers ────────────────────────────────────────────────
+function toRgb(hex) {
+  const h = String(hex || '').replace('#', '');
+  const n = h.length === 3 ? h.split('').map((x) => x + x).join('') : h;
+  const i = parseInt(n, 16);
+  return [(i >> 16) & 255, (i >> 8) & 255, i & 255];
+}
+function relLum([r, g, b]) {
+  const f = (c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+function contrast(a, b) {
+  const la = relLum(toRgb(a));
+  const lb = relLum(toRgb(b));
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+function lerpHex(a, b, t) {
+  const [ar, ag, ab] = toRgb(a);
+  const [br, bg, bb] = toRgb(b);
+  const r = Math.round(ar + (br - ar) * t);
+  const g = Math.round(ag + (bg - ag) * t);
+  const bl = Math.round(ab + (bb - ab) * t);
+  return (
+    '#' +
+    [r, g, bl].map((x) => x.toString(16).padStart(2, '0')).join('').toUpperCase()
+  );
+}
+
+// ── Demo data (shaped like remediateFailingPairs output) ────────
+const BG = '#F3F1EA';
+const FAIL_FG = '#B8B199';
+const PASS_FG = '#403C34';
+
+const REMEDIATIONS = [
+  {
+    fg: '#B8B199',
+    bg: '#F3F1EA',
+    ratio: 2.11,
+    rule: 'AA-normal',
+    suggestion: { replace: 'fg', color: '#403C34', newRatio: 7.84 },
+  },
+  {
+    fg: '#8B8778',
+    bg: '#F3F1EA',
+    ratio: 3.28,
+    rule: 'AA-normal',
+    suggestion: { replace: 'fg', color: '#0A0908', newRatio: 15.92 },
+  },
+  {
+    fg: '#FF4800',
+    bg: '#ECE8DD',
+    ratio: 3.51,
+    rule: 'AAA-normal',
+    suggestion: { replace: 'fg', color: '#0A0908', newRatio: 15.31 },
+  },
+];
+
+function tagFor(ratio) {
+  if (ratio >= 7) return { label: 'AAA', color: 'var(--ink)', underline: true };
+  if (ratio >= 4.5) return { label: 'AA', color: 'var(--accent)', underline: false };
+  if (ratio >= 3) return { label: 'AA large', color: 'var(--accent)', underline: false };
+  return { label: 'FAIL', color: 'var(--ink)', underline: false };
+}
+
+export default function A11ySlider() {
+  const [t, setT] = useState(0);
+  const fg = useMemo(() => lerpHex(FAIL_FG, PASS_FG, t / 100), [t]);
+  const ratio = useMemo(() => contrast(fg, BG), [fg]);
+  const tag = tagFor(ratio);
+
+  return (
+    <>
+      <Rule number="05" label="A11y remediation" />
+      <div className="with-margin" style={{ marginTop: 'var(--r5)' }}>
+        <div>
+          <div className="eyebrow" style={{ marginBottom: 'var(--r3)' }}>§05 A11y remediation</div>
+          <h2 className="display" style={{ marginBottom: 'var(--r4)' }}>
+            From score to fix.
+          </h2>
+          <p className="prose" style={{ fontSize: 18, maxWidth: '62ch', color: 'var(--ink-2)' }}>
+            Most tools hand you a failing contrast ratio. designlang hands you the next color in
+            your own palette that passes AA. Drag to see the difference.
+          </p>
+
+          <div
+            className="grid-12"
+            style={{ marginTop: 'var(--r7)', alignItems: 'start' }}
+          >
+            {/* LEFT — slider tiles (span 6) */}
+            <div style={{ gridColumn: 'span 6' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--r4)' }}>
+                {/* Failing tile (static reference) */}
+                <Tile
+                  bg={BG}
+                  fg={FAIL_FG}
+                  ratio={contrast(FAIL_FG, BG)}
+                  label="failing pair"
+                  staticTag={{ label: 'FAIL', color: 'var(--ink)', underline: false }}
+                />
+                {/* Live tile driven by slider */}
+                <Tile
+                  bg={BG}
+                  fg={fg}
+                  ratio={ratio}
+                  label="remediated"
+                  staticTag={tag}
+                />
+              </div>
+
+              <div style={{ marginTop: 'var(--r5)' }}>
+                <label
+                  htmlFor="a11y-range"
+                  className="mono"
+                  style={{
+                    fontSize: 11,
+                    letterSpacing: '0.14em',
+                    textTransform: 'uppercase',
+                    color: 'var(--ink-2)',
+                    display: 'block',
+                    marginBottom: 8,
+                  }}
+                >
+                  drag: failing → remediated
+                </label>
+                <input
+                  id="a11y-range"
+                  type="range"
+                  min="0"
+                  max="100"
+                  value={t}
+                  onChange={(e) => setT(Number(e.target.value))}
+                  aria-valuetext={`contrast ratio ${ratio.toFixed(2)} to 1`}
+                  className="a11y-range"
+                  style={{ width: '100%' }}
+                />
+                <div
+                  className="mono"
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    marginTop: 6,
+                    fontSize: 11,
+                    color: 'var(--ink-3)',
+                  }}
+                >
+                  <span>{FAIL_FG}</span>
+                  <span style={{ fontVariantNumeric: 'tabular-nums' }}>{fg}</span>
+                  <span>{PASS_FG}</span>
+                </div>
+              </div>
+            </div>
+
+            {/* RIGHT — remediation list (span 6) */}
+            <div style={{ gridColumn: 'span 6' }}>
+              <div
+                className="mono"
+                style={{
+                  fontSize: 11,
+                  letterSpacing: '0.14em',
+                  textTransform: 'uppercase',
+                  color: 'var(--ink-2)',
+                  marginBottom: 'var(--r3)',
+                }}
+              >
+                remediateFailingPairs() output
+              </div>
+              <div
+                role="table"
+                style={{
+                  border: '1px solid var(--ink)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 12,
+                }}
+              >
+                <div
+                  role="row"
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1.3fr 0.3fr 1.3fr 0.9fr 0.7fr',
+                    padding: '8px 12px',
+                    borderBottom: '1px solid var(--ink)',
+                    color: 'var(--ink-3)',
+                    letterSpacing: '0.08em',
+                    textTransform: 'uppercase',
+                    fontSize: 10,
+                  }}
+                >
+                  <span>original</span>
+                  <span />
+                  <span>suggested</span>
+                  <span>ratio</span>
+                  <span>rule</span>
+                </div>
+                {REMEDIATIONS.map((r, i) => (
+                  <div
+                    key={i}
+                    role="row"
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: '1.3fr 0.3fr 1.3fr 0.9fr 0.7fr',
+                      padding: '10px 12px',
+                      borderTop: i === 0 ? 0 : '1px solid var(--ink-3)',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <span>
+                      <Swatch color={r.fg} /> {r.fg}{' '}
+                      <span style={{ color: 'var(--ink-3)' }}>on</span>{' '}
+                      <Swatch color={r.bg} />
+                    </span>
+                    <span style={{ color: 'var(--ink-3)', textAlign: 'center' }}>→</span>
+                    <span>
+                      <Swatch color={r.suggestion.color} /> {r.suggestion.color}
+                    </span>
+                    <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+                      <span style={{ color: 'var(--ink-3)' }}>{r.ratio.toFixed(2)}</span>
+                      <span style={{ color: 'var(--ink-3)' }}> → </span>
+                      <span style={{ color: 'var(--accent)' }}>
+                        {r.suggestion.newRatio.toFixed(2)}
+                      </span>
+                    </span>
+                    <span style={{ color: 'var(--ink-2)' }}>{r.rule}</span>
+                  </div>
+                ))}
+              </div>
+              <p
+                className="mono"
+                style={{
+                  marginTop: 'var(--r3)',
+                  fontSize: 11,
+                  color: 'var(--ink-3)',
+                  maxWidth: '52ch',
+                }}
+              >
+                designlang only suggests colors that already exist in the extracted palette. No
+                invented tokens.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <Marginalia>
+          <div>WCAG thresholds</div>
+          <div style={{ marginTop: 6 }}>
+            <div><code>AA normal 4.5:1</code></div>
+            <div><code>AA large 3:1</code></div>
+            <div><code>AAA normal 7:1</code></div>
+            <div><code>AAA large 4.5:1</code></div>
+          </div>
+          <hr style={{ margin: '12px 0', border: 0, borderTop: '1px solid var(--ink-3)' }} />
+          <p className="foot">
+            Run <code>designlang &lt;url&gt;</code> and every failing pair ships with a drop-in fix.
+          </p>
+        </Marginalia>
+      </div>
+
+      <style jsx>{`
+        .a11y-range {
+          -webkit-appearance: none;
+          appearance: none;
+          height: 2px;
+          background: var(--ink);
+          outline: 0;
+          cursor: pointer;
+        }
+        .a11y-range::-webkit-slider-thumb {
+          -webkit-appearance: none;
+          appearance: none;
+          width: 18px;
+          height: 18px;
+          background: var(--paper);
+          border: 2px solid var(--ink);
+          border-radius: 0;
+          cursor: grab;
+        }
+        .a11y-range::-moz-range-thumb {
+          width: 18px;
+          height: 18px;
+          background: var(--paper);
+          border: 2px solid var(--ink);
+          border-radius: 0;
+          cursor: grab;
+        }
+        .a11y-range:focus-visible {
+          outline: 2px solid var(--accent);
+          outline-offset: 3px;
+        }
+      `}</style>
+    </>
+  );
+}
+
+function Swatch({ color }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        display: 'inline-block',
+        width: 10,
+        height: 10,
+        background: color,
+        border: '1px solid var(--ink)',
+        verticalAlign: 'middle',
+        marginRight: 4,
+      }}
+    />
+  );
+}
+
+function Tile({ bg, fg, ratio, label, staticTag }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--r3)' }}>
+      <div
+        style={{
+          width: '100%',
+          aspectRatio: '1 / 1',
+          maxWidth: 220,
+          maxHeight: 220,
+          background: bg,
+          border: '1px solid var(--ink)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <span
+          className="display"
+          style={{ color: fg, fontSize: 'clamp(36px, 4vw, 64px)', letterSpacing: '-0.03em' }}
+        >
+          Aa
+        </span>
+      </div>
+      <div className="mono" style={{ fontSize: 11, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <span style={{ color: 'var(--ink-3)', letterSpacing: '0.1em', textTransform: 'uppercase' }}>
+          {label}
+        </span>
+        <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+          {fg.toUpperCase()} <span style={{ color: 'var(--ink-3)' }}>on</span> {bg.toUpperCase()}
+        </span>
+        <span
+          style={{
+            color: staticTag.color,
+            fontVariantNumeric: 'tabular-nums',
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            textDecoration: staticTag.underline ? 'underline' : 'none',
+            textDecorationColor: 'var(--accent)',
+            textUnderlineOffset: 3,
+          }}
+        >
+          {staticTag.label} {ratio.toFixed(2)}:1
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/website/app/components/CssHealth.js
+++ b/website/app/components/CssHealth.js
@@ -1,0 +1,243 @@
+// §04 CSS health — mostly static. Static SVG plot, no ResizeObserver needed
+// (responsive via 100% width + aspect-ratio). Numbers are the PR B smoke
+// sample taken from stripe.com: 14 sheets, 89% unused, 764 !important rules,
+// 9,041 duplicate declarations.
+
+// Synthetic sample shaped from the PR B smoke distribution: a mostly low
+// specificity body with a rising-ramp tail — the classic "!important wall"
+// silhouette. X = rule order (0..100), Y = collapsed specificity (a*100+b*10+c).
+const POINTS = [
+  [2, 11], [4, 10], [6, 20], [8, 12], [10, 21], [12, 11], [14, 22],
+  [16, 20], [18, 12], [20, 22], [22, 30], [24, 20], [26, 21], [28, 31],
+  [30, 22], [32, 30], [34, 31], [36, 22], [38, 32], [40, 30], [42, 40],
+  [44, 32], [46, 41], [48, 42], [50, 51], [52, 42], [54, 50], [56, 61],
+  [58, 52], [60, 71], [62, 81], [64, 92], [66, 112], [68, 121], [70, 141],
+  [72, 161], [74, 172], [76, 191], [78, 202], [80, 221], [82, 232],
+  [84, 252], [86, 272], [88, 291], [90, 311], [92, 331], [94, 352],
+  [96, 372], [98, 391], [100, 412],
+];
+
+const VENDOR_CHIPS = [
+  ['-webkit-', '183'],
+  ['-moz-', '41'],
+  ['-ms-', '7'],
+  ['-o-', '2'],
+  ['duplicates', '9,041'],
+];
+
+const STATS = [
+  ['89%', 'unused css'],
+  ['764', '!important rules'],
+  ['9,041', 'duplicate declarations'],
+  ['14', 'stylesheets analyzed'],
+];
+
+import Rule from './Rule';
+import Marginalia from './Marginalia';
+
+function SpecificityPlot() {
+  // viewBox 100 x 100 (abstract units), axis gutters inside.
+  const maxY = 500;
+  const padL = 10;
+  const padB = 12;
+  const padT = 4;
+  const padR = 4;
+
+  return (
+    <svg
+      viewBox="0 0 200 125"
+      preserveAspectRatio="none"
+      role="img"
+      aria-label="Specificity scatter plot — rule order vs specificity score"
+      style={{
+        width: '100%',
+        aspectRatio: '16 / 10',
+        border: '1px solid var(--ink)',
+        background: 'var(--paper)',
+        display: 'block',
+      }}
+    >
+      {/* axis lines */}
+      <line x1={padL} y1={125 - padB} x2={200 - padR} y2={125 - padB} stroke="var(--ink)" strokeWidth="0.5" />
+      <line x1={padL} y1={padT} x2={padL} y2={125 - padB} stroke="var(--ink)" strokeWidth="0.5" />
+
+      {/* axis labels (mono ~10px visually — SVG units scaled) */}
+      <text x={padL} y={124} fontFamily="var(--font-mono)" fontSize="3.2" fill="var(--ink-2)" letterSpacing="0.1">
+        rule order →
+      </text>
+      <text
+        x={padL + 1}
+        y={padT + 3}
+        fontFamily="var(--font-mono)"
+        fontSize="3.2"
+        fill="var(--ink-2)"
+        letterSpacing="0.1"
+      >
+        ↑ specificity
+      </text>
+      <text x={200 - padR - 14} y={124} fontFamily="var(--font-mono)" fontSize="3" fill="var(--ink-3)">
+        n=50
+      </text>
+
+      {/* points */}
+      {POINTS.map(([x, y], i) => {
+        const px = padL + (x / 100) * (200 - padL - padR);
+        const py = 125 - padB - (Math.min(y, maxY) / maxY) * (125 - padB - padT);
+        const outlier = y > 200;
+        return (
+          <rect
+            key={i}
+            x={px - 1}
+            y={py - 1}
+            width="2"
+            height="2"
+            fill={outlier ? 'var(--accent)' : 'var(--ink)'}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+export default function CssHealth() {
+  return (
+    <>
+      <Rule number="04" label="CSS health audit" />
+      <div className="with-margin" style={{ marginTop: 'var(--r5)' }}>
+        <div>
+          <div className="eyebrow" style={{ marginBottom: 'var(--r3)' }}>§04 CSS health</div>
+          <h2 className="display" style={{ marginBottom: 'var(--r4)' }}>
+            The stylesheet is the problem.
+          </h2>
+          <p className="prose" style={{ fontSize: 18, maxWidth: '62ch', color: 'var(--ink-2)' }}>
+            Most sites ship 40–90% unused CSS, long walls of <code>!important</code> escalations,
+            and a specificity graph that rises forever. v7.0 surfaces all of it — not as a
+            vanity score, but as exact declaration-level evidence.
+          </p>
+
+          <div
+            className="grid-12"
+            style={{
+              marginTop: 'var(--r7)',
+              gap: 'var(--col-gap)',
+              alignItems: 'start',
+            }}
+          >
+            {/* Big numerals — span 5 */}
+            <div
+              style={{
+                gridColumn: 'span 5',
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: 'var(--r5) var(--r4)',
+              }}
+            >
+              {STATS.map(([n, label]) => (
+                <div key={label} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                  <div
+                    className="display"
+                    style={{
+                      fontSize: 'clamp(64px, 7vw, 120px)',
+                      lineHeight: 0.95,
+                      fontVariantNumeric: 'tabular-nums',
+                      fontFeatureSettings: "'tnum' 1",
+                      letterSpacing: '-0.04em',
+                    }}
+                  >
+                    {n}
+                  </div>
+                  <div
+                    className="mono"
+                    style={{
+                      fontSize: 11,
+                      letterSpacing: '0.14em',
+                      textTransform: 'uppercase',
+                      color: 'var(--ink-2)',
+                    }}
+                  >
+                    {label}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Plot — span 7 */}
+            <div style={{ gridColumn: 'span 7' }}>
+              <div
+                className="mono"
+                style={{
+                  fontSize: 11,
+                  letterSpacing: '0.14em',
+                  textTransform: 'uppercase',
+                  color: 'var(--ink-2)',
+                  marginBottom: 'var(--r3)',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                }}
+              >
+                <span>specificity distribution</span>
+                <span style={{ color: 'var(--accent)' }}>outliers: specificity &gt; 200</span>
+              </div>
+              <SpecificityPlot />
+              <div
+                className="mono"
+                style={{
+                  fontSize: 11,
+                  color: 'var(--ink-3)',
+                  marginTop: 'var(--r3)',
+                }}
+              >
+                collapsed score: a×100 + b×10 + c. rising tail = accumulated !important wall.
+              </div>
+            </div>
+          </div>
+
+          {/* Caption strip — vendor prefix chips */}
+          <div
+            style={{
+              marginTop: 'var(--r7)',
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 'var(--r3)',
+              borderTop: 'var(--hair)',
+              paddingTop: 'var(--r4)',
+            }}
+          >
+            {VENDOR_CHIPS.map(([k, v]) => (
+              <span
+                key={k}
+                className="mono"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'baseline',
+                  gap: 8,
+                  padding: '3px 8px',
+                  border: '1px solid var(--ink)',
+                  fontSize: 11,
+                  letterSpacing: '0.04em',
+                }}
+              >
+                <span style={{ color: 'var(--ink-2)' }}>{k}</span>
+                <span style={{ fontVariantNumeric: 'tabular-nums' }}>{v}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <Marginalia>
+          <div>additive scoring</div>
+          <p style={{ marginTop: 6 }}>
+            Tracked additively: existing score fields kept for back-compat; CSS health joins as a new
+            dimension.
+          </p>
+          <hr style={{ margin: '12px 0', border: 0, borderTop: '1px solid var(--ink-3)' }} />
+          <div>works on any site</div>
+          <p className="foot" style={{ marginTop: 6 }}>
+            Flags rising specificity, zombie declarations, and abandoned <code>!important</code> walls —
+            with exact selector provenance.
+          </p>
+        </Marginalia>
+      </div>
+    </>
+  );
+}

--- a/website/app/components/RegionsComponents.js
+++ b/website/app/components/RegionsComponents.js
@@ -1,0 +1,429 @@
+'use client';
+
+// §06 Regions + components.
+// Two sub-blocks:
+//   a. Region classifier — schematic page + legend of 9 roles
+//   b. Component clusters — an "unfold" list of 4 button variants
+
+import { useEffect, useRef, useState } from 'react';
+import Rule from './Rule';
+import Marginalia from './Marginalia';
+
+// Schematic regions — shape matches semantic-regions.js output
+// { role, selector, bbox: { x, y, w, h }, signals: [...] }
+const REGIONS = [
+  { role: 'nav', x: 0, y: 0, w: 640, h: 48 },
+  { role: 'hero', x: 0, y: 48, w: 640, h: 140 },
+  { role: 'features', x: 0, y: 188, w: 640, h: 84 },
+  { role: 'pricing', x: 0, y: 272, w: 640, h: 70 },
+  { role: 'testimonials', x: 0, y: 342, w: 640, h: 42 },
+  { role: 'footer', x: 0, y: 384, w: 640, h: 36 },
+];
+
+const ROLES = [
+  { role: 'nav', desc: 'top-anchored navigation', signal: 'landmark + top-anchored + link density > 0.5' },
+  { role: 'hero', desc: 'primary above-the-fold statement', signal: 'large type + early viewport + CTA' },
+  { role: 'features', desc: 'grid of benefit/feature cells', signal: '3+ siblings, similar structural hash' },
+  { role: 'pricing', desc: 'price tiers and plans', signal: 'currency symbol + repeated card shape' },
+  { role: 'testimonials', desc: 'social proof / quotes', signal: 'blockquote or quote glyph + attribution' },
+  { role: 'cta', desc: 'standalone conversion band', signal: 'single button + heading, full-width container' },
+  { role: 'footer', desc: 'bottom landmark', signal: 'landmark + bottom-anchored + link density high' },
+  { role: 'sidebar', desc: 'lateral aside content', signal: 'landmark=complementary or aside element' },
+  { role: 'content', desc: 'prose / article body', signal: 'main landmark, paragraph density, reading width' },
+];
+
+// Cluster — shape matches component-clusters.js output
+const BUTTON_CLUSTER = {
+  kind: 'button',
+  instanceCount: 24,
+  variants: [
+    {
+      name: 'primary',
+      css: {
+        background: 'var(--accent)',
+        color: 'var(--paper)',
+        border: '1px solid var(--accent)',
+        padding: '10px 18px',
+      },
+      instanceCount: 14,
+    },
+    {
+      name: 'secondary',
+      css: {
+        background: 'transparent',
+        color: 'var(--ink)',
+        border: '1px solid var(--ink)',
+        padding: '10px 18px',
+      },
+      instanceCount: 6,
+    },
+    {
+      name: 'ghost',
+      css: {
+        background: 'transparent',
+        color: 'var(--ink)',
+        border: '1px solid transparent',
+        padding: '10px 18px',
+        textDecoration: 'underline',
+        textUnderlineOffset: 3,
+      },
+      instanceCount: 3,
+    },
+    {
+      name: 'disabled',
+      css: {
+        background: 'var(--paper-2)',
+        color: 'var(--ink-3)',
+        border: '1px solid var(--ink-3)',
+        padding: '10px 18px',
+      },
+      instanceCount: 1,
+    },
+  ],
+};
+
+export default function RegionsComponents() {
+  return (
+    <>
+      <Rule number="06" label="Regions and components" />
+      <div className="with-margin" style={{ marginTop: 'var(--r5)' }}>
+        <div>
+          <div className="eyebrow" style={{ marginBottom: 'var(--r3)' }}>§06 Regions + components</div>
+          <h2 className="display" style={{ marginBottom: 'var(--r4)' }}>
+            Structure, not just style.
+          </h2>
+          <p className="prose" style={{ fontSize: 18, maxWidth: '62ch', color: 'var(--ink-2)' }}>
+            designlang labels the page before measuring it. Nav, hero, pricing, footer — nine
+            roles; landmarks first, heuristics second. Components are clustered by DOM signature
+            and style vector, not by guessing at class names.
+          </p>
+
+          <RegionOverlay />
+
+          <div
+            style={{
+              borderTop: '1px solid var(--ink)',
+              marginTop: 'var(--r8)',
+              paddingTop: 'var(--r6)',
+            }}
+          />
+
+          <ComponentClusters />
+        </div>
+
+        <Marginalia>
+          <div>MCP companion</div>
+          <p style={{ marginTop: 6 }}>
+            Regions and components live alongside the tokens, in the MCP companion JSON and the
+            DTCG <code>$extensions</code> field.
+          </p>
+          <hr style={{ margin: '12px 0', border: 0, borderTop: '1px solid var(--ink-3)' }} />
+          <p className="foot">
+            Agents can query <code>get_region</code> and <code>get_component</code> over MCP to
+            regenerate a section in matching style.
+          </p>
+        </Marginalia>
+      </div>
+    </>
+  );
+}
+
+// ── Sub-block A — Region classifier ────────────────────────────
+function RegionOverlay() {
+  const [hovered, setHovered] = useState(null);
+
+  return (
+    <div style={{ marginTop: 'var(--r7)' }}>
+      <div
+        className="mono"
+        style={{
+          fontSize: 11,
+          letterSpacing: '0.14em',
+          textTransform: 'uppercase',
+          color: 'var(--ink-2)',
+          marginBottom: 'var(--r3)',
+        }}
+      >
+        §06.a Region classifier
+      </div>
+
+      <div className="grid-12" style={{ alignItems: 'start' }}>
+        {/* Schematic page — span 7 */}
+        <div style={{ gridColumn: 'span 7' }}>
+          <div
+            style={{
+              position: 'relative',
+              width: '100%',
+              aspectRatio: '640 / 420',
+              background: 'var(--paper-2)',
+              border: '1px solid var(--ink)',
+            }}
+          >
+            <svg
+              viewBox="0 0 640 420"
+              preserveAspectRatio="none"
+              style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+              role="img"
+              aria-label="Schematic page with six classified regions"
+            >
+              {REGIONS.map((r) => {
+                const active = hovered === r.role;
+                return (
+                  <g
+                    key={r.role}
+                    onMouseEnter={() => setHovered(r.role)}
+                    onMouseLeave={() => setHovered(null)}
+                    style={{ cursor: 'pointer' }}
+                  >
+                    <rect
+                      x={r.x + 4}
+                      y={r.y + 4}
+                      width={r.w - 8}
+                      height={r.h - 8}
+                      fill={active ? 'var(--paper)' : 'transparent'}
+                      stroke="var(--ink)"
+                      strokeWidth="1"
+                    />
+                    <rect
+                      x={r.x + 10}
+                      y={r.y + 10}
+                      width={r.role.length * 7 + 10}
+                      height={16}
+                      fill="var(--paper)"
+                      stroke="var(--ink)"
+                      strokeWidth="0.5"
+                    />
+                    <text
+                      x={r.x + 15}
+                      y={r.y + 21}
+                      fontFamily="var(--font-mono)"
+                      fontSize="10"
+                      fill={active ? 'var(--accent)' : 'var(--ink)'}
+                      letterSpacing="0.06em"
+                    >
+                      {r.role}
+                    </text>
+                  </g>
+                );
+              })}
+            </svg>
+          </div>
+          <div
+            className="mono"
+            style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 'var(--r3)' }}
+          >
+            hover a region to match its role in the legend →
+          </div>
+        </div>
+
+        {/* Legend — span 5 */}
+        <div style={{ gridColumn: 'span 5' }}>
+          <div
+            className="mono"
+            style={{
+              fontSize: 10,
+              letterSpacing: '0.14em',
+              textTransform: 'uppercase',
+              color: 'var(--ink-3)',
+              marginBottom: 'var(--r3)',
+              display: 'grid',
+              gridTemplateColumns: '100px 1fr',
+              gap: 12,
+            }}
+          >
+            <span>role</span>
+            <span>signal</span>
+          </div>
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0, borderTop: '1px solid var(--ink)' }}>
+            {ROLES.map((r) => {
+              const active = hovered === r.role;
+              return (
+                <li
+                  key={r.role}
+                  onMouseEnter={() => setHovered(r.role)}
+                  onMouseLeave={() => setHovered(null)}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '100px 1fr',
+                    gap: 12,
+                    padding: '8px 0',
+                    borderBottom: '1px solid var(--ink-3)',
+                    alignItems: 'baseline',
+                  }}
+                >
+                  <span
+                    className="mono"
+                    style={{
+                      fontSize: 12,
+                      color: active ? 'var(--ink)' : 'var(--ink-2)',
+                      textDecoration: active ? 'underline' : 'none',
+                      textDecorationColor: 'var(--accent)',
+                      textUnderlineOffset: 3,
+                      textDecorationThickness: 2,
+                    }}
+                  >
+                    {r.role}
+                  </span>
+                  <span style={{ fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.45 }}>
+                    <span style={{ color: 'var(--ink)' }}>{r.desc}.</span>{' '}
+                    <span className="mono" style={{ fontSize: 11, color: 'var(--ink-3)' }}>
+                      {r.signal}
+                    </span>
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Sub-block B — Component clusters ───────────────────────────
+function ComponentClusters() {
+  const ref = useRef(null);
+  const [visible, setVisible] = useState(false);
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReduced(mq.matches);
+  }, []);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const el = ref.current;
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setVisible(true);
+            io.disconnect();
+          }
+        }
+      },
+      { threshold: 0.25 }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return (
+    <div>
+      <div
+        className="mono"
+        style={{
+          fontSize: 11,
+          letterSpacing: '0.14em',
+          textTransform: 'uppercase',
+          color: 'var(--ink-2)',
+          marginBottom: 'var(--r3)',
+        }}
+      >
+        §06.b Component clusters
+      </div>
+      <div
+        className="mono"
+        style={{
+          fontSize: 12,
+          color: 'var(--ink)',
+          marginBottom: 'var(--r4)',
+          paddingBottom: 'var(--r3)',
+          borderBottom: '1px solid var(--ink)',
+        }}
+      >
+        button — {BUTTON_CLUSTER.instanceCount} instances, {BUTTON_CLUSTER.variants.length}{' '}
+        variants ({BUTTON_CLUSTER.variants.map((v) => v.name).join(', ')})
+      </div>
+
+      <div
+        ref={ref}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(4, 1fr)',
+          gap: 'var(--r4)',
+        }}
+      >
+        {BUTTON_CLUSTER.variants.map((v, i) => {
+          const shown = reduced || visible;
+          return (
+            <div
+              key={v.name}
+              style={{
+                border: '1px solid var(--ink)',
+                padding: 'var(--r4)',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 'var(--r3)',
+                background: 'var(--paper)',
+                opacity: shown ? 1 : 0,
+                transform: shown ? 'translateX(0)' : 'translateX(-12px)',
+                transition: reduced
+                  ? 'none'
+                  : `opacity 200ms ease ${i * 80}ms, transform 200ms ease ${i * 80}ms`,
+              }}
+            >
+              <div
+                className="mono"
+                style={{
+                  fontSize: 10,
+                  letterSpacing: '0.14em',
+                  textTransform: 'uppercase',
+                  color: 'var(--ink-3)',
+                }}
+              >
+                {v.name} · {v.instanceCount}
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  minHeight: 92,
+                  background: 'var(--paper-2)',
+                  border: '1px solid var(--ink-3)',
+                }}
+              >
+                <span
+                  className="mono"
+                  style={{
+                    ...v.css,
+                    fontSize: 13,
+                    letterSpacing: '0.04em',
+                    textTransform: 'uppercase',
+                    display: 'inline-block',
+                  }}
+                >
+                  Continue
+                </span>
+              </div>
+              <pre
+                className="mono"
+                style={{
+                  fontSize: 10,
+                  color: 'var(--ink-2)',
+                  lineHeight: 1.5,
+                  whiteSpace: 'pre-wrap',
+                  margin: 0,
+                }}
+              >
+{formatCss(v.css)}
+              </pre>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function formatCss(css) {
+  return Object.entries(css)
+    .map(([k, v]) => `${kebab(k)}: ${v};`)
+    .join('\n');
+}
+function kebab(s) {
+  return s.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
+}

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -5,6 +5,7 @@ import TokenBrowser from './components/TokenBrowser';
 import McpSection from './components/McpSection';
 import PlatformTabs from './components/PlatformTabs';
 import CssHealth from './components/CssHealth';
+import A11ySlider from './components/A11ySlider';
 
 export default function Home() {
   return (
@@ -111,7 +112,7 @@ export default function Home() {
 
       {/* ── §05 REMEDIATION ───────────────────────────────── */}
       <section>
-        <Rule number="05" label="A11y remediation" />
+        <A11ySlider />
       </section>
 
       {/* ── §06 REGIONS + COMPONENTS ──────────────────────── */}

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -4,6 +4,7 @@ import HeroExtractor from './components/HeroExtractor';
 import TokenBrowser from './components/TokenBrowser';
 import McpSection from './components/McpSection';
 import PlatformTabs from './components/PlatformTabs';
+import CssHealth from './components/CssHealth';
 
 export default function Home() {
   return (
@@ -105,7 +106,7 @@ export default function Home() {
 
       {/* ── §04 HEALTH ────────────────────────────────────── */}
       <section>
-        <Rule number="04" label="CSS health audit" />
+        <CssHealth />
       </section>
 
       {/* ── §05 REMEDIATION ───────────────────────────────── */}

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -6,6 +6,7 @@ import McpSection from './components/McpSection';
 import PlatformTabs from './components/PlatformTabs';
 import CssHealth from './components/CssHealth';
 import A11ySlider from './components/A11ySlider';
+import RegionsComponents from './components/RegionsComponents';
 
 export default function Home() {
   return (
@@ -117,7 +118,7 @@ export default function Home() {
 
       {/* ── §06 REGIONS + COMPONENTS ──────────────────────── */}
       <section>
-        <Rule number="06" label="Regions and components" />
+        <RegionsComponents />
       </section>
 
       {/* ── §07 SPECIMENS ─────────────────────────────────── */}


### PR DESCRIPTION
## Summary

Wave 2 PR D implements §04–§06 of the designlang website redesign: three content sections covering CSS health, accessibility remediation, and regions + components — the new v7.0 analytics capabilities rendered in the paper+ink editorial system.

### Commits
- `feat(website): CSS health metrics panel with specificity plot` — §04. 2×2 big-numeral stat grid (89% unused, 764 !important, 9041 duplicates, 14 sheets), inline-SVG specificity scatter plot with accent-highlighted outliers (specificity > 200), vendor-prefix chip strip.
- `feat(website): interactive a11y contrast slider` — §05. Two color tiles (failing + live-remediated) driven by a range input with inline WCAG contrast math. Ratio tag switches between FAIL / AA / AAA as the slider crosses 3.0, 4.5, 7.0. Remediation table mirrors `remediateFailingPairs()` output shape.
- `feat(website): regions + components unfold` — §06. Sub-block a: schematic page with 6 classified regions + 9-role legend with hover cross-link. Sub-block b: button cluster (24 instances, 4 variants) with IntersectionObserver-triggered staggered slide-in (80ms apart, 200ms each).

### Copy / motion / accessibility notes
- Designer field-notes voice throughout. Headings set in Fraunces; labels in JetBrains Mono.
- Motion only in §06.b cluster unfold — single 12px translate + fade, 80ms stagger, 200ms duration. `prefers-reduced-motion: reduce` renders the final state directly.
- No emoji. No icon libraries. One inline SVG per section, drawn with intent.
- No Framer Motion, no glassmorphism, no drop shadows, no AI gradients.
- Slider is a native `<input type="range">` — keyboard-accessible with a 2px accent focus outline at 3px offset. `aria-valuetext` announces the live ratio.
- Region schematic is a single SVG with `role="img"` and aria-label; legend rows are a real `<ul>`.
- Contrast math is inlined (~12 lines of WCAG formula) — no CLI import.

## Test plan

- [x] `node --test website/lib/*.test.js` — 28/28 passing
- [x] `node --test tests/*.test.js` — 241/241 passing
- [x] `npx next build` — compiles cleanly, all 4 static pages generate
- [x] Manual: §04, §05, §06 render at 1440×900 (screenshots: /tmp/wave2-d1.png, /tmp/wave2-d2.png, /tmp/wave2-d3.png)
- [ ] Drag the §05 slider and confirm the right tile ratio updates live and the tag transitions FAIL → AA → AAA as it crosses thresholds
- [ ] Hover any region in the §06.a schematic and confirm the matching legend row gets an accent underline
- [ ] Scroll §06.b into view and confirm the 4 button cards stagger in (or render instantly with reduced motion)