### PR TITLE
fix(website): remove black overscroll band + tighten top spacing

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -50,6 +50,7 @@
 html {
   background: var(--paper);
   color: var(--ink);
+  color-scheme: light;
   font-family: var(--font-body);
   font-size: 16px;
   line-height: 1.45;
@@ -59,6 +60,7 @@ html {
 }
 
 body {
+  background: var(--paper);
   min-height: 100dvh;
   overflow-x: hidden;
 }

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -14,7 +14,7 @@ export default function Home() {
   return (
     <main className="page">
       {/* ── HEAD SLUG ─────────────────────────────────────── */}
-      <header style={{ paddingTop: 'var(--r6)', paddingBottom: 'var(--r7)' }}>
+      <header style={{ paddingTop: 'var(--r4)', paddingBottom: 'var(--r5)' }}>
         <div
           style={{
             display: 'flex',
@@ -44,7 +44,7 @@ export default function Home() {
       </header>
 
       {/* ── §00 HERO ──────────────────────────────────────── */}
-      <section id="extract" style={{ paddingBlock: 'var(--r10) var(--r9)', borderTop: 0 }}>
+      <section id="extract" style={{ paddingBlock: 'var(--r7) var(--r8)', borderTop: 0 }}>
         <div className="with-margin">
           <div>
             <div className="section-label" style={{ marginBottom: 'var(--r6)' }}>


### PR DESCRIPTION
Browser was rendering dark overscroll above the paper page because `color-scheme` was never declared — dark-mode OSes inferred dark. Setting `color-scheme: light` on html and an explicit paper background on body. Also tightened header and hero top padding so content sits immediately below the viewport edge.