### PR TITLE
fix(website): full mobile responsiveness pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test-output/
 *.log
 .DS_Store
 .vercel/
+.vercel

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -301,9 +301,205 @@ section[id] {
 h1, h2, h3, h4, h5, h6 { font-weight: 400; }
 
 h2.display {
-  font-size: clamp(40px, 6vw, 88px);
+  font-size: clamp(36px, 6vw, 88px);
 }
 
 h3.display {
-  font-size: clamp(28px, 3.5vw, 48px);
+  font-size: clamp(26px, 3.5vw, 48px);
+}
+
+.hero-title {
+  font-size: clamp(48px, 11vw, 200px);
+}
+
+/* ── Mobile & tablet pass ───────────────────────────────────── */
+
+@media (max-width: 860px) {
+  :root {
+    --page-pad-x: 18px;
+    --col-gap: 14px;
+  }
+
+  section {
+    padding-block: var(--r7);
+  }
+
+  .display,
+  .hero-title,
+  h1,
+  h2,
+  h3 {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    hyphens: auto;
+    letter-spacing: -0.02em;
+  }
+
+  .hero-title {
+    font-size: clamp(44px, 13vw, 96px);
+    line-height: 0.95;
+  }
+
+  h2.display {
+    font-size: clamp(32px, 8vw, 56px);
+  }
+
+  h3.display {
+    font-size: clamp(22px, 6vw, 36px);
+  }
+
+  .prose p,
+  .prose {
+    font-size: 16px !important;
+  }
+
+  /* Header nav: horizontal scroll instead of overflow. */
+  header nav {
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    white-space: nowrap;
+    gap: var(--r4) !important;
+    font-size: 11px !important;
+    max-width: 60%;
+  }
+
+  header nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Hero form: stack input over button, no border on button side. */
+  #extract form {
+    flex-direction: column;
+    max-width: 100% !important;
+  }
+
+  #extract form input {
+    border-right: 0 !important;
+    border-bottom: var(--hair);
+    padding: 14px 16px !important;
+    font-size: 15px !important;
+  }
+
+  #extract form button {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  /* Tables, code blocks, long scroll strips: constrain inside page, scroll on x. */
+  pre,
+  table,
+  .scroll-x {
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  pre {
+    font-size: 12px !important;
+    padding: var(--r3) var(--r4) !important;
+  }
+
+  /* Grid-12 defaults: drop to single column on mobile unless overridden. */
+  .grid-12 {
+    grid-template-columns: minmax(0, 1fr) !important;
+    gap: var(--r4) !important;
+  }
+
+  /* Min-width: 0 on every grid child so content (like a 640-unit SVG) can't
+     push a 1fr track wider than the viewport. */
+  .grid-12 > *,
+  .with-margin > *,
+  [style*='grid-template-columns'] > * {
+    min-width: 0;
+  }
+
+  /* Everything absolutely should not push the page sideways. */
+  body,
+  main.page {
+    max-width: 100vw;
+    overflow-x: clip;
+  }
+
+  /* Constrain every SVG, image, and video so fixed-width art can't spill. */
+  section svg,
+  section img,
+  section video,
+  section canvas {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* Any element that opts into `.scroll-x` or `.tabstrip` scrolls horizontally
+     inside its section on narrow viewports. */
+  .scroll-x,
+  .tabstrip,
+  [role='tablist'] {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+  }
+
+  /* Token browser: let it scroll-x on tiny viewports. */
+  section [data-token-browser],
+  section [data-regions-schematic],
+  section [data-platform-code],
+  section [data-specimens-strip] {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Specimen cards / wide cards: the strip itself scrolls; cards keep their
+     design width. */
+  [data-specimens-strip] > * {
+    flex: 0 0 auto;
+  }
+
+  /* Any container with a fixed min-width: safe max-width safety net. */
+  main.page > * {
+    max-width: 100%;
+  }
+
+  /* Inline-style grid overrides — components use style={{gridTemplateColumns:…}}
+     so we match the resulting attribute and force single-column on mobile. */
+  [style*="grid-template-columns: repeat(4"],
+  [style*="grid-template-columns: repeat(3"],
+  [style*="grid-template-columns:5fr"],
+  [style*="grid-template-columns: 5fr"],
+  [style*="grid-template-columns:100px"],
+  [style*="grid-template-columns: 100px"] {
+    grid-template-columns: 1fr !important;
+  }
+
+  /* Specimens strip: horizontal scroll with snap. Cards stay at their
+     design-time width; the parent scrolls. */
+  [style*="scroll-snap-type"] {
+    padding-inline: 0 !important;
+  }
+
+  [style*="scroll-snap-type"] > * {
+    min-width: 80vw;
+    max-width: 92vw;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-title {
+    font-size: clamp(40px, 12vw, 72px);
+  }
+
+  header nav {
+    max-width: 55%;
+    gap: 14px !important;
+    font-size: 10px !important;
+    letter-spacing: 0.08em !important;
+  }
+
+  .section-label {
+    font-size: 11px !important;
+  }
+
+  pre {
+    font-size: 11px !important;
+  }
 }

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -55,11 +55,8 @@ export default function Home() {
               <span>§00 — Entry</span>
             </div>
             <h1
-              className="display"
-              style={{
-                fontSize: 'clamp(64px, 11vw, 200px)',
-                marginBottom: 'var(--r7)',
-              }}
+              className="display hero-title"
+              style={{ marginBottom: 'var(--r7)' }}
             >
               A website<br />
               reads as a<br />


### PR DESCRIPTION
Closes the gap raised on mobile: header nav overflowing, huge Fraunces hero crashing out of the column, 640-unit regions schematic forcing the grid to 626px wide on a 390px viewport, comparison table with no horizontal scroll, hero form laid out as a cramped single row.

## Changes

- Responsive **hero-title** clamp (`13vw` min 44px, 96px cap at `<=860`, 72px cap at `<=480`).
- `h2/h3.display` scale down on mobile, `word-break` + `hyphens: auto` on long display headings.
- **Header nav** becomes a horizontal scroll strip (scrollbar hidden) instead of overflowing off-screen.
- **Hero form** stacks vertically on mobile: URL input full-width above a full-width `Extract` button.
- `.grid-12` collapses to `minmax(0, 1fr)` on mobile; `min-width: 0` on grid children so embedded wide content (the 640-unit regions schematic SVG, long code strings, etc.) can't blow out the 1fr column.
- Inline-style grids (`repeat(3/4, 1fr)`, `5fr 2fr 5fr`, `100px 1fr`) forced to `1fr` on mobile via attribute selectors.
- Horizontal scroll on `tablist`s, wide tables, code blocks, scroll-snap specimen strips.
- Section `svg/img/video` capped at `max-width: 100%`.
- Body + `main.page` `overflow-x: clip` as safety net.
- Tighter page-padding (18px) and gap on mobile.
- Specimens cards sized `80–92vw` inside their scroll-snap strip.

## Verified
- 390×844 viewport: hero, DTCG browser, MCP split, platform tabs, CSS health, a11y slider, regions schematic, specimens row, comparison table, install/footer all render without horizontal overflow.
- PlatformTabs tab-row and Comparison table scroll horizontally inside their own bounds.