### PR TITLE
docs(v7.1): README + website Install section for Chrome extension, cookie-file, --insecure

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,26 @@ A dedicated audit pass surfaced on `design.cssHealth`:
 
 Also contributes a `cssHealth` dimension to the overall design score.
 
+### 22. Chrome Extension (NEW in v7.1)
+
+A Manifest-v3 popup lives in [`chrome-extension/`](chrome-extension/). One click on any tab opens `designlang.manavaryasingh.com` with the URL prefilled — no copy-paste, no context switch. There is also a **Copy CLI** button that puts `npx designlang <url>` in your clipboard.
+
+- **Permissions:** `activeTab` only, plus host access to the hosted extractor.
+- **Install:** toggle developer mode at `chrome://extensions`, click *Load unpacked*, pick the `chrome-extension/` folder.
+- **Firefox + Edge** work with the same MV3 manifest.
+
+### 23. Better Auth + Network Control (NEW in v7.1)
+
+Extracting from authenticated, self-signed, or non-default environments now takes one flag:
+
+- **`--cookie-file <path>`** — loads cookies from JSON array, Playwright `storageState.json`, or Netscape `cookies.txt` (browser extensions, curl exports). Merges cleanly with the existing `--cookie name=value` flag.
+- **`--insecure`** — ignore HTTPS/SSL certificate errors for self-signed dev servers, corporate staging, or MITM tools.
+- **`--user-agent <ua>`** — override the browser User-Agent string.
+
+```bash
+designlang https://staging.internal --cookie-file ./session.json --insecure
+```
+
 ## All Features
 
 | Feature | Flag / Command | Description |
@@ -325,7 +345,10 @@ Also contributes a `cssHealth` dimension to the overall design score.
 | Font files | automatic | Source detection (Google/self-hosted/CDN/system), @font-face CSS |
 | Image styles | automatic | Aspect ratios, shapes, filters, pattern classification |
 | Dark mode | `--dark` | Extracts dark color scheme + light/dark diff |
-| Auth pages | `--cookie`, `--header` | Extract from authenticated/protected pages |
+| Auth pages | `--cookie`, `--cookie-file`, `--header` | Extract from authenticated/protected pages; cookie files in JSON / Playwright storageState / Netscape formats |
+| Self-signed / dev TLS | `--insecure` | Ignore HTTPS/SSL certificate errors |
+| User-Agent override | `--user-agent <ua>` | Set a custom User-Agent string |
+| Chrome extension | `chrome-extension/` | One-click handoff from any tab, MV3, `activeTab` only |
 | Multi-page | `--depth <n>` | Crawl N internal pages for site-wide tokens |
 | Screenshots | `--screenshots` | Capture buttons, cards, inputs, nav, hero, full page |
 | Responsive | `--responsive` | Crawl at 4 viewports, map breakpoint changes |

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -187,8 +187,10 @@ function InstallTracks() {
 {`1  $ npx designlang <url>
 2  $ npx designlang <url> --platforms all
 3  $ npx designlang <url> --emit-agent-rules
-4  $ npx designlang <url> --tokens-legacy
-5  $ npx designlang <url> --dark`}
+4  $ npx designlang <url> --cookie-file ./cookies.txt
+5  $ npx designlang <url> --insecure
+6  $ npx designlang <url> --user-agent "custom-ua"
+7  $ npx designlang <url> --tokens-legacy`}
           </pre>
         </div>
 
@@ -246,26 +248,71 @@ function InstallTracks() {
             <li>agents.md</li>
           </ul>
         </div>
+
+        {/* Chrome extension */}
+        <div className="install-col">
+          <div style={colHead}>track 04 · new in v7.1</div>
+          <h3 className="display" style={colTitle}>Chrome extension</h3>
+          <p style={{ fontSize: 14, color: 'var(--ink-2)', marginBottom: 'var(--r3)', maxWidth: '34ch' }}>
+            One click from any tab. Opens this page with the URL prefilled.
+          </p>
+          <ol
+            className="mono"
+            style={{
+              padding: 0,
+              margin: 0,
+              listStylePosition: 'inside',
+              fontSize: 12,
+              lineHeight: 1.9,
+              color: 'var(--ink-2)',
+            }}
+          >
+            <li>clone the repo</li>
+            <li>open <code style={{ color: 'var(--ink)' }}>chrome://extensions</code></li>
+            <li>toggle developer mode</li>
+            <li>load unpacked → <code style={{ color: 'var(--ink)' }}>chrome-extension/</code></li>
+          </ol>
+          <p style={{ fontSize: 13, color: 'var(--ink-2)', marginTop: 'var(--r4)', fontStyle: 'italic', fontFamily: 'var(--font-display)' }}>
+            Manifest v3. Only permission: <code className="mono" style={{ fontStyle: 'normal' }}>activeTab</code>.
+          </p>
+          <a
+            href="https://github.com/Manavarya09/design-extract/tree/main/chrome-extension"
+            target="_blank"
+            rel="noopener"
+            className="mono"
+            style={{ display: 'inline-block', marginTop: 'var(--r3)', fontSize: 12, letterSpacing: '0.06em', textTransform: 'uppercase' }}
+          >
+            source →
+          </a>
+        </div>
       </div>
 
       <style>{`
         .install-grid {
           display: grid;
-          grid-template-columns: repeat(3, minmax(0, 1fr));
+          grid-template-columns: repeat(4, minmax(0, 1fr));
           gap: 0;
         }
         .install-col {
-          padding: 0 var(--r5);
+          padding: 0 var(--r4);
         }
         .install-col:first-child { padding-left: 0; }
         .install-col:last-child { padding-right: 0; }
         .install-col + .install-col {
           border-left: 1px solid var(--ink);
         }
-        @media (max-width: 860px) {
-          .install-grid { grid-template-columns: 1fr; gap: var(--r6); }
-          .install-col { padding: 0; }
-          .install-col + .install-col { border-left: 0; border-top: 1px solid var(--ink); padding-top: var(--r5); }
+        @media (max-width: 1100px) {
+          .install-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0; }
+          .install-col { padding: var(--r4) var(--r4); }
+          .install-col:nth-child(2n+1) { padding-left: 0; }
+          .install-col:nth-child(2n) { padding-right: 0; }
+          .install-col:nth-child(n+3) { border-top: 1px solid var(--ink); }
+          .install-col:nth-child(2n+1) { border-left: 0; }
+        }
+        @media (max-width: 640px) {
+          .install-grid { grid-template-columns: 1fr; gap: 0; }
+          .install-col { padding: var(--r5) 0; border-left: 0 !important; }
+          .install-col + .install-col { border-top: 1px solid var(--ink); }
         }
       `}</style>
     </div>


### PR DESCRIPTION
Surface v7.1's new features in both README and the live website.

## README
- New section **22 — Chrome Extension** with install steps and permission note.
- New section **23 — Better Auth + Network Control** covering `--cookie-file`, `--insecure`, `--user-agent`.
- 'All Features' table: expands the Auth pages row, adds rows for `--insecure`, `--user-agent`, and the Chrome extension.

## Website `§09 Install`
- Grid goes from 3 tracks to **4 tracks** — added **Track 04 · Chrome extension** with install-in-dev-mode steps, Manifest v3 + `activeTab`-only note, and a link to the source folder.
- Track 01 CLI examples now show `--cookie-file`, `--insecure`, `--user-agent`.
- Responsive grid: 4 cols on desktop, 2 cols at ≤1100px, 1 col at ≤640px. Verified at 390×844 and 1440×900.

## Verified
- 249/249 tests still pass.
- Desktop + mobile screenshots of §09 Install look correct.