### PR TITLE
feat(extract): tier 1a — pseudo-elements, variable fonts, container queries, env()

### DIFF
--- a/src/crawler.js
+++ b/src/crawler.js
@@ -262,6 +262,31 @@ async function extractPageData(page, ignoreSelectors) {
     }
     const elements = collectElements(document, []);
 
+    function readPseudo(el, which) {
+      try {
+        const ps = getComputedStyle(el, which);
+        const content = ps.getPropertyValue('content');
+        if (!content || content === 'none' || content === 'normal') return null;
+        return {
+          content,
+          display: ps.display,
+          position: ps.position,
+          top: ps.top,
+          left: ps.left,
+          right: ps.right,
+          bottom: ps.bottom,
+          width: ps.width,
+          height: ps.height,
+          background: ps.background,
+          color: ps.color,
+          border: ps.border,
+          transform: ps.transform,
+          mask: ps.mask || ps.getPropertyValue('-webkit-mask') || '',
+          clipPath: ps.clipPath || ps.getPropertyValue('-webkit-clip-path') || '',
+        };
+      } catch { return null; }
+    }
+
     for (const el of elements) {
       const cs = getComputedStyle(el);
       const tag = el.tagName.toLowerCase();
@@ -269,6 +294,10 @@ async function extractPageData(page, ignoreSelectors) {
       const role = el.getAttribute('role') || '';
       const rect = el.getBoundingClientRect();
       const area = rect.width * rect.height;
+
+      const before = readPseudo(el, '::before');
+      const after = readPseudo(el, '::after');
+      const pseudo = (before || after) ? { before, after } : null;
 
       results.computedStyles.push({
         tag, classList, role, area,
@@ -307,6 +336,13 @@ async function extractPageData(page, ignoreSelectors) {
         gridTemplateColumns: cs.gridTemplateColumns,
         gridTemplateRows: cs.gridTemplateRows,
         maxWidth: cs.maxWidth,
+        fontVariationSettings: cs.fontVariationSettings || cs.getPropertyValue('font-variation-settings') || 'normal',
+        fontFeatureSettings: cs.fontFeatureSettings || cs.getPropertyValue('font-feature-settings') || 'normal',
+        textWrap: cs.textWrap || cs.getPropertyValue('text-wrap') || '',
+        textDecorationStyle: cs.textDecorationStyle || '',
+        textDecorationThickness: cs.textDecorationThickness || '',
+        textUnderlineOffset: cs.textUnderlineOffset || '',
+        pseudo,
       });
     }
 
@@ -365,6 +401,59 @@ async function extractPageData(page, ignoreSelectors) {
         } catch { /* cross-origin — already tracked */ }
       }
     } catch { /* no access */ }
+
+    // Container queries (@container rules) and env() usage
+    results.containerQueries = [];
+    results.envUsage = [];
+    function walkRulesForContainersAndEnv(rules) {
+      for (const rule of rules) {
+        try {
+          // Container query
+          if (typeof CSSContainerRule !== 'undefined' && rule instanceof CSSContainerRule) {
+            const inner = [];
+            try {
+              for (const inr of rule.cssRules) {
+                if (inr.selectorText) inner.push(inr.selectorText);
+              }
+            } catch {}
+            results.containerQueries.push({
+              condition: rule.conditionText || rule.containerQuery || '',
+              selectorText: inner.join(', '),
+              declarationCount: inner.length,
+            });
+          } else if (rule.cssText && rule.cssText.startsWith('@container')) {
+            results.containerQueries.push({
+              condition: rule.conditionText || '',
+              selectorText: '',
+              declarationCount: 0,
+            });
+          }
+          // env() scan on declaration text
+          if (rule.style) {
+            const css = rule.cssText || '';
+            const envMatches = css.match(/env\(\s*(safe-area-inset-[a-z]+|viewport-[a-z-]+|[a-z-]+)/gi);
+            if (envMatches) {
+              for (const m of envMatches) {
+                results.envUsage.push(m.replace(/^env\(\s*/, '').trim());
+              }
+            }
+          }
+          // Recurse into grouping rules (media, supports, container)
+          if (rule.cssRules) {
+            walkRulesForContainersAndEnv(rule.cssRules);
+          }
+        } catch { /* ignore per-rule errors */ }
+      }
+    }
+    try {
+      for (const sheet of document.styleSheets) {
+        try {
+          walkRulesForContainersAndEnv(sheet.cssRules);
+        } catch { /* cross-origin — already tracked */ }
+      }
+    } catch { /* no access */ }
+    // dedupe envUsage
+    results.envUsage = [...new Set(results.envUsage)];
 
     // Component clusters (v7): per-element features for similarity-based grouping.
     function colorToChannels(str) {
@@ -551,6 +640,17 @@ function parseCrossOriginCSS(cssText, data) {
   for (const m of cssText.matchAll(/@media\s*([^{]+)\{/g)) {
     data.mediaQueries.push(m[1].trim());
   }
+  // Container queries
+  if (!data.containerQueries) data.containerQueries = [];
+  for (const m of cssText.matchAll(/@container\s*([^{]*)\{/g)) {
+    data.containerQueries.push({ condition: m[1].trim(), selectorText: '', declarationCount: 0 });
+  }
+  // env() usage
+  if (!data.envUsage) data.envUsage = [];
+  for (const m of cssText.matchAll(/env\(\s*(safe-area-inset-[a-z]+|viewport-[a-z-]+)/gi)) {
+    data.envUsage.push(m[1]);
+  }
+  data.envUsage = [...new Set(data.envUsage)];
   // Keyframes
   for (const m of cssText.matchAll(/@keyframes\s+([\w-]+)\s*\{([\s\S]*?)\n\}/g)) {
     const steps = [];

--- a/src/extractors/modern-css.js
+++ b/src/extractors/modern-css.js
@@ -1,0 +1,100 @@
+// Extractor for modern CSS features captured by the crawler:
+//   - Pseudo-elements (::before / ::after)
+//   - Variable-font axes (font-variation-settings)
+//   - OpenType features (font-feature-settings)
+//   - Modern text layout (text-wrap, text-decoration-*)
+//   - Container queries (@container)
+//   - env() usage (safe-area-inset-*, viewport-*)
+
+export function extractModernCss(payload) {
+  const light = (payload && payload.light) || payload || {};
+  const styles = Array.isArray(light.computedStyles) ? light.computedStyles : [];
+
+  // Pseudo-elements
+  const pseudoSamples = [];
+  let pseudoCount = 0;
+  for (const s of styles) {
+    const p = s && s.pseudo;
+    if (!p) continue;
+    if (p.before) { pseudoCount++; if (pseudoSamples.length < 20) pseudoSamples.push({ tag: s.tag, classList: s.classList, which: '::before', style: p.before }); }
+    if (p.after) { pseudoCount++; if (pseudoSamples.length < 20) pseudoSamples.push({ tag: s.tag, classList: s.classList, which: '::after', style: p.after }); }
+  }
+
+  // Variable fonts
+  const axesMap = new Map();
+  let variableFontCount = 0;
+  for (const s of styles) {
+    const v = s && s.fontVariationSettings;
+    if (!v || v === 'normal' || v === '') continue;
+    variableFontCount++;
+    // e.g. "\"wght\" 600, \"slnt\" -4"
+    for (const m of String(v).matchAll(/"([^"]+)"\s+(-?\d+(?:\.\d+)?)/g)) {
+      const axis = m[1];
+      const val = parseFloat(m[2]);
+      if (!axesMap.has(axis)) axesMap.set(axis, { axis, min: val, max: val, count: 0 });
+      const a = axesMap.get(axis);
+      a.min = Math.min(a.min, val);
+      a.max = Math.max(a.max, val);
+      a.count++;
+    }
+  }
+
+  // OpenType features
+  const featMap = new Map();
+  for (const s of styles) {
+    const f = s && s.fontFeatureSettings;
+    if (!f || f === 'normal' || f === '') continue;
+    for (const m of String(f).matchAll(/"([^"]+)"(?:\s+(on|off|\d+))?/g)) {
+      const key = m[1];
+      featMap.set(key, (featMap.get(key) || 0) + 1);
+    }
+  }
+
+  // Text-wrap / decoration
+  const textWrapMap = new Map();
+  const decStyleMap = new Map();
+  const thicknessMap = new Map();
+  const offsetMap = new Map();
+  for (const s of styles) {
+    if (s.textWrap && s.textWrap !== 'wrap' && s.textWrap !== '') {
+      textWrapMap.set(s.textWrap, (textWrapMap.get(s.textWrap) || 0) + 1);
+    }
+    if (s.textDecorationStyle && s.textDecorationStyle !== 'solid' && s.textDecorationStyle !== '') {
+      decStyleMap.set(s.textDecorationStyle, (decStyleMap.get(s.textDecorationStyle) || 0) + 1);
+    }
+    if (s.textDecorationThickness && s.textDecorationThickness !== 'auto' && s.textDecorationThickness !== '') {
+      thicknessMap.set(s.textDecorationThickness, (thicknessMap.get(s.textDecorationThickness) || 0) + 1);
+    }
+    if (s.textUnderlineOffset && s.textUnderlineOffset !== 'auto' && s.textUnderlineOffset !== '') {
+      offsetMap.set(s.textUnderlineOffset, (offsetMap.get(s.textUnderlineOffset) || 0) + 1);
+    }
+  }
+
+  const containerQueries = Array.isArray(light.containerQueries) ? light.containerQueries : [];
+  const envUsage = Array.isArray(light.envUsage) ? light.envUsage : [];
+
+  return {
+    pseudoElements: {
+      count: pseudoCount,
+      samples: pseudoSamples,
+    },
+    variableFonts: {
+      count: variableFontCount,
+      axes: [...axesMap.values()].sort((a, b) => b.count - a.count),
+    },
+    openTypeFeatures: [...featMap.entries()]
+      .map(([feature, count]) => ({ feature, count }))
+      .sort((a, b) => b.count - a.count),
+    textWrap: {
+      wrap: [...textWrapMap.entries()].map(([value, count]) => ({ value, count })),
+      decorationStyle: [...decStyleMap.entries()].map(([value, count]) => ({ value, count })),
+      decorationThickness: [...thicknessMap.entries()].map(([value, count]) => ({ value, count })),
+      underlineOffset: [...offsetMap.entries()].map(([value, count]) => ({ value, count })),
+    },
+    containerQueries: {
+      count: containerQueries.length,
+      rules: containerQueries,
+    },
+    envUsage: [...new Set(envUsage)],
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import { extractCssHealth } from './extractors/css-health.js';
 import { remediateFailingPairs } from './extractors/a11y-remediation.js';
 import { extractSemanticRegions } from './extractors/semantic-regions.js';
 import { clusterComponents } from './extractors/component-clusters.js';
+import { extractModernCss } from './extractors/modern-css.js';
 
 function safeExtract(fn, ...args) {
   try { return fn(...args); } catch { return null; }
@@ -63,6 +64,7 @@ export async function extractDesignLanguage(url, options = {}) {
     cssHealth: safeExtract(extractCssHealth, rawData.light.cssCoverage) || null,
     regions: safeExtract(extractSemanticRegions, rawData.light.sections) || [],
     componentClusters: safeExtract(clusterComponents, rawData.light.componentCandidates) || [],
+    modernCss: safeExtract(extractModernCss, rawData) || { pseudoElements: { count: 0, samples: [] }, variableFonts: { count: 0, axes: [] }, openTypeFeatures: [], textWrap: { wrap: [], decorationStyle: [], decorationThickness: [], underlineOffset: [] }, containerQueries: { count: 0, rules: [] }, envUsage: [] },
     score: null,
   };
 

--- a/tests/modern-css.test.js
+++ b/tests/modern-css.test.js
@@ -1,0 +1,104 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractModernCss } from '../src/extractors/modern-css.js';
+
+function mkStyle(overrides = {}) {
+  return {
+    tag: 'div',
+    classList: '',
+    fontVariationSettings: 'normal',
+    fontFeatureSettings: 'normal',
+    textWrap: '',
+    textDecorationStyle: '',
+    textDecorationThickness: '',
+    textUnderlineOffset: '',
+    pseudo: null,
+    ...overrides,
+  };
+}
+
+describe('extractModernCss', () => {
+  it('returns zeroed structure for empty payload', () => {
+    const r = extractModernCss({});
+    assert.equal(r.pseudoElements.count, 0);
+    assert.equal(r.variableFonts.count, 0);
+    assert.equal(r.containerQueries.count, 0);
+    assert.deepEqual(r.envUsage, []);
+  });
+
+  it('counts pseudo-elements and captures samples', () => {
+    const light = {
+      computedStyles: [
+        mkStyle({ tag: 'a', pseudo: { before: { content: '"→"', color: 'red' }, after: null } }),
+        mkStyle({ tag: 'li', pseudo: { before: { content: '"•"' }, after: { content: '"x"' } } }),
+      ],
+    };
+    const r = extractModernCss({ light });
+    assert.equal(r.pseudoElements.count, 3);
+    assert.ok(r.pseudoElements.samples.length >= 2);
+    assert.equal(r.pseudoElements.samples[0].which, '::before');
+  });
+
+  it('aggregates variable-font axes with min/max', () => {
+    const light = {
+      computedStyles: [
+        mkStyle({ fontVariationSettings: '"wght" 400, "slnt" 0' }),
+        mkStyle({ fontVariationSettings: '"wght" 700, "slnt" -8' }),
+      ],
+    };
+    const r = extractModernCss({ light });
+    assert.equal(r.variableFonts.count, 2);
+    const wght = r.variableFonts.axes.find(a => a.axis === 'wght');
+    assert.ok(wght);
+    assert.equal(wght.min, 400);
+    assert.equal(wght.max, 700);
+    const slnt = r.variableFonts.axes.find(a => a.axis === 'slnt');
+    assert.equal(slnt.min, -8);
+    assert.equal(slnt.max, 0);
+  });
+
+  it('collects OpenType features and counts', () => {
+    const light = {
+      computedStyles: [
+        mkStyle({ fontFeatureSettings: '"ss01" on, "cv11"' }),
+        mkStyle({ fontFeatureSettings: '"ss01"' }),
+      ],
+    };
+    const r = extractModernCss({ light });
+    const ss01 = r.openTypeFeatures.find(f => f.feature === 'ss01');
+    assert.equal(ss01.count, 2);
+    const cv11 = r.openTypeFeatures.find(f => f.feature === 'cv11');
+    assert.equal(cv11.count, 1);
+  });
+
+  it('collects modern text-layout properties', () => {
+    const light = {
+      computedStyles: [
+        mkStyle({ textWrap: 'balance', textDecorationStyle: 'wavy', textDecorationThickness: '2px', textUnderlineOffset: '3px' }),
+        mkStyle({ textWrap: 'balance' }),
+        mkStyle({ textWrap: 'pretty' }),
+      ],
+    };
+    const r = extractModernCss({ light });
+    const balance = r.textWrap.wrap.find(w => w.value === 'balance');
+    assert.equal(balance.count, 2);
+    assert.equal(r.textWrap.decorationStyle[0].value, 'wavy');
+    assert.equal(r.textWrap.decorationThickness[0].value, '2px');
+    assert.equal(r.textWrap.underlineOffset[0].value, '3px');
+  });
+
+  it('passes through container queries and env() usage', () => {
+    const light = {
+      computedStyles: [],
+      containerQueries: [
+        { condition: '(min-width: 480px)', selectorText: '.card', declarationCount: 3 },
+      ],
+      envUsage: ['safe-area-inset-top', 'safe-area-inset-top', 'viewport-segment-top'],
+    };
+    const r = extractModernCss({ light });
+    assert.equal(r.containerQueries.count, 1);
+    assert.equal(r.containerQueries.rules[0].condition, '(min-width: 480px)');
+    assert.equal(r.envUsage.length, 2);
+    assert.ok(r.envUsage.includes('safe-area-inset-top'));
+  });
+});


### PR DESCRIPTION
## Summary
Capture modern CSS features the computed-style walker previously missed:

- `::before` / `::after` pseudo-elements with content, position, bg, transform, mask, clip-path
- `font-variation-settings` (variable font axes with min/max) and `font-feature-settings`
- `text-wrap`, `text-decoration-style/thickness`, `text-underline-offset`
- `@container` rules walked from every stylesheet (condition + selectors)
- `env(safe-area-inset-*, viewport-*)` usage scan

New extractor: `src/extractors/modern-css.js` → surfaced on the output as `design.modernCss`.

## Test plan
- [x] 6 new unit tests in `tests/modern-css.test.js` (255/255 green)
- [x] Smoke: `node bin/design-extract.js https://vercel.com` shows 4 pseudo samples, 86 `@container` rules, `liga` feature, and `text-wrap: balance` usage