### PR TITLE
feat(extract): tier 1b — wide-gamut color (oklch, color-mix, light-dark) + CSS source-file attribution

### DIFF
--- a/src/crawler.js
+++ b/src/crawler.js
@@ -262,6 +262,41 @@ async function extractPageData(page, ignoreSelectors) {
     }
     const elements = collectElements(document, []);
 
+    // Build a lightweight index: stylesheet URL + their top selectors.
+    // Used to attribute each element's primary source stylesheet.
+    const sheetIndex = [];
+    try {
+      for (const sheet of document.styleSheets) {
+        const entry = { url: sheet.href || '', mediaText: sheet.media ? sheet.media.mediaText : '', selectors: [] };
+        try {
+          let cap = 0;
+          for (const rule of sheet.cssRules) {
+            if (cap >= 200) break;
+            if (rule && rule.selectorText) {
+              entry.selectors.push(rule.selectorText);
+              cap++;
+            }
+          }
+        } catch { /* cross-origin */ }
+        if (entry.url || entry.selectors.length > 0) sheetIndex.push(entry);
+      }
+    } catch { /* no access */ }
+
+    function findSourceFor(el) {
+      // Try to find the first stylesheet that has a selector matching this element.
+      for (const sheet of sheetIndex) {
+        for (const sel of sheet.selectors) {
+          try {
+            // selectorText can contain multiple comma-separated selectors
+            if (el.matches(sel)) {
+              return { url: sheet.url, mediaText: sheet.mediaText };
+            }
+          } catch { /* invalid or unsupported selector */ }
+        }
+      }
+      return null;
+    }
+
     function readPseudo(el, which) {
       try {
         const ps = getComputedStyle(el, which);
@@ -287,6 +322,7 @@ async function extractPageData(page, ignoreSelectors) {
       } catch { return null; }
     }
 
+    let sourceAttrBudget = 500;
     for (const el of elements) {
       const cs = getComputedStyle(el);
       const tag = el.tagName.toLowerCase();
@@ -298,6 +334,13 @@ async function extractPageData(page, ignoreSelectors) {
       const before = readPseudo(el, '::before');
       const after = readPseudo(el, '::after');
       const pseudo = (before || after) ? { before, after } : null;
+
+      let sources = null;
+      if (sourceAttrBudget > 0) {
+        const s = findSourceFor(el);
+        if (s) sources = [s];
+        sourceAttrBudget--;
+      }
 
       results.computedStyles.push({
         tag, classList, role, area,
@@ -343,6 +386,7 @@ async function extractPageData(page, ignoreSelectors) {
         textDecorationThickness: cs.textDecorationThickness || '',
         textUnderlineOffset: cs.textUnderlineOffset || '',
         pseudo,
+        sources,
       });
     }
 
@@ -402,12 +446,35 @@ async function extractPageData(page, ignoreSelectors) {
       }
     } catch { /* no access */ }
 
-    // Container queries (@container rules) and env() usage
+    // Container queries (@container rules), env() usage, and modern colors
     results.containerQueries = [];
     results.envUsage = [];
+    results.modernColors = [];
+    const MODERN_COLOR_RE = /(oklch\([^)]+\)|oklab\([^)]+\)|color-mix\([^)]+\)|light-dark\([^)]+\)|color\(\s*display-p3[^)]+\)|color\(\s*rec2020[^)]+\))/gi;
     function walkRulesForContainersAndEnv(rules) {
       for (const rule of rules) {
         try {
+          // Scan declarations for modern color functions
+          if (rule.style && rule.cssText) {
+            const css = rule.cssText;
+            for (const m of css.matchAll(MODERN_COLOR_RE)) {
+              const raw = m[1];
+              let type = 'other';
+              if (/^oklch/i.test(raw)) type = 'oklch';
+              else if (/^oklab/i.test(raw)) type = 'oklab';
+              else if (/^color-mix/i.test(raw)) type = 'color-mix';
+              else if (/^light-dark/i.test(raw)) type = 'light-dark';
+              else if (/display-p3/i.test(raw)) type = 'display-p3';
+              else if (/rec2020/i.test(raw)) type = 'rec2020';
+              // Try to infer property
+              let property = '';
+              for (let i = 0; i < rule.style.length; i++) {
+                const p = rule.style[i];
+                if ((rule.style.getPropertyValue(p) || '').includes(raw)) { property = p; break; }
+              }
+              results.modernColors.push({ raw, type, property, selector: rule.selectorText || '' });
+            }
+          }
           // Container query
           if (typeof CSSContainerRule !== 'undefined' && rule instanceof CSSContainerRule) {
             const inner = [];
@@ -651,6 +718,20 @@ function parseCrossOriginCSS(cssText, data) {
     data.envUsage.push(m[1]);
   }
   data.envUsage = [...new Set(data.envUsage)];
+  // Modern colors
+  if (!data.modernColors) data.modernColors = [];
+  const modernRe = /(oklch\([^)]+\)|oklab\([^)]+\)|color-mix\([^)]+\)|light-dark\([^)]+\)|color\(\s*display-p3[^)]+\)|color\(\s*rec2020[^)]+\))/gi;
+  for (const m of cssText.matchAll(modernRe)) {
+    const raw = m[1];
+    let type = 'other';
+    if (/^oklch/i.test(raw)) type = 'oklch';
+    else if (/^oklab/i.test(raw)) type = 'oklab';
+    else if (/^color-mix/i.test(raw)) type = 'color-mix';
+    else if (/^light-dark/i.test(raw)) type = 'light-dark';
+    else if (/display-p3/i.test(raw)) type = 'display-p3';
+    else if (/rec2020/i.test(raw)) type = 'rec2020';
+    data.modernColors.push({ raw, type, property: '', selector: '' });
+  }
   // Keyframes
   for (const m of cssText.matchAll(/@keyframes\s+([\w-]+)\s*\{([\s\S]*?)\n\}/g)) {
     const steps = [];

--- a/src/extractors/token-sources.js
+++ b/src/extractors/token-sources.js
@@ -1,0 +1,65 @@
+// Attribute top design tokens back to the stylesheet URL that most likely
+// contributed them. Uses the per-element `sources` captured by the crawler.
+
+import { parseColor, rgbToHex } from '../utils.js';
+
+function firstSourceUrlWhere(styles, predicate) {
+  for (const s of styles) {
+    if (!s || !predicate(s)) continue;
+    const src = Array.isArray(s.sources) ? s.sources[0] : null;
+    if (src && src.url) return src.url;
+  }
+  return '';
+}
+
+export function extractTokenSources(design, computedStyles) {
+  const styles = Array.isArray(computedStyles) ? computedStyles : [];
+  const out = [];
+
+  // Primary color
+  const primaryHex = design.colors?.primary?.hex;
+  if (primaryHex) {
+    const url = firstSourceUrlWhere(styles, s => {
+      const p = parseColor(s.color);
+      return p && rgbToHex(p) === primaryHex;
+    });
+    out.push({ token: 'color.primary', path: 'colors.primary', sourceUrl: url });
+  }
+
+  // Text color (first in design.colors.text[])
+  const textHex = (design.colors?.text || [])[0];
+  if (textHex) {
+    const url = firstSourceUrlWhere(styles, s => {
+      const p = parseColor(s.color);
+      return p && rgbToHex(p) === textHex;
+    });
+    out.push({ token: 'color.text', path: 'colors.text[0]', sourceUrl: url });
+  }
+
+  // Body font — first typography family
+  const bodyFont = design.typography?.families?.[0]?.name;
+  if (bodyFont) {
+    const url = firstSourceUrlWhere(styles, s => typeof s.fontFamily === 'string' && s.fontFamily.includes(bodyFont));
+    out.push({ token: 'font.body', path: 'typography.families[0]', sourceUrl: url });
+  }
+
+  // Spacing base
+  const spacingBase = design.spacing?.base;
+  if (spacingBase != null) {
+    const target = `${spacingBase}px`;
+    const url = firstSourceUrlWhere(styles,
+      s => s.paddingTop === target || s.paddingLeft === target || s.marginTop === target || s.gap === target);
+    out.push({ token: 'spacing.base', path: 'spacing.base', sourceUrl: url });
+  }
+
+  // Radius base — first non-zero from design.borders.radii
+  const radii = design.borders?.radii || [];
+  const firstRadius = radii.find(r => (r.value || r) && (r.value || r) !== '0px');
+  if (firstRadius) {
+    const target = typeof firstRadius === 'string' ? firstRadius : (firstRadius.value || '');
+    const url = firstSourceUrlWhere(styles, s => s.borderRadius === target);
+    out.push({ token: 'radius.base', path: 'borders.radii[0]', sourceUrl: url });
+  }
+
+  return out;
+}

--- a/src/extractors/wide-gamut.js
+++ b/src/extractors/wide-gamut.js
@@ -1,0 +1,47 @@
+// Catalog of wide-gamut / modern color function usages from the crawler's
+// scan of stylesheet cssText. Produces counts + sample raw values + converted
+// sRGB hex for oklch/oklab values.
+
+import { oklchLikeToHex } from '../utils/color-gamut.js';
+
+export function extractWideGamut(modernColors) {
+  const src = Array.isArray(modernColors) ? modernColors : [];
+  const catalog = {
+    oklch: { count: 0, samples: [] },
+    oklab: { count: 0, samples: [] },
+    colorMix: { count: 0, samples: [] },
+    lightDark: { count: 0, samples: [] },
+    displayP3: { count: 0, samples: [] },
+    rec2020: { count: 0, samples: [] },
+  };
+
+  const bucket = {
+    oklch: catalog.oklch,
+    oklab: catalog.oklab,
+    'color-mix': catalog.colorMix,
+    'light-dark': catalog.lightDark,
+    'display-p3': catalog.displayP3,
+    rec2020: catalog.rec2020,
+  };
+
+  for (const entry of src) {
+    const b = bucket[entry.type];
+    if (!b) continue;
+    b.count++;
+    if (b.samples.length < 10) {
+      const sample = {
+        raw: entry.raw,
+        property: entry.property || '',
+        selector: entry.selector || '',
+      };
+      if (entry.type === 'oklch' || entry.type === 'oklab') {
+        const hex = oklchLikeToHex(entry.raw);
+        if (hex) sample.value = hex;
+      }
+      b.samples.push(sample);
+    }
+  }
+
+  const totalCount = Object.values(catalog).reduce((n, c) => n + c.count, 0);
+  return { ...catalog, totalCount };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,8 @@ import { remediateFailingPairs } from './extractors/a11y-remediation.js';
 import { extractSemanticRegions } from './extractors/semantic-regions.js';
 import { clusterComponents } from './extractors/component-clusters.js';
 import { extractModernCss } from './extractors/modern-css.js';
+import { extractWideGamut } from './extractors/wide-gamut.js';
+import { extractTokenSources } from './extractors/token-sources.js';
 
 function safeExtract(fn, ...args) {
   try { return fn(...args); } catch { return null; }
@@ -65,6 +67,8 @@ export async function extractDesignLanguage(url, options = {}) {
     regions: safeExtract(extractSemanticRegions, rawData.light.sections) || [],
     componentClusters: safeExtract(clusterComponents, rawData.light.componentCandidates) || [],
     modernCss: safeExtract(extractModernCss, rawData) || { pseudoElements: { count: 0, samples: [] }, variableFonts: { count: 0, axes: [] }, openTypeFeatures: [], textWrap: { wrap: [], decorationStyle: [], decorationThickness: [], underlineOffset: [] }, containerQueries: { count: 0, rules: [] }, envUsage: [] },
+    wideGamut: safeExtract(extractWideGamut, rawData.light.modernColors || []) || { oklch: { count: 0, samples: [] }, oklab: { count: 0, samples: [] }, colorMix: { count: 0, samples: [] }, lightDark: { count: 0, samples: [] }, displayP3: { count: 0, samples: [] }, rec2020: { count: 0, samples: [] }, totalCount: 0 },
+    tokenSources: [],
     score: null,
   };
 
@@ -107,6 +111,8 @@ export async function extractDesignLanguage(url, options = {}) {
       remediation: remediateFailingPairs(failingPairs, palette),
     };
   } catch { /* non-fatal */ }
+
+  design.tokenSources = safeExtract(extractTokenSources, design, styles) || [];
 
   design.score = safeExtract(scoreDesignSystem, design);
   if (design.score === null) warnings.push('scoring failed');

--- a/src/utils/color-gamut.js
+++ b/src/utils/color-gamut.js
@@ -1,0 +1,82 @@
+// OKLCH / OKLab → sRGB hex conversion utilities.
+// Based on the public OKLab formulas by Björn Ottosson
+// (https://bottosson.github.io/posts/oklab/). Implemented locally (no deps).
+
+function clamp01(v) { return Math.max(0, Math.min(1, v)); }
+
+function linearToSrgb(x) {
+  // Convert linear-light sRGB [0..1] to sRGB gamma-encoded [0..1]
+  if (x < 0) x = 0;
+  if (x > 1) x = 1;
+  return x <= 0.0031308 ? 12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055;
+}
+
+export function oklabToSrgb(L, a, b) {
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.2914855480 * b;
+
+  const l = l_ * l_ * l_;
+  const m = m_ * m_ * m_;
+  const s = s_ * s_ * s_;
+
+  const r = +4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
+  const g = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
+  const b2 = -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s;
+
+  return [linearToSrgb(r), linearToSrgb(g), linearToSrgb(b2)];
+}
+
+export function oklchToSrgb(L, C, h) {
+  const hr = (h * Math.PI) / 180;
+  const a = C * Math.cos(hr);
+  const b = C * Math.sin(hr);
+  return oklabToSrgb(L, a, b);
+}
+
+function toHex(v) {
+  const n = Math.round(clamp01(v) * 255);
+  return n.toString(16).padStart(2, '0');
+}
+
+export function rgbToHex(r, g, b) {
+  return '#' + toHex(r) + toHex(g) + toHex(b);
+}
+
+// Parse an oklch() or oklab() CSS value. Accepts values like:
+//   oklch(62.8% 0.258 29.23)
+//   oklch(0.628 0.258 29.23)
+//   oklab(0.628 0.1 -0.1)
+// Returns { type: 'oklch'|'oklab', L, C, h, a, b, raw } or null.
+export function parseOklchOrOklab(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  const m = raw.match(/^\s*(oklch|oklab)\(\s*([^)]+)\)\s*$/i);
+  if (!m) return null;
+  const type = m[1].toLowerCase();
+  // Strip alpha (everything after /)
+  const body = m[2].split('/')[0].trim();
+  const parts = body.split(/[\s,]+/).filter(Boolean);
+  if (parts.length < 3) return null;
+
+  function parseNum(s, scale = 1) {
+    if (s.endsWith('%')) return parseFloat(s) / 100;
+    return parseFloat(s) * scale;
+  }
+
+  const p0 = parts[0].endsWith('%') ? parseFloat(parts[0]) / 100 : parseFloat(parts[0]);
+  const p1 = parseFloat(parts[1]);
+  const p2 = parseFloat(parts[2]);
+  if ([p0, p1, p2].some(v => Number.isNaN(v))) return null;
+
+  if (type === 'oklch') return { type, L: p0, C: p1, h: p2, raw };
+  return { type, L: p0, a: p1, b: p2, raw };
+}
+
+export function oklchLikeToHex(raw) {
+  const parsed = parseOklchOrOklab(raw);
+  if (!parsed) return null;
+  const [r, g, b] = parsed.type === 'oklch'
+    ? oklchToSrgb(parsed.L, parsed.C, parsed.h)
+    : oklabToSrgb(parsed.L, parsed.a, parsed.b);
+  return rgbToHex(r, g, b);
+}

--- a/tests/wide-gamut.test.js
+++ b/tests/wide-gamut.test.js
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { oklchToSrgb, oklabToSrgb, oklchLikeToHex, parseOklchOrOklab, rgbToHex } from '../src/utils/color-gamut.js';
+import { extractWideGamut } from '../src/extractors/wide-gamut.js';
+import { extractTokenSources } from '../src/extractors/token-sources.js';
+
+describe('color-gamut', () => {
+  it('converts oklch(1 0 0) to white', () => {
+    const hex = oklchLikeToHex('oklch(1 0 0)');
+    assert.equal(hex, '#ffffff');
+  });
+
+  it('converts oklch(0 0 0) to black', () => {
+    const hex = oklchLikeToHex('oklch(0 0 0)');
+    assert.equal(hex, '#000000');
+  });
+
+  it('converts a mid-chroma oklch to approximate sRGB', () => {
+    // oklch(62.8% 0.258 29.23) ≈ red (#ff0000) region
+    const hex = oklchLikeToHex('oklch(62.8% 0.258 29.23)');
+    assert.ok(/^#[0-9a-f]{6}$/.test(hex));
+    // Red channel should dominate
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    assert.ok(r > g, `expected r>g, got ${hex}`);
+    assert.ok(r > b, `expected r>b, got ${hex}`);
+  });
+
+  it('parses oklab values with percentages', () => {
+    const p = parseOklchOrOklab('oklab(62.8% 0.1 -0.1)');
+    assert.equal(p.type, 'oklab');
+    assert.ok(Math.abs(p.L - 0.628) < 1e-6);
+  });
+
+  it('rgbToHex clamps and formats correctly', () => {
+    assert.equal(rgbToHex(1, 0, 0), '#ff0000');
+    assert.equal(rgbToHex(0, 1, 0), '#00ff00');
+    assert.equal(rgbToHex(1.5, -0.5, 0.5), '#ff0080');
+  });
+});
+
+describe('extractWideGamut', () => {
+  it('returns zeros for empty input', () => {
+    const r = extractWideGamut([]);
+    assert.equal(r.totalCount, 0);
+    assert.equal(r.oklch.count, 0);
+  });
+
+  it('buckets colors by type and emits hex for oklch samples', () => {
+    const r = extractWideGamut([
+      { raw: 'oklch(62.8% 0.258 29.23)', type: 'oklch', property: 'color', selector: '.btn' },
+      { raw: 'color-mix(in oklab, red, blue)', type: 'color-mix', property: 'background', selector: '.x' },
+      { raw: 'light-dark(white, black)', type: 'light-dark', property: 'color', selector: '.y' },
+      { raw: 'color(display-p3 1 0 0)', type: 'display-p3', property: 'background', selector: '.p3' },
+    ]);
+    assert.equal(r.oklch.count, 1);
+    assert.ok(r.oklch.samples[0].value?.startsWith('#'));
+    assert.equal(r.colorMix.count, 1);
+    assert.equal(r.lightDark.count, 1);
+    assert.equal(r.displayP3.count, 1);
+    assert.equal(r.totalCount, 4);
+  });
+});
+
+describe('extractTokenSources', () => {
+  it('returns an array of token→sourceUrl entries based on first matching element', () => {
+    const design = {
+      colors: { primary: { hex: '#0072f5' }, text: ['#111111'] },
+      typography: { families: [{ name: 'Geist' }] },
+      spacing: { base: 8 },
+      borders: { radii: [{ value: '8px' }] },
+    };
+    const styles = [
+      { color: 'rgb(0, 114, 245)', fontFamily: '"Geist", sans-serif', paddingTop: '8px', borderRadius: '8px', sources: [{ url: 'https://cdn.example/app.css', mediaText: '' }] },
+      { color: 'rgb(17, 17, 17)', sources: [{ url: 'https://cdn.example/text.css', mediaText: '' }] },
+    ];
+    const out = extractTokenSources(design, styles);
+    const primary = out.find(t => t.token === 'color.primary');
+    assert.equal(primary.sourceUrl, 'https://cdn.example/app.css');
+    const text = out.find(t => t.token === 'color.text');
+    assert.equal(text.sourceUrl, 'https://cdn.example/text.css');
+    const font = out.find(t => t.token === 'font.body');
+    assert.equal(font.sourceUrl, 'https://cdn.example/app.css');
+    const spacing = out.find(t => t.token === 'spacing.base');
+    assert.equal(spacing.sourceUrl, 'https://cdn.example/app.css');
+    const radius = out.find(t => t.token === 'radius.base');
+    assert.equal(radius.sourceUrl, 'https://cdn.example/app.css');
+  });
+});


### PR DESCRIPTION
## Summary
- Capture modern color functions from stylesheet source (before computed styles flatten to rgb): `oklch`, `oklab`, `color-mix`, `light-dark`, `color(display-p3|rec2020)` → `design.wideGamut`.
- Pure-JS OKLab/OKLCH → sRGB hex converter in `src/utils/color-gamut.js` (no deps). Emits `{ raw, value: '#rrggbb' }` on oklch samples.
- Per-element CSS source-file attribution: crawler indexes stylesheet URL + selectors, attaches `el.sources = [{ url, mediaText }]`. `design.tokenSources` surfaces URLs for primary color, text color, body font, spacing base, radius base.

## Test plan
- [x] 8 new unit tests (color conversion, catalog, token attribution); 263/263 green.
- [x] Smoke: `node bin/design-extract.js https://vercel.com` resolves color.primary/text/font to their Next.js CSS chunk URLs; `linear.app` reports 20 color-mix + 1 display-p3 usages.