### PR TITLE
feat(extract): tier 2 — multi-page token reconciliation (shared vs per-route)

### DIFF
--- a/bin/design-extract.js
+++ b/bin/design-extract.js
@@ -21,6 +21,7 @@ import { formatFlutterDart } from '../src/formatters/flutter-dart.js';
 import { formatVueTheme } from '../src/formatters/vue-theme.js';
 import { formatSvelteTheme } from '../src/formatters/svelte-theme.js';
 import { formatAgentRules } from '../src/formatters/agent-rules.js';
+import { reconcileRoutes, formatRoutesReport } from '../src/formatters/routes-reconciliation.js';
 import { loadConfig, mergeConfig } from '../src/config.js';
 import { diffDesigns, formatDiffMarkdown, formatDiffHtml } from '../src/diff.js';
 import { saveSnapshot, getHistory, formatHistoryMarkdown } from '../src/history.js';
@@ -258,6 +259,25 @@ program
           writeFileSync(p, out[name], 'utf-8');
           platformFiles.push({ path: p, label: `WordPress (${name})` });
         }
+      }
+
+      // Multi-route token reconciliation (Tier 2). Only when --depth >= 1 and
+      // the crawler actually returned per-route token data.
+      if (merged.depth >= 1 && Array.isArray(design.routes) && design.routes.length > 0) {
+        const reconciled = reconcileRoutes(design.routes);
+        const sharedPath = join(outDir, `${prefix}-tokens-shared.json`);
+        writeFileSync(sharedPath, JSON.stringify(reconciled.shared, null, 2), 'utf-8');
+        platformFiles.push({ path: sharedPath, label: 'Shared tokens (multi-route)' });
+        const routesDir = join(outDir, `${prefix}-tokens-routes`);
+        mkdirSync(routesDir, { recursive: true });
+        for (const [slug, entry] of Object.entries(reconciled.perRoute)) {
+          const rp = join(routesDir, `${slug}.json`);
+          writeFileSync(rp, JSON.stringify({ url: entry.url, path: entry.path, added: entry.added, changed: entry.changed }, null, 2), 'utf-8');
+          platformFiles.push({ path: rp, label: `Route tokens (${slug})` });
+        }
+        const reportPath = join(outDir, `${prefix}-routes-report.md`);
+        writeFileSync(reportPath, formatRoutesReport(reconciled), 'utf-8');
+        platformFiles.push({ path: reportPath, label: 'Routes report (markdown)' });
       }
 
       // Agent rules (opt-in, also enabled by --full)

--- a/src/crawler.js
+++ b/src/crawler.js
@@ -109,7 +109,17 @@ export async function crawlPage(url, options = {}) {
 
     // Multi-page crawl: discover internal links and extract from them
     let additionalPages = [];
+    const routes = [];
     if (depth > 0) {
+      // Seed routes with the primary page
+      try {
+        const u0 = new URL(url);
+        routes.push({
+          url,
+          path: u0.pathname || '/',
+          computedStylesSample: (lightData.computedStyles || []).slice(0, 2000),
+        });
+      } catch { /* ignore */ }
       const internalLinks = await discoverInternalLinks(page, url, depth);
       for (const link of internalLinks) {
         try {
@@ -118,6 +128,14 @@ export async function crawlPage(url, options = {}) {
           await page.evaluate(() => document.fonts.ready).catch(() => {});
           const pageData = await extractPageData(page);
           additionalPages.push({ url: link, data: pageData });
+          try {
+            const u = new URL(link);
+            routes.push({
+              url: link,
+              path: u.pathname || '/',
+              computedStylesSample: (pageData.computedStyles || []).slice(0, 2000),
+            });
+          } catch { /* ignore */ }
         } catch { /* skip failed pages */ }
       }
     }
@@ -163,6 +181,7 @@ export async function crawlPage(url, options = {}) {
       light: lightData,
       dark: darkData,
       interactState,
+      routes: routes.length > 0 ? routes : undefined,
       pagesAnalyzed: 1 + additionalPages.length,
       componentScreenshots,
     };

--- a/src/formatters/routes-reconciliation.js
+++ b/src/formatters/routes-reconciliation.js
@@ -1,0 +1,160 @@
+// Shared-vs-per-route reconciliation for multi-page token extraction.
+// Input: [{ url, path, tokens: DTCG-shaped { primitive, semantic, ... } }]
+// Output: { shared, perRoute: { <slug>: { added, changed } }, summary }
+//
+// "Shared" = a token path present with the same $value in ALL routes.
+// "Added"  = a token path present on this route but missing from the shared set.
+// "Changed"= a token path present in shared but with a different $value here.
+
+export function slugForPath(p) {
+  if (!p || p === '/' || p === '') return 'index';
+  return String(p)
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase() || 'index';
+}
+
+function isLeaf(node) {
+  return node && typeof node === 'object' && '$value' in node;
+}
+
+// Walk a DTCG tree and produce a flat map of dotted-path -> serialized $value.
+function flattenTokens(tree, prefix = '', out = {}) {
+  if (!tree || typeof tree !== 'object') return out;
+  if (isLeaf(tree)) {
+    out[prefix] = JSON.stringify(tree.$value);
+    return out;
+  }
+  for (const [k, v] of Object.entries(tree)) {
+    if (k.startsWith('$')) continue;
+    const p = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object') flattenTokens(v, p, out);
+  }
+  return out;
+}
+
+// Set a dotted-path key to a (JSON-parsed) value on a nested object (leaf as DTCG $value).
+function setPath(root, dotted, jsonVal) {
+  const parts = dotted.split('.');
+  let cur = root;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const p = parts[i];
+    if (!cur[p] || typeof cur[p] !== 'object') cur[p] = {};
+    cur = cur[p];
+  }
+  cur[parts[parts.length - 1]] = { $value: JSON.parse(jsonVal) };
+}
+
+export function reconcileRoutes(routes) {
+  const safeRoutes = Array.isArray(routes) ? routes.filter(r => r && r.tokens) : [];
+  if (safeRoutes.length === 0) {
+    return {
+      shared: {},
+      perRoute: {},
+      summary: { routeCount: 0, sharedTokenCount: 0, totalUnique: 0, drift: [] },
+    };
+  }
+
+  // Flatten each route's tokens (combining primitive + semantic trees).
+  const flat = safeRoutes.map(r => {
+    const merged = {};
+    flattenTokens(r.tokens.primitive || {}, 'primitive', merged);
+    flattenTokens(r.tokens.semantic || {}, 'semantic', merged);
+    return { route: r, flat: merged };
+  });
+
+  // Build shared set: paths present across ALL routes with identical serialized value.
+  const firstKeys = Object.keys(flat[0].flat);
+  const sharedFlat = {};
+  for (const key of firstKeys) {
+    const v = flat[0].flat[key];
+    const allAgree = flat.every(f => f.flat[key] === v);
+    if (allAgree) sharedFlat[key] = v;
+  }
+
+  // Rebuild shared as DTCG tree.
+  const shared = {};
+  for (const [k, v] of Object.entries(sharedFlat)) setPath(shared, k, v);
+
+  // Per-route deltas.
+  const perRoute = {};
+  const usedSlugs = new Map();
+  const drift = [];
+  for (const { route, flat: f } of flat) {
+    let slug = slugForPath(route.path);
+    // Slug collision resolution.
+    if (usedSlugs.has(slug)) {
+      const n = usedSlugs.get(slug) + 1;
+      usedSlugs.set(slug, n);
+      slug = `${slug}-${n}`;
+    } else {
+      usedSlugs.set(slug, 1);
+    }
+
+    const added = {};
+    const changed = {};
+    for (const [k, v] of Object.entries(f)) {
+      if (!(k in sharedFlat)) {
+        // Not shared at all — either unique to this route or conflicts across routes.
+        // If the key exists in another route with a different value, it's a "changed" vs shared is not applicable;
+        // we classify as added when the token is absent from sharedFlat entirely.
+        const existsInOthers = flat.some(o => o.flat !== f && (k in o.flat));
+        if (!existsInOthers) {
+          setPath(added, k, v);
+        } else {
+          // Present in multiple routes but disagreeing values -> changed relative to the shared baseline.
+          setPath(changed, k, v);
+          drift.push({ path: route.path, token: k, value: JSON.parse(v) });
+        }
+      }
+    }
+    perRoute[slug] = { url: route.url, path: route.path, added, changed };
+  }
+
+  const allKeys = new Set();
+  for (const f of flat) for (const k of Object.keys(f.flat)) allKeys.add(k);
+
+  return {
+    shared,
+    perRoute,
+    summary: {
+      routeCount: safeRoutes.length,
+      sharedTokenCount: Object.keys(sharedFlat).length,
+      totalUnique: allKeys.size,
+      drift,
+    },
+  };
+}
+
+export function formatRoutesReport(reconciled) {
+  const { summary, perRoute } = reconciled;
+  const lines = [];
+  lines.push('# Multi-route Token Reconciliation');
+  lines.push('');
+  lines.push(`- Routes crawled: **${summary.routeCount}**`);
+  lines.push(`- Shared tokens: **${summary.sharedTokenCount}**`);
+  lines.push(`- Total unique tokens across routes: **${summary.totalUnique}**`);
+  lines.push(`- Cross-route drift entries: **${summary.drift.length}**`);
+  lines.push('');
+  lines.push('## Per-route contributions');
+  for (const [slug, entry] of Object.entries(perRoute)) {
+    const addedCount = countLeaves(entry.added);
+    const changedCount = countLeaves(entry.changed);
+    lines.push(`- \`${entry.path}\` (${slug}): ${addedCount} added, ${changedCount} changed`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+function countLeaves(tree) {
+  let n = 0;
+  const walk = (node) => {
+    if (!node || typeof node !== 'object') return;
+    if (isLeaf(node)) { n++; return; }
+    for (const [k, v] of Object.entries(node)) {
+      if (!k.startsWith('$')) walk(v);
+    }
+  };
+  walk(tree);
+  return n;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ import { extractModernCss } from './extractors/modern-css.js';
 import { extractWideGamut } from './extractors/wide-gamut.js';
 import { extractTokenSources } from './extractors/token-sources.js';
 import { extractInteractionStates } from './extractors/interaction-states.js';
+import { formatDtcgTokens } from './formatters/dtcg-tokens.js';
 
 function safeExtract(fn, ...args) {
   try { return fn(...args); } catch { return null; }
@@ -116,6 +117,23 @@ export async function extractDesignLanguage(url, options = {}) {
   } catch { /* non-fatal */ }
 
   design.tokenSources = safeExtract(extractTokenSources, design, styles) || [];
+
+  // Per-route token extraction (Tier 2 multi-page reconciliation).
+  if (Array.isArray(rawData.routes) && rawData.routes.length > 0) {
+    design.routes = rawData.routes.map(r => {
+      const rStyles = r.computedStylesSample || [];
+      const rDesign = {
+        meta: { url: r.url },
+        colors: safeExtract(extractColors, rStyles) || { all: [], neutrals: [], backgrounds: [], text: [], gradients: [] },
+        typography: safeExtract(extractTypography, rStyles) || { families: [], scale: [] },
+        spacing: safeExtract(extractSpacing, rStyles) || { scale: [], base: null },
+        shadows: safeExtract(extractShadows, rStyles) || { values: [] },
+        borders: safeExtract(extractBorders, rStyles) || { radii: [] },
+      };
+      const tokens = safeExtract(formatDtcgTokens, rDesign) || { primitive: {}, semantic: {} };
+      return { url: r.url, path: r.path, tokens };
+    });
+  }
 
   design.score = safeExtract(scoreDesignSystem, design);
   if (design.score === null) warnings.push('scoring failed');

--- a/tests/routes-reconciliation.test.js
+++ b/tests/routes-reconciliation.test.js
@@ -1,0 +1,120 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { reconcileRoutes, slugForPath, formatRoutesReport } from '../src/formatters/routes-reconciliation.js';
+
+function leaf(v) { return { $value: v, $type: 'color' }; }
+
+const baseTokens = {
+  primitive: {
+    color: {
+      brand: { primary: leaf('#ff0000'), secondary: leaf('#00ff00') },
+      neutral: { 100: leaf('#ffffff') },
+    },
+  },
+  semantic: {},
+};
+
+describe('slugForPath', () => {
+  it('treats / and empty as index', () => {
+    assert.equal(slugForPath('/'), 'index');
+    assert.equal(slugForPath(''), 'index');
+    assert.equal(slugForPath(null), 'index');
+  });
+  it('slugifies standard paths', () => {
+    assert.equal(slugForPath('/pricing'), 'pricing');
+    assert.equal(slugForPath('/docs/getting-started'), 'docs-getting-started');
+  });
+});
+
+describe('reconcileRoutes', () => {
+  it('returns empty-safe output for no routes', () => {
+    const r = reconcileRoutes([]);
+    assert.equal(r.summary.routeCount, 0);
+    assert.equal(r.summary.sharedTokenCount, 0);
+    assert.deepEqual(r.perRoute, {});
+  });
+
+  it('intersects identical tokens across routes into shared', () => {
+    const routes = [
+      { url: 'https://x.com/', path: '/', tokens: baseTokens },
+      { url: 'https://x.com/about', path: '/about', tokens: baseTokens },
+    ];
+    const r = reconcileRoutes(routes);
+    assert.equal(r.summary.routeCount, 2);
+    assert.ok(r.summary.sharedTokenCount >= 3);
+    // shared tree has the primitive.color.brand.primary leaf
+    assert.equal(r.shared.primitive.color.brand.primary.$value, '#ff0000');
+    // neither route should have "added" or "changed" entries
+    assert.deepEqual(r.perRoute.index.added, {});
+    assert.deepEqual(r.perRoute.index.changed, {});
+    assert.deepEqual(r.perRoute.about.added, {});
+  });
+
+  it('emits `added` tokens for a route that has unique tokens', () => {
+    const priceTokens = {
+      primitive: {
+        color: {
+          brand: { primary: leaf('#ff0000'), secondary: leaf('#00ff00') },
+          neutral: { 100: leaf('#ffffff') },
+          accent: { gold: leaf('#ffd700') }, // unique to /pricing
+        },
+      },
+      semantic: {},
+    };
+    const routes = [
+      { url: 'https://x.com/', path: '/', tokens: baseTokens },
+      { url: 'https://x.com/pricing', path: '/pricing', tokens: priceTokens },
+    ];
+    const r = reconcileRoutes(routes);
+    assert.equal(r.perRoute.pricing.added.primitive.color.accent.gold.$value, '#ffd700');
+    // The base route has no "added" since all its tokens are shared or absent.
+    assert.deepEqual(r.perRoute.index.added, {});
+  });
+
+  it('emits `changed` when a route overrides an otherwise-shared token value', () => {
+    const darkTokens = {
+      primitive: {
+        color: {
+          brand: { primary: leaf('#aa0000'), secondary: leaf('#00ff00') }, // primary differs
+          neutral: { 100: leaf('#ffffff') },
+        },
+      },
+      semantic: {},
+    };
+    const routes = [
+      { url: 'https://x.com/', path: '/', tokens: baseTokens },
+      { url: 'https://x.com/dark', path: '/dark', tokens: darkTokens },
+    ];
+    const r = reconcileRoutes(routes);
+    // primary shouldn't be shared because values disagree
+    assert.ok(!('primary' in (r.shared.primitive?.color?.brand || {})),
+      'disagreeing primary should not be shared');
+    // both routes should have primary in their `changed` bucket
+    assert.equal(r.perRoute.index.changed.primitive.color.brand.primary.$value, '#ff0000');
+    assert.equal(r.perRoute.dark.changed.primitive.color.brand.primary.$value, '#aa0000');
+    assert.ok(r.summary.drift.length >= 2);
+  });
+
+  it('resolves slug collisions by appending a numeric suffix', () => {
+    const routes = [
+      { url: 'https://x.com/docs/a', path: '/docs-a', tokens: baseTokens },
+      { url: 'https://x.com/docs-a/', path: '/docs-a', tokens: baseTokens },
+    ];
+    const r = reconcileRoutes(routes);
+    const slugs = Object.keys(r.perRoute);
+    assert.equal(slugs.length, 2);
+    assert.ok(slugs.includes('docs-a'));
+    assert.ok(slugs.some(s => s.startsWith('docs-a-')));
+  });
+
+  it('formatRoutesReport produces readable markdown', () => {
+    const routes = [
+      { url: 'https://x.com/', path: '/', tokens: baseTokens },
+      { url: 'https://x.com/pricing', path: '/pricing', tokens: baseTokens },
+    ];
+    const md = formatRoutesReport(reconcileRoutes(routes));
+    assert.match(md, /Routes crawled.*2/);
+    assert.match(md, /Shared tokens/);
+    assert.match(md, /pricing/);
+  });
+});


### PR DESCRIPTION
## Summary
- Crawler now attaches \`rawData.routes\` with per-page computedStyles samples when \`--depth >= 1\`.
- Orchestrator runs token extractors (colors, typography, spacing, shadows, borders) per route, attaching DTCG tokens to \`design.routes\`.
- New \`src/formatters/routes-reconciliation.js\` exports \`reconcileRoutes()\` and \`formatRoutesReport()\`.
- CLI emits three new files when \`--depth >= 1\`: \`*-tokens-shared.json\`, \`*-tokens-routes/<slug>.json\`, and \`*-routes-report.md\`.

## Test plan
- [x] \`node --test tests/*.test.js\` → 275 green (267 prior + 8 new)
- [x] Smoke: \`node bin/design-extract.js https://vercel.com --depth 3\` → 10 pages, 15 shared tokens, 70 total unique, per-route JSON + report produced.