### PR TITLE
fix: handle shadow objects missing .value in prompt formatter

### DIFF
--- a/src/formatters/prompt-pack.js
+++ b/src/formatters/prompt-pack.js
@@ -15,16 +15,16 @@ function typeFamilies(design) {
 
 function scaleSnippet(scale = []) {
   if (!scale.length) return '(not detected)';
-  return scale.slice(0, 8).map(s => (s.value || s) + (s.label ? ` (${s.label})` : '')).join(', ');
+  return scale.slice(0, 8).map(s => String(s.value ?? s) + (s.label ? ` (${s.label})` : '')).join(', ');
 }
 
 function radiiSnippet(borders) {
-  const r = (borders?.radii || []).slice(0, 6).map(x => (x.value || x).toString());
+  const r = (borders?.radii || []).slice(0, 6).map(x => String(x.value ?? x));
   return r.length ? r.join(', ') : '(none)';
 }
 
 function shadowSnippet(shadows) {
-  const s = (shadows?.values || []).slice(0, 3).map(x => (x.value || x).toString());
+  const s = (shadows?.values || []).slice(0, 3).map(x => String(x.raw ?? x.value ?? x));
   return s.length ? s.join(' | ') : '(none)';
 }
 
@@ -138,8 +138,8 @@ export function formatCursorPrompt(design) {
     'export const tokens = {',
     `  colors: [${b.colors.map(c => `'${c}'`).join(', ')}],`,
     `  fonts: [${b.fonts.map(f => `'${f}'`).join(', ')}],`,
-    `  radii: [${(design.borders?.radii || []).slice(0, 6).map(r => `'${(r.value || r)}'`).join(', ')}],`,
-    `  shadows: [${(design.shadows?.values || []).slice(0, 3).map(s => `'${(s.value || s).replace(/'/g, "\\'")}'`).join(', ')}],`,
+    `  radii: [${(design.borders?.radii || []).slice(0, 6).map(r => `'${String(r.value ?? r)}'`).join(', ')}],`,
+    `  shadows: [${(design.shadows?.values || []).slice(0, 3).map(s => `'${String(s.raw ?? s.value ?? s).replace(/'/g, "\\'")}'`).join(', ')}],`,
     '};',
     '```',
     '',

--- a/src/multipage.js
+++ b/src/multipage.js
@@ -127,11 +127,11 @@ function typeSet(typography) {
 }
 
 function spaceSet(spacing) {
-  return new Set(((spacing?.scale) || []).map(s => (s.value || s).toString()));
+  return new Set(((spacing?.scale) || []).map(s => String(s.value ?? s)));
 }
 
 function radiusSet(borders) {
-  return new Set(((borders?.radii) || []).map(r => (r.value || r).toString()));
+  return new Set(((borders?.radii) || []).map(r => String(r.value ?? r)));
 }
 
 export function computeCrossPageConsistency(pages) {


### PR DESCRIPTION
Shadow objects from extractShadows() use .raw instead of .value, causing "replace is not a function" when formatting Cursor prompts.

Use nullish coalescing (s.raw ?? s.value ?? s) with String() to safely coerce all token types across prompt-pack and multipage.

Fixes https://github.com/Manavarya09/design-extract/issues/41
Fixes https://github.com/Manavarya09/design-extract/issues/43