### PR TITLE
fix: resolve NaN values in Tailwind HSL color scale generation

### DIFF
--- a/src/formatters/tailwind.js
+++ b/src/formatters/tailwind.js
@@ -1,7 +1,7 @@
 import { rgbToHex, rgbToHsl } from '../utils.js';
 
 function generateColorScale(hex, parsed) {
-  const { h, s } = rgbToHsl(parsed);
+  const { h, s } = parsed.hsl ?? rgbToHsl(parsed.rgb);
   const scale = {};
   const levels = [
     { name: '50', l: 97 }, { name: '100', l: 94 }, { name: '200', l: 86 },


### PR DESCRIPTION
Fixes the issue where `tailwind.config.js` outputs `hsl(NaN, NaN%, ...)` for color shades.

The problem was that `generateColorScale` in `src/formatters/tailwind.js` called `rgbToHsl(parsed)` where `parsed` is the full color object `{ hex, rgb, hsl, count }` — not an `{ r, g, b }` object. The `rgbToHsl` function received `undefined` for r/g/b, producing NaN.

The `hsl` property is already pre-computed on the color object, so we can use it directly (falling back to `rgbToHsl(parsed.rgb)` for any color objects that lack it).

Fixes #44