### PR TITLE
fix(codeql): tighten host assertions + drop unused import

### DIFF
--- a/bin/design-extract.js
+++ b/bin/design-extract.js
@@ -43,7 +43,6 @@ import { syncDesign } from '../src/sync.js';
 import { compareBrands, formatBrandMatrix, formatBrandMatrixHtml } from '../src/multibrand.js';
 import { generateClone } from '../src/clone.js';
 import { watchSite } from '../src/watch.js';
-import { diffDarkMode } from '../src/darkdiff.js';
 import { applyDesign } from '../src/apply.js';
 import { formatGrade, formatGradeMarkdown } from '../src/formatters/grade.js';
 import { formatBattle, formatBattleMarkdown } from '../src/formatters/battle.js';

--- a/tests/formatters.test.js
+++ b/tests/formatters.test.js
@@ -720,7 +720,8 @@ describe('formatGrade', () => {
     assert.match(html, /<title>[^<]*Grade B[^<]*<\/title>/);
     assert.ok(html.includes('class="grade-letter">B<'), 'grade letter should be B');
     assert.ok(html.includes('85 / 100'), 'overall score should appear');
-    assert.ok(html.includes('example.com'), 'host should appear');
+    // Anchored within rendered markup; not a URL-origin check (CodeQL js/incomplete-url-substring-sanitization).
+    assert.match(html, />example\.com</, 'host should appear in rendered markup');
   });
 
   it('embeds evidence from the audited design (palette, type, dimensions)', () => {
@@ -800,8 +801,9 @@ describe('formatBattle', () => {
   it('returns a self-contained HTML document with both grades and a verdict', () => {
     const html = formatBattle(mockDesign, designB, { version: '12.2.0' });
     assert.ok(html.startsWith('<!doctype html>'), 'should be a complete HTML document');
-    assert.ok(html.includes('example.com'), 'host A must render');
-    assert.ok(html.includes('other.example.com'), 'host B must render');
+    // Anchored within rendered markup; not a URL-origin check (CodeQL js/incomplete-url-substring-sanitization).
+    assert.match(html, />example\.com</, 'host A must render in markup');
+    assert.match(html, />other\.example\.com</, 'host B must render in markup');
     assert.ok(html.includes('class="grade">B<'), 'grade A=B must render');
     assert.ok(html.includes('class="grade">C<'), 'grade B=C must render');
     assert.ok(/takes it\.|close.* to call/.test(html), 'must include a verdict line');


### PR DESCRIPTION
## Summary

Closes 4 CodeQL alerts on \`main\`:

| # | Severity | Rule | Location |
|---|---|---|---|
| #80, #81 | High | \`js/incomplete-url-substring-sanitization\` | tests/formatters.test.js:803-804 (battle tests, mine from #51) |
| #78 | High | \`js/incomplete-url-substring-sanitization\` | tests/formatters.test.js:723 (grade tests, from v12.1) |
| #79 | Note | \`js/unused-local-variable\` | bin/design-extract.js:46 (\`diffDarkMode\`) |

The "incomplete URL substring sanitization" alerts are CodeQL false positives — the patterns are **test assertions**, not URL validators. But the same patterns *are* dangerous in real validators, so swapping \`html.includes('example.com')\` → \`html.match(/>example\.com</)\` is both:
- A tighter assertion (anchored inside rendered markup)
- A way to silence the rule by demonstrating intent

The \`diffDarkMode\` import was dead — the CLI uses \`diffDesigns\` from \`src/diff.js\`.

## Out of scope

Skipped pre-existing alerts to keep this PR surgical:
- #70, #71 — file-system race conditions in \`src/sync.js\` / \`src/studio.js\` (need careful review)
- #72-77 — other unused imports (separate cleanup pass)

## Test plan

- [x] \`npm test\` — 336/336 still passing
- [x] Manual: \`node bin/design-extract.js diff stripe.com vercel.com\` works without \`diffDarkMode\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)