### PR TITLE
chore(codeql): remove 8 unused imports across src + tests

### DIFF
--- a/src/formatters/css-vars.js
+++ b/src/formatters/css-vars.js
@@ -1,5 +1,3 @@
-import { pxToRem } from '../utils.js';
-
 export function formatCssVars(design) {
   const lines = [':root {'];
 

--- a/src/formatters/tailwind.js
+++ b/src/formatters/tailwind.js
@@ -1,4 +1,4 @@
-import { rgbToHex, rgbToHsl } from '../utils.js';
+import { rgbToHsl } from '../utils.js';
 
 function generateColorScale(hex, parsed) {
   const { h, s } = parsed.hsl ?? rgbToHsl(parsed.rgb);

--- a/src/formatters/vue-theme.js
+++ b/src/formatters/vue-theme.js
@@ -1,5 +1,3 @@
-import { rgbToHsl } from '../utils.js';
-
 export function formatVueTheme(design) {
   const { colors, typography, spacing, borders, shadows } = design;
   const lines = [];

--- a/src/history.js
+++ b/src/history.js
@@ -1,6 +1,6 @@
 // Historical tracking — save and compare design snapshots over time
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ import { extractWideGamut } from './extractors/wide-gamut.js';
 import { extractTokenSources } from './extractors/token-sources.js';
 import { extractInteractionStates } from './extractors/interaction-states.js';
 import { extractMotion } from './extractors/motion.js';
-import { extractComponentAnatomy, formatAnatomyStubs } from './extractors/component-anatomy.js';
+import { extractComponentAnatomy } from './extractors/component-anatomy.js';
 import { extractVoice } from './extractors/voice.js';
 import { extractPageIntent } from './extractors/page-intent.js';
 import { extractSectionRoles } from './extractors/section-roles.js';
@@ -39,7 +39,6 @@ import { extractBackgroundPatterns } from './extractors/background-patterns.js';
 import { extractStackIntel } from './extractors/stack-intel.js';
 import { extractFormStates } from './extractors/form-states.js';
 import { formatDtcgTokens } from './formatters/dtcg-tokens.js';
-import { formatMotionTokens } from './formatters/motion-tokens.js';
 
 function safeExtract(fn, ...args) {
   try { return fn(...args); } catch { return null; }

--- a/src/sync.js
+++ b/src/sync.js
@@ -5,7 +5,7 @@ import { formatTokens } from './formatters/tokens.js';
 import { formatTailwind } from './formatters/tailwind.js';
 import { formatCssVars } from './formatters/css-vars.js';
 import { saveSnapshot, getHistory } from './history.js';
-import { writeFileSync, readFileSync, statSync } from 'fs';
+import { writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 // Race-safe "update only if file exists" — statSync inside try/catch

--- a/src/visual-diff.js
+++ b/src/visual-diff.js
@@ -7,7 +7,6 @@ import { extractDesignLanguage } from './index.js';
 import { diffDesigns } from './diff.js';
 import { nameFromUrl } from './utils.js';
 import { statSync, existsSync, readFileSync } from 'fs';
-import { basename } from 'path';
 
 function fileKb(p) {
   try { return Math.round(statSync(p).size / 1024); } catch { return 0; }

--- a/tests/wide-gamut.test.js
+++ b/tests/wide-gamut.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { oklchToSrgb, oklabToSrgb, oklchLikeToHex, parseOklchOrOklab, rgbToHex } from '../src/utils/color-gamut.js';
+import { oklchLikeToHex, parseOklchOrOklab, rgbToHex } from '../src/utils/color-gamut.js';
 import { extractWideGamut } from '../src/extractors/wide-gamut.js';
 import { extractTokenSources } from '../src/extractors/token-sources.js';
 


### PR DESCRIPTION
## Summary

Closes 8 CodeQL \`js/unused-local-variable\` alerts. All changes are pure
import-list trims — no runtime behavior changes.

| # | File | Removed |
|---|---|---|
| #72 | \`src/history.js\` | \`existsSync\` |
| #73 | \`src/sync.js\` | \`readFileSync\` |
| #62 | \`src/visual-diff.js\` | \`basename\` |
| #57 | \`src/index.js\` | \`formatAnatomyStubs\` (still re-exported on line 201) |
| #58 | \`src/index.js\` | \`formatMotionTokens\` (still re-exported on line 200) |
| #54 | \`src/formatters/tailwind.js\` | \`rgbToHex\` |
| #55 | \`src/formatters/vue-theme.js\` | \`rgbToHsl\` |
| #52 | \`src/formatters/css-vars.js\` | \`pxToRem\` |
| #64 | \`tests/wide-gamut.test.js\` | \`oklchToSrgb\`, \`oklabToSrgb\` |

## Out of scope (intentionally)

- **Unused *functions*** (#61, #66–#69, #76–#77): may be internal API surface; need per-call review.
- **File-system race conditions** (#70 src/sync.js, #71 src/studio.js): real bugs — need a dedicated atomic-write pass, not a one-line fix.
- **Unused vars in HeroExtractor** (#74, #75): React component state — need to verify they're truly dead, not WIP.

## Test plan

- [x] \`npm test\` — 336/336 pass
- [x] All touched modules import-load cleanly via \`node -e \"import('./…')\"\`
- [x] grep verified: none of the removed names had call sites in their source file
- [x] Cross-checked re-exports for src/index.js — \`formatMotionTokens\` and \`formatAnatomyStubs\` are still exported via \`export { … } from '…'\` on lines 200–201

🤖 Generated with [Claude Code](https://claude.com/claude-code)