### PR TITLE
fix: guard extractDesignLanguage() call sites against blast-radius failures

### DIFF
--- a/src/ci.js
+++ b/src/ci.js
@@ -34,7 +34,18 @@ export async function runCi(url, opts) {
 
   // 1. Extract
   const { extractDesignLanguage } = await import('./index.js');
-  const design = await extractDesignLanguage(url);
+  let design;
+  try {
+    design = await extractDesignLanguage(url);
+  } catch (err) {
+    out.push(section('Extraction', `_failed — ${err.message}_`));
+    const md = out.join('\n');
+    const mdPath = join(outDir, 'ci-report.md');
+    writeFileSync(mdPath, md, 'utf-8');
+    const summary = { url, score: null, grade: null, driftVerdict: 'unknown', timestamp: new Date().toISOString() };
+    writeFileSync(join(outDir, 'ci-summary.json'), JSON.stringify(summary, null, 2), 'utf-8');
+    return { mdPath, md, summary, shouldFail: true };
+  }
 
   // 2. Score block
   if (design.score) {

--- a/src/drift.js
+++ b/src/drift.js
@@ -66,7 +66,12 @@ function findNearest(value, palette) {
 
 export async function checkDrift(url, { tokens: tokensFile, tolerance = 8, options = {} } = {}) {
   const local = loadLocalTokens(tokensFile);
-  const design = await extractDesignLanguage(url, options);
+  let design;
+  try {
+    design = await extractDesignLanguage(url, options);
+  } catch (err) {
+    throw new Error(`Extraction failed for ${url}: ${err.message}`);
+  }
   const livePalette = design.colors?.all || [];
 
   const drifted = [];

--- a/src/visual-diff.js
+++ b/src/visual-diff.js
@@ -22,7 +22,12 @@ function toDataUri(p) {
 
 async function captureFor(url, options = {}) {
   const raw = await crawlPage(url, { ...options, screenshots: true });
-  const design = await extractDesignLanguage(url, { ...options, screenshots: true });
+  let design;
+  try {
+    design = await extractDesignLanguage(url, { ...options, screenshots: true });
+  } catch (err) {
+    throw new Error(`Extraction failed for ${url}: ${err.message}`);
+  }
   return { raw, design };
 }
 


### PR DESCRIPTION
## What this fixes

`extractDesignLanguage()` is called bare (no try/catch) in three places:
- `src/ci.js:37`
- `src/drift.js:69`
- `src/visual-diff.js:25`

If the function throws (browser crash, network timeout, bad URL), all three surfaces die with a raw unhandled error and produce no output. `route.js` already had a try/catch — these three did not.

## Changes

**ci.js** — extraction failure now writes a partial CI report with an `### Extraction — failed` section and returns `shouldFail: true` instead of throwing. The report file still gets written so CI artifacts aren't empty.

**drift.js** — rethrows with URL context: `"Extraction failed for <url>: <message>"` so the CI catch block and CLI handler both get actionable output.

**visual-diff.js** — same pattern in `captureFor()`. Each side now fails with a clear message instead of a raw browser/network stack trace.

## Why it matters

These three all feed into CI pipelines where silent/partial failures are especially painful. A Playwright crash on a flaky network shouldn't produce a blank CI report with exit code 1 and no explanation.

No behavior changes on the happy path — only failure handling improves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)