### PR TITLE
feat(extractor): share-on-X + copy-link buttons after a successful extraction

### DIFF
--- a/website/app/components/HeroExtractor.js
+++ b/website/app/components/HeroExtractor.js
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Marginalia from './Marginalia';
 import ResultViewer from './ResultViewer';
+import ShareExtractionButton from './ShareExtractionButton';
 
 const STAGE_LABEL = {
   crawl: 'walking DOM',
@@ -344,6 +345,16 @@ export default function HeroExtractor() {
           onDownloadZip={handleDownload}
           downloadBusy={downloadBusy}
         />
+      )}
+
+      {status === 'done' && (
+        <div style={{ marginTop: 18, paddingTop: 14, borderTop: '1px solid var(--hairline)' }}>
+          <ShareExtractionButton
+            url={inputRef.current?.value || ''}
+            hash={typeof window !== 'undefined' ? window.location.pathname.match(/^\/x\/([\w-]+)/)?.[1] : null}
+            summary={summary}
+          />
+        </div>
       )}
 
       <style jsx>{`

--- a/website/app/components/ShareExtractionButton.js
+++ b/website/app/components/ShareExtractionButton.js
@@ -1,0 +1,36 @@
+'use client';
+
+import { useState } from 'react';
+
+const SITE = 'https://designlang.app';
+
+export default function ShareExtractionButton({ url, hash, summary }) {
+  const [done, setDone] = useState(null); // 'copy' | 'tweet' | null
+
+  const permalink = hash ? `${SITE}/x/${hash}` : `${SITE}/#extract`;
+  const host = (() => { try { return new URL(url).hostname.replace(/^www\./, ''); } catch { return 'a website'; } })();
+  const tokens = summary?.colors ?? '?';
+  const grade = summary?.score?.grade || '—';
+  const text = `extracted ${host} with designlang — ${tokens} tokens, grade ${grade}`;
+
+  function tweet() {
+    const intent = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(permalink)}`;
+    window.open(intent, '_blank', 'noopener,noreferrer');
+    setDone('tweet'); setTimeout(() => setDone(null), 1500);
+  }
+
+  async function copyLink() {
+    try { await navigator.clipboard.writeText(permalink); setDone('copy'); setTimeout(() => setDone(null), 1500); } catch { /* noop */ }
+  }
+
+  return (
+    <div className="share-row">
+      <button type="button" className="btn btn-ghost btn-sm" onClick={tweet}>
+        {done === 'tweet' ? 'opened…' : 'Share on X'}
+      </button>
+      <button type="button" className="btn btn-ghost btn-sm" onClick={copyLink}>
+        {done === 'copy' ? 'copied!' : 'Copy link'}
+      </button>
+    </div>
+  );
+}

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -588,6 +588,12 @@ code, pre, kbd { font-family: var(--ff-mono); font-size: 13px; }
 @keyframes spin { to { transform: rotate(360deg); } }
 .spin { animation: spin 1s linear infinite; }
 
+/* ── Share row (post-extraction CTA) ─────────────────────────── */
+
+.share-row {
+  display: flex; gap: 10px; flex-wrap: wrap; align-items: center;
+}
+
 /* ── Copyable command (hero) ─────────────────────────────────── */
 
 .copycmd {


### PR DESCRIPTION
Adds a small row of CTAs that appears in the live extractor as soon as status === 'done':

- **Share on X** — opens an X intent with a pre-composed post (`extracted <host> with designlang — N tokens, grade X`) and the permalink.
- **Copy link** — copies the `/x/<hash>` permalink (or `/#extract` if not yet hashed).

Tiny new component: `app/components/ShareExtractionButton.js` (+ a one-line `.share-row` style). Wired into `HeroExtractor` only — no other surface changes.

Why: turns every browser extraction into a viral artifact. First lever from the post-v12.12 strategy doc.