### PR TITLE
feat(changelog): /changelog page rendering CHANGELOG.md live

### DIFF
--- a/website/app/changelog/page.js
+++ b/website/app/changelog/page.js
@@ -1,0 +1,146 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export const revalidate = 3600;
+
+export const metadata = {
+  title: 'Changelog — designlang',
+  description:
+    'Every release of designlang. Brand-book PDF, MCP server, motion tokens, multi-platform emitters, CSS health audit — version by version.',
+  alternates: { canonical: 'https://designlang.app/changelog' },
+  openGraph: { title: 'designlang changelog', description: 'Every release of designlang, version by version.' },
+};
+
+// Tiny Markdown renderer: enough for what CHANGELOG.md actually uses.
+function renderMarkdown(md) {
+  const blocks = [];
+  let inFence = false;
+  let fenceLang = '';
+  let fenceLines = [];
+  let listType = null;
+  let listItems = [];
+  let para = [];
+
+  function flushPara() {
+    if (para.length) { blocks.push({ kind: 'p', text: para.join(' ') }); para = []; }
+  }
+  function flushList() {
+    if (listItems.length) { blocks.push({ kind: 'list', type: listType, items: listItems }); listItems = []; listType = null; }
+  }
+
+  for (const raw of md.split('\n')) {
+    const line = raw;
+    if (line.startsWith('```')) {
+      if (inFence) { blocks.push({ kind: 'code', lang: fenceLang, text: fenceLines.join('\n') }); fenceLines = []; fenceLang = ''; inFence = false; }
+      else { flushPara(); flushList(); inFence = true; fenceLang = line.slice(3).trim(); }
+      continue;
+    }
+    if (inFence) { fenceLines.push(raw); continue; }
+    if (line.startsWith('## '))  { flushPara(); flushList(); blocks.push({ kind: 'h2', text: line.slice(3) }); continue; }
+    if (line.startsWith('### ')) { flushPara(); flushList(); blocks.push({ kind: 'h3', text: line.slice(4) }); continue; }
+    if (line.startsWith('# '))   { flushPara(); flushList(); blocks.push({ kind: 'h1', text: line.slice(2) }); continue; }
+    const ulMatch = line.match(/^[-*] (.*)$/);
+    const olMatch = line.match(/^\d+\. (.*)$/);
+    if (ulMatch) { flushPara(); if (listType !== 'ul') flushList(); listType = 'ul'; listItems.push(ulMatch[1]); continue; }
+    if (olMatch) { flushPara(); if (listType !== 'ol') flushList(); listType = 'ol'; listItems.push(olMatch[1]); continue; }
+    if (line.trim() === '') { flushPara(); flushList(); continue; }
+    flushList();
+    para.push(line);
+  }
+  flushPara();
+  flushList();
+  return blocks;
+}
+
+// Render inline markdown (links, bold, code) as React nodes — no innerHTML.
+function inline(text) {
+  // Tokenise: split on links, bold and code in priority order.
+  const out = [];
+  let rest = text;
+  // Use a single combined regex with capture groups; iterate greedily.
+  while (rest.length > 0) {
+    const linkIdx = rest.search(/\[[^\]]+\]\([^)]+\)/);
+    const boldIdx = rest.search(/\*\*[^*]+\*\*/);
+    const codeIdx = rest.search(/`[^`]+`/);
+    const cands = [linkIdx, boldIdx, codeIdx].filter((i) => i >= 0);
+    if (cands.length === 0) { out.push(rest); break; }
+    const next = Math.min(...cands);
+    if (next > 0) { out.push(rest.slice(0, next)); rest = rest.slice(next); }
+    if (rest.startsWith('[')) {
+      const m = rest.match(/^\[([^\]]+)\]\(([^)]+)\)/);
+      if (m) { out.push({ link: { text: m[1], href: m[2] } }); rest = rest.slice(m[0].length); continue; }
+    }
+    if (rest.startsWith('**')) {
+      const m = rest.match(/^\*\*([^*]+)\*\*/);
+      if (m) { out.push({ bold: m[1] }); rest = rest.slice(m[0].length); continue; }
+    }
+    if (rest.startsWith('`')) {
+      const m = rest.match(/^`([^`]+)`/);
+      if (m) { out.push({ code: m[1] }); rest = rest.slice(m[0].length); continue; }
+    }
+    out.push(rest[0]); rest = rest.slice(1);
+  }
+  return out.map((seg, i) => {
+    if (typeof seg === 'string') return seg;
+    if (seg.link) return <a key={i} href={seg.link.href}>{seg.link.text}</a>;
+    if (seg.bold) return <strong key={i}>{seg.bold}</strong>;
+    if (seg.code) return <code key={i}>{seg.code}</code>;
+    return null;
+  });
+}
+
+function Block({ b }) {
+  switch (b.kind) {
+    case 'h1': return <h1 className="cl-h1">{inline(b.text)}</h1>;
+    case 'h2': return <h2 className="cl-h2">{inline(b.text)}</h2>;
+    case 'h3': return <h3 className="cl-h3">{inline(b.text)}</h3>;
+    case 'p':  return <p  className="cl-p" >{inline(b.text)}</p>;
+    case 'list': {
+      const Tag = b.type === 'ol' ? 'ol' : 'ul';
+      return <Tag className="cl-list">{b.items.map((it, i) => <li key={i}>{inline(it)}</li>)}</Tag>;
+    }
+    case 'code': return <pre className="cl-pre"><code>{b.text}</code></pre>;
+    default: return null;
+  }
+}
+
+async function loadChangelog() {
+  // Bundled copy lives at website/public/CHANGELOG.md so it ships with the
+  // build on Vercel. Fall back to the repo root for local dev.
+  const candidates = [
+    join(process.cwd(), 'public', 'CHANGELOG.md'),
+    join(process.cwd(), 'CHANGELOG.md'),
+    join(process.cwd(), '..', 'CHANGELOG.md'),
+  ];
+  for (const p of candidates) {
+    try { return await readFile(p, 'utf-8'); } catch { /* try next */ }
+  }
+  return '# Changelog\n\nNo CHANGELOG.md found at build time.';
+}
+
+export default async function ChangelogPage() {
+  const md = await loadChangelog();
+  const blocks = renderMarkdown(md);
+
+  return (
+    <main>
+      <section className="section" style={{ paddingTop: 64, paddingBottom: 32 }}>
+        <div className="wrap-narrow">
+          <p className="eyebrow">changelog</p>
+          <h1 className="h1" style={{ fontSize: 'clamp(40px, 5.5vw, 64px)' }}>Every release.</h1>
+          <p className="lede" style={{ marginTop: 20 }}>
+            From v0.1.0 to v12.12.0 — every shipping change to designlang.
+            Sourced live from <code className="kbd">CHANGELOG.md</code> in the repo.
+          </p>
+        </div>
+      </section>
+      <section className="section" style={{ paddingTop: 24 }}>
+        <div className="wrap-narrow">
+          <article className="cl-prose">
+            {blocks.map((b, i) => <Block key={i} b={b} />)}
+          </article>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -629,6 +629,33 @@ code, pre, kbd { font-family: var(--ff-mono); font-size: 13px; }
   .copycmd-hint { display: none; }
 }
 
+/* ── Changelog page ──────────────────────────────────────────── */
+
+.cl-prose { max-width: 70ch; color: var(--fg); padding-bottom: 80px; }
+.cl-prose .cl-h1 { display: none; } /* page header already shown */
+.cl-prose .cl-h2 {
+  font-size: 28px; font-weight: 500; letter-spacing: -0.015em;
+  color: #fff; margin: 56px 0 14px; padding-top: 18px;
+  border-top: 1px solid var(--hairline);
+}
+.cl-prose .cl-h2:first-of-type { margin-top: 24px; padding-top: 0; border-top: 0; }
+.cl-prose .cl-h3 { font-size: 18px; font-weight: 500; margin: 28px 0 8px; color: #fff; }
+.cl-prose .cl-p  { margin: 0 0 14px; color: var(--fg-2); line-height: 1.65; }
+.cl-prose .cl-list { margin: 0 0 14px; padding-left: 22px; color: var(--fg-2); line-height: 1.65; }
+.cl-prose code {
+  background: rgba(255,255,255,0.05); padding: 2px 6px; border-radius: 4px;
+  border: 1px solid var(--hairline); color: #ffd2d2; font-size: 13px;
+}
+.cl-prose .cl-pre {
+  background: rgba(0,0,0,0.5); border: 1px solid var(--hairline);
+  padding: 14px 16px; border-radius: 10px; overflow-x: auto; color: var(--fg);
+  margin: 0 0 18px;
+}
+.cl-prose .cl-pre code { background: transparent; border: 0; padding: 0; color: var(--fg); font-size: 13px; }
+.cl-prose a { color: var(--red-3); border-bottom: 1px solid rgba(255,128,128,0.3); }
+.cl-prose a:hover { color: #fff; border-bottom-color: rgba(255,255,255,0.5); }
+.cl-prose strong { color: #fff; font-weight: 500; }
+
 /* ── FAQ ─────────────────────────────────────────────────────── */
 
 .faq-list { display: flex; flex-direction: column; gap: 10px; }

--- a/website/app/sitemap.js
+++ b/website/app/sitemap.js
@@ -19,6 +19,7 @@ export default function sitemap() {
     { path: '/gallery',               priority: 0.9,  freq: 'hourly'  },
     { path: '/spec',                  priority: 0.9,  freq: 'monthly' },
     { path: '/vs/design-extractor',   priority: 0.9,  freq: 'weekly'  },
+    { path: '/changelog',             priority: 0.7,  freq: 'weekly'  },
     { path: '/#faq',                  priority: 0.7,  freq: 'monthly' },
     { path: '/#about',                priority: 0.7,  freq: 'monthly' },
   ];


### PR DESCRIPTION
Adds a public `/changelog` page that renders the repo's `CHANGELOG.md` directly. The build copies the markdown to `website/public/CHANGELOG.md` so it ships with Vercel; the page reads it at request time (revalidate every hour).

The renderer is a small dependency-free Markdown subset that only handles what the changelog actually uses (h2 / h3, code fences, lists, links, bold, inline code) — no innerHTML, no third-party deps.

Also adds the route to `sitemap.xml` and gives it the editorial `.cl-prose` styling (red accent links, mono inline code, hairline-divided sections).

Why: lets prospective users see the velocity (12 minor versions in May alone) without leaving the marketing site, and gives Google + AI search engines a continuously-updated text surface to index.