### PR TITLE
feat(copy): use CopyCmd component on /features and /vs pages

### DIFF
--- a/website/app/features/page.js
+++ b/website/app/features/page.js
@@ -1,3 +1,5 @@
+import CopyCmd from '../components/CopyCmd';
+
 export const metadata = {
   title: 'Features — designlang',
   description:
@@ -98,7 +100,7 @@ export default function Features() {
             <h2 className="h2" style={{ fontSize: 28 }}>One command.</h2>
             <p className="lede" style={{ margin: '0 auto 20px' }}>Every output above lands in <code className="kbd">./design-extract-output</code> in seconds.</p>
             <div className="row" style={{ justifyContent: 'center', flexWrap: 'wrap' }}>
-              <code className="kbd" style={{ fontSize: 13, padding: '8px 14px' }}>npx designlang stripe.com</code>
+              <CopyCmd cmd="npx designlang stripe.com" hint="" />
               <a href="/" className="btn btn-primary">Try it live</a>
             </div>
           </div>

--- a/website/app/vs/design-extractor/page.js
+++ b/website/app/vs/design-extractor/page.js
@@ -1,3 +1,5 @@
+import CopyCmd from '../../components/CopyCmd';
+
 export const metadata = {
   title: 'designlang vs design-extractor.com — honest comparison',
   description:
@@ -86,7 +88,7 @@ export default function Vs() {
               No signup, no API key. The whole CLI lives behind <code className="kbd">npx</code>.
             </p>
             <div className="row" style={{ justifyContent: 'center', flexWrap: 'wrap' }}>
-              <code className="kbd" style={{ fontSize: 13, padding: '8px 14px' }}>npx designlang stripe.com</code>
+              <CopyCmd cmd="npx designlang stripe.com" hint="" />
               <a href="/" className="btn btn-primary">Try it live</a>
             </div>
           </div>


### PR DESCRIPTION
Replaces the static `<code class="kbd">npx designlang stripe.com</code>` snippets at the bottom of `/features` and `/vs/design-extractor` with the `CopyCmd` button (the same one that already lives in the hero). One click copies the command to the clipboard.

Tiny PR — two import lines + two snippet swaps. Makes every "try it now" CTA on the marketing site actually one-click copyable instead of select-and-copy.