### PR TITLE
feat(landing): rebuild 'what's inside' as bento with live mini visuals

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -416,6 +416,193 @@ code, pre, kbd { font-family: var(--ff-mono); font-size: 13px; }
 .feature h3 { font-size: 17px; font-weight: 500; margin: 4px 0 0; color: #fff; line-height: 1.3; }
 .feature p { margin: 0; color: var(--fg-2); font-size: 14px; line-height: 1.55; }
 
+/* ── Bento "what's inside" section ───────────────────────────── */
+
+.bento-section { padding-bottom: 64px; }
+.bento-head { max-width: 720px; margin: 0 auto 36px; text-align: center; }
+.bento-head .h2 { margin: 0 auto 12px; }
+.bento-head .lede { margin: 0 auto 22px; }
+.bento-stats {
+  display: inline-flex; flex-wrap: wrap; gap: 14px; align-items: center; justify-content: center;
+  font-size: 12px; color: var(--fg-3);
+  padding: 10px 18px; border-radius: 999px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--hairline);
+}
+.bento-stats strong { color: #fff; font-weight: 600; margin-right: 4px; }
+.bento-sep { opacity: 0.4; }
+
+.bento {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 18px;
+}
+.bento-hero { grid-column: span 6; }
+.bento-2    { grid-column: span 3; }
+.bento-3    { grid-column: span 2; }
+
+@media (max-width: 980px) {
+  .bento-hero, .bento-2 { grid-column: span 6; }
+  .bento-3 { grid-column: span 3; }
+}
+@media (max-width: 640px) {
+  .bento-3 { grid-column: span 6; }
+}
+
+.bento-card {
+  position: relative;
+  display: flex; flex-direction: column; gap: 14px;
+  padding: 24px 26px;
+  background: var(--surface-2);
+  border: 1px solid var(--hairline);
+  border-radius: 18px;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  overflow: hidden;
+  transition: border-color .15s ease, transform .15s ease;
+}
+.bento-card:hover { border-color: rgba(239,68,68,0.45); transform: translateY(-2px); }
+.bento-card h3 { font-size: 18px; font-weight: 500; color: #fff; line-height: 1.3; margin: 4px 0 0; }
+.bento-card p  { font-size: 14px; color: var(--fg-2); line-height: 1.55; margin: 0; }
+
+.bento-hero {
+  display: grid; grid-template-columns: minmax(0, 0.95fr) minmax(0, 1fr);
+  gap: 32px; padding: 32px 36px; align-items: center;
+}
+.bento-hero h3 { font-size: 26px; letter-spacing: -0.015em; }
+.bento-hero p  { font-size: 15px; max-width: 42ch; }
+.bento-hero .bento-card-text { display: flex; flex-direction: column; gap: 12px; }
+
+@media (max-width: 760px) {
+  .bento-hero { grid-template-columns: 1fr; padding: 26px 24px; }
+}
+
+.bento-2 { padding: 26px 28px; }
+.bento-2 h3 { font-size: 20px; letter-spacing: -0.01em; }
+.bento-2 .bento-card-viz { margin-top: auto; padding-top: 16px; }
+
+.bento-3 .bento-card-viz { margin-top: auto; padding-top: 14px; }
+
+/* === DTCG tree viz === */
+.dtcg-tree {
+  background: rgba(0,0,0,0.4);
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  padding: 16px 18px;
+  font-family: var(--ff-mono); font-size: 11.5px;
+  color: var(--fg-2); line-height: 1.6;
+}
+.dtcg-row { display: flex; align-items: center; gap: 8px; }
+.dtcg-indent  { padding-left: 14px; color: var(--fg-3); }
+.dtcg-indent2 { padding-left: 28px; color: var(--fg-3); }
+.dtcg-key   { color: #ffd2d2; flex: 0 0 auto; }
+.dtcg-val   { color: var(--fg-3); margin-left: auto; }
+.dtcg-swatch{ width: 12px; height: 12px; border-radius: 3px; flex: 0 0 auto; box-shadow: inset 0 0 0 1px rgba(255,255,255,0.1); }
+.dtcg-bar   { height: 4px; background: var(--fg-2); border-radius: 999px; flex: 0 0 auto; }
+
+/* === platforms grid === */
+.bento-platforms {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 6px;
+}
+.platform-chip {
+  display: flex; align-items: center; justify-content: center;
+  height: 36px; border-radius: 8px;
+  font-family: var(--ff-mono); font-size: 11px; color: #fff;
+  letter-spacing: 0.02em;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.12), 0 4px 12px -4px rgba(0,0,0,0.4);
+  transition: transform .12s ease;
+}
+.platform-chip:hover { transform: translateY(-1px) scale(1.04); }
+
+/* === MCP snippet === */
+.mcp-snippet {
+  background: rgba(0,0,0,0.5);
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  padding: 14px 16px;
+  font-family: var(--ff-mono); font-size: 11.5px; line-height: 1.55;
+  color: var(--fg); margin: 0;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+/* === a11y pair === */
+.a11y-pair { display: flex; align-items: center; gap: 8px; }
+.a11y-tile {
+  flex: 1; display: flex; flex-direction: column; gap: 4px;
+  padding: 12px 14px; border-radius: 10px;
+}
+.a11y-aa    { font-size: 22px; font-weight: 500; line-height: 1; }
+.a11y-ratio { font-family: var(--ff-mono); font-size: 10px; opacity: 0.85; }
+.a11y-arrow { color: var(--fg-3); font-family: var(--ff-mono); }
+.a11y-fail .a11y-aa { opacity: 0.6; }
+
+/* === voice quote === */
+.voice-quote {
+  margin: 0;
+  padding: 14px 16px;
+  background: rgba(0,0,0,0.35);
+  border-left: 3px solid var(--red-2);
+  border-radius: 0 10px 10px 0;
+  font-style: italic; font-size: 14px; color: #fff;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.voice-meta {
+  font-style: normal; font-family: var(--ff-mono); font-size: 10px;
+  letter-spacing: 0.08em; color: var(--fg-3); text-transform: uppercase;
+}
+
+/* === PDF cover === */
+.pdf-cover {
+  position: relative; aspect-ratio: 4 / 3;
+  background: #f5f1eb; color: #1a1a1a;
+  border-radius: 6px;
+  display: flex; flex-direction: column; justify-content: flex-end;
+  padding: 14px 16px;
+  box-shadow: 0 14px 30px -10px rgba(0,0,0,0.6);
+  overflow: hidden;
+}
+.pdf-cover-band { position: absolute; left: 0; right: 0; top: 0; height: 38%; background: var(--red-2); }
+.pdf-cover-title { position: relative; font-size: 24px; font-weight: 500; color: #1a1a1a; line-height: 1; }
+.pdf-cover-meta  { font-size: 10px; opacity: 0.55; margin-top: 4px; }
+
+/* === health bars === */
+.health-bars { display: flex; flex-direction: column; gap: 8px; }
+.health-row {
+  display: grid; grid-template-columns: 80px 1fr 28px;
+  gap: 10px; align-items: center;
+  font-size: 11px;
+}
+.health-label { color: var(--fg-3); text-transform: uppercase; letter-spacing: 0.1em; }
+.health-bar   { height: 6px; background: rgba(255,255,255,0.06); border-radius: 999px; overflow: hidden; }
+.health-bar span { display: block; height: 100%; border-radius: 999px; transition: width .3s ease; }
+.health-num   { color: #fff; font-weight: 600; text-align: right; }
+
+/* === dual themes === */
+.dual-themes { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+.theme-tile {
+  padding: 12px 14px;
+  border-radius: 10px;
+  display: flex; flex-direction: column; gap: 8px;
+  font-family: var(--ff-mono); font-size: 10px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+}
+.theme-light { background: #f6f6f6; color: #1a1a1a; }
+.theme-dark  { background: #0a0a0a; color: #f6f6f6; box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08); }
+.theme-swatches { display: flex; gap: 4px; }
+.theme-swatches i { display: block; width: 16px; height: 16px; border-radius: 4px; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1); }
+
+/* === CI log === */
+.ci-log {
+  background: rgba(0,0,0,0.5);
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  padding: 12px 14px;
+  font-size: 11.5px; line-height: 1.7; color: var(--fg-2);
+}
+.ci-log .ci-pass { color: #86efac; margin-right: 8px; font-weight: 600; }
+.ci-log .ci-warn { color: #fde68a; margin-right: 8px; font-weight: 600; }
+
 /* ── Reddit marquee (auto-scrolling 3-col) ───────────────────── */
 
 .rdt-section { padding-bottom: 80px; }

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -167,24 +167,189 @@ function ExtractSection() {
 
 function FeaturesSection() {
   return (
-    <section className="section">
+    <section className="section bento-section">
       <div className="wrap">
-        <p className="eyebrow">what&rsquo;s inside</p>
-        <h2 className="h2">Everything you would build by hand.</h2>
-        <p className="lede" style={{ marginBottom: 36 }}>
-          Nine extractors, eight emitters, one design system. No paid tier. No API keys.
-        </p>
-        <div className="grid-3">
-          {FEATURES.map(f => (
-            <article key={f.title} className="feature">
-              <span className="feature-tag">{f.tag}</span>
-              <h3>{f.title}</h3>
-              <p>{f.body}</p>
-            </article>
-          ))}
+        <header className="bento-head">
+          <p className="eyebrow">what&rsquo;s inside</p>
+          <h2 className="h2">Everything you would build by hand.</h2>
+          <p className="lede">
+            Nine extractors, eleven emitters, one design system — for the open web, every native runtime, and your AI editor.
+          </p>
+          <div className="bento-stats mono">
+            <span><strong>26</strong> capabilities</span>
+            <span className="bento-sep">/</span>
+            <span><strong>11</strong> output formats</span>
+            <span className="bento-sep">/</span>
+            <span><strong>3</strong> MCP-aware editors</span>
+            <span className="bento-sep">/</span>
+            <span><strong>$0</strong> · MIT</span>
+          </div>
+        </header>
+
+        <div className="bento">
+          {/* Row 1: hero card (DTCG, full width) */}
+          <article className="bento-card bento-hero">
+            <div className="bento-card-text">
+              <span className="feature-tag">tokens</span>
+              <h3>W3C DTCG tokens, fully linked.</h3>
+              <p>
+                Primitive · semantic · composite. Drop-in for Tailwind, CSS vars, Figma variables,
+                shadcn theme, and React / Vue / Svelte. Reads from the live DOM — the names match
+                what your designers actually shipped.
+              </p>
+            </div>
+            <div className="bento-card-viz" aria-hidden>
+              <div className="dtcg-tree">
+                <div className="dtcg-row"><span className="dtcg-key">primitive.color.brand.500</span><span className="dtcg-swatch" style={{ background: '#dc2626' }} /><span className="dtcg-val">#dc2626</span></div>
+                <div className="dtcg-row dtcg-indent"><span className="dtcg-key">↳ semantic.color.action.primary</span><span className="dtcg-swatch" style={{ background: '#dc2626' }} /><span className="dtcg-val">{'{primitive.color.brand.500}'}</span></div>
+                <div className="dtcg-row dtcg-indent2"><span className="dtcg-key">↳ button.solid.background</span><span className="dtcg-swatch" style={{ background: '#dc2626' }} /><span className="dtcg-val">{'{semantic.color.action.primary}'}</span></div>
+                <div className="dtcg-row" style={{ marginTop: 10 }}><span className="dtcg-key">primitive.spacing.4</span><span className="dtcg-bar" style={{ width: 16 }} /><span className="dtcg-val">16px</span></div>
+                <div className="dtcg-row dtcg-indent"><span className="dtcg-key">↳ semantic.spacing.gutter</span><span className="dtcg-bar" style={{ width: 16 }} /><span className="dtcg-val">{'{primitive.spacing.4}'}</span></div>
+              </div>
+            </div>
+          </article>
+
+          {/* Row 2: two big cards */}
+          <article className="bento-card bento-2">
+            <div className="bento-card-text">
+              <span className="feature-tag">multi-platform</span>
+              <h3>One run, eleven outputs.</h3>
+              <p>iOS SwiftUI, Android Compose, Flutter Dart, WordPress block theme, plus every web format. No second tool.</p>
+            </div>
+            <div className="bento-card-viz bento-platforms" aria-hidden>
+              {[
+                ['Tail',     '#06b6d4'],
+                ['CSS',      '#264de4'],
+                ['shadcn',   '#0f172a'],
+                ['Figma',    '#a259ff'],
+                ['React',    '#61dafb'],
+                ['Vue',      '#42b883'],
+                ['Svelte',   '#ff3e00'],
+                ['iOS',      '#0071e3'],
+                ['Android',  '#3ddc84'],
+                ['Flutter',  '#02569b'],
+                ['WP',       '#21759b'],
+                ['PDF',      '#dc2626'],
+              ].map(([label, color]) => (
+                <span key={label} className="platform-chip" style={{ background: color }}>{label}</span>
+              ))}
+            </div>
+          </article>
+
+          <article className="bento-card bento-2">
+            <div className="bento-card-text">
+              <span className="feature-tag">mcp</span>
+              <h3>Lives inside your editor.</h3>
+              <p>Stdio MCP for Claude Code, Cursor, Windsurf. Plus auto-generated AGENTS.md / .cursorrules / Claude skills.</p>
+            </div>
+            <div className="bento-card-viz" aria-hidden>
+              <pre className="mcp-snippet">
+                <span className="tok-com">{'# .claude/mcp.json'}</span>{'\n'}
+                <span className="tok-pun">{'{'}</span>{'\n'}
+                {'  '}<span className="tok-key">{'"designlang"'}</span>: <span className="tok-pun">{'{'}</span>{'\n'}
+                {'    '}<span className="tok-key">{'"command"'}</span>: <span className="tok-str">{'"npx"'}</span>,{'\n'}
+                {'    '}<span className="tok-key">{'"args"'}</span>: <span className="tok-str">{'["designlang","mcp"]'}</span>{'\n'}
+                {'  '}<span className="tok-pun">{'}'}</span>{'\n'}
+                <span className="tok-pun">{'}'}</span>
+              </pre>
+            </div>
+          </article>
+
+          {/* Row 3: three small cards */}
+          <article className="bento-card bento-3">
+            <span className="feature-tag">a11y</span>
+            <h3>WCAG remediation.</h3>
+            <p>The smallest hue-shift that passes AA. Not just a red badge.</p>
+            <div className="bento-card-viz" aria-hidden>
+              <div className="a11y-pair">
+                <div className="a11y-tile a11y-fail" style={{ background: '#7f1d1d', color: '#a06868' }}>
+                  <span className="a11y-aa">Aa</span>
+                  <span className="a11y-ratio">2.1 · fail</span>
+                </div>
+                <span className="a11y-arrow">→</span>
+                <div className="a11y-tile a11y-pass" style={{ background: '#7f1d1d', color: '#ffffff' }}>
+                  <span className="a11y-aa">Aa</span>
+                  <span className="a11y-ratio">7.4 · AA</span>
+                </div>
+              </div>
+            </div>
+          </article>
+
+          <article className="bento-card bento-3">
+            <span className="feature-tag">voice</span>
+            <h3>Real CTAs, real headlines.</h3>
+            <p>The brand voice extracted from the page itself — not Lorem ipsum.</p>
+            <div className="bento-card-viz" aria-hidden>
+              <blockquote className="voice-quote">
+                &ldquo;Make payments your competitive advantage.&rdquo;
+                <span className="voice-meta">— headline · stripe.com</span>
+              </blockquote>
+            </div>
+          </article>
+
+          <article className="bento-card bento-3">
+            <span className="feature-tag">pdf</span>
+            <h3>Brand books, native PDF.</h3>
+            <p>13 chapters, page bookmarks, running footer, tokens attached.</p>
+            <div className="bento-card-viz" aria-hidden>
+              <div className="pdf-cover">
+                <div className="pdf-cover-band" />
+                <div className="pdf-cover-title">Stripe</div>
+                <div className="pdf-cover-meta mono">v1.0 · 13 chapters</div>
+              </div>
+            </div>
+          </article>
+
+          {/* Row 4: three small cards */}
+          <article className="bento-card bento-3">
+            <span className="feature-tag">css health</span>
+            <h3>CSS health audit.</h3>
+            <p>Specificity, dead rules, duplicates. Fix what AI agents trip over.</p>
+            <div className="bento-card-viz" aria-hidden>
+              <div className="health-bars">
+                <div className="health-row"><span className="health-label mono">specificity</span><span className="health-bar"><span style={{ width: '78%', background: '#fde68a' }} /></span><span className="health-num mono">B+</span></div>
+                <div className="health-row"><span className="health-label mono">dead rules</span><span className="health-bar"><span style={{ width: '92%', background: '#86efac' }} /></span><span className="health-num mono">A</span></div>
+                <div className="health-row"><span className="health-label mono">duplicates</span><span className="health-bar"><span style={{ width: '64%', background: '#fdba74' }} /></span><span className="health-num mono">B−</span></div>
+              </div>
+            </div>
+          </article>
+
+          <article className="bento-card bento-3">
+            <span className="feature-tag">dark mode</span>
+            <h3>Dual extraction.</h3>
+            <p>Walks both themes, diffs them, emits one set of paired tokens.</p>
+            <div className="bento-card-viz" aria-hidden>
+              <div className="dual-themes">
+                <div className="theme-tile theme-light">
+                  <span className="mono">light</span>
+                  <span className="theme-swatches"><i style={{ background: '#fafafa' }} /><i style={{ background: '#171717' }} /><i style={{ background: '#dc2626' }} /></span>
+                </div>
+                <div className="theme-tile theme-dark">
+                  <span className="mono">dark</span>
+                  <span className="theme-swatches"><i style={{ background: '#0a0a0a' }} /><i style={{ background: '#fafafa' }} /><i style={{ background: '#ff5757' }} /></span>
+                </div>
+              </div>
+            </div>
+          </article>
+
+          <article className="bento-card bento-3">
+            <span className="feature-tag">ci</span>
+            <h3>Drift CI bot.</h3>
+            <p>Snapshot your tokens. Fail the build when the live system silently moves.</p>
+            <div className="bento-card-viz" aria-hidden>
+              <div className="ci-log mono">
+                <div><span className="ci-pass">✓</span> 47 tokens · in sync</div>
+                <div><span className="ci-warn">!</span> 1 hue shift · accent</div>
+                <div><span className="ci-pass">✓</span> all checks passing</div>
+              </div>
+            </div>
+          </article>
         </div>
-        <div style={{ marginTop: 28 }}>
-          <a href="/features" className="btn btn-ghost">All features</a>
+
+        <div style={{ marginTop: 32, display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+          <a href="/features" className="btn btn-primary">See all 26 capabilities</a>
+          <a href="/blog/mcp-launch" className="btn btn-ghost">Wire it into your editor</a>
+          <span className="mono faint" style={{ fontSize: 12, marginLeft: 'auto' }}>nothing above is paywalled</span>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Replaces the flat 3×3 grid of text cards with a proper bento layout where every card has a small live visual proof of what the feature does:

- **Hero card** (full width, 6 cols): W3C DTCG tokens with a real DTCG token-tree (primitive → semantic → composite, with linked references and an inline spacing bar)
- **Multi-platform** (3 cols): a 3×4 grid of 12 colour-correct platform chips (Tailwind cyan, Figma purple, Vue green, iOS blue, Spotify-style green for Android, etc.)
- **MCP** (3 cols): a syntax-highlighted `.claude/mcp.json` snippet
- **WCAG** (2 cols): two side-by-side `Aa` tiles showing fail (2.1, faded) → pass (7.4, AA-coloured) with an arrow
- **Voice** (2 cols): an italic blockquote with a real Stripe headline and meta caption
- **PDF** (2 cols): a mini PDF cover with extracted-primary red band + brand title + chapter count
- **CSS health** (2 cols): three labelled drift-bars (specificity B+, dead rules A, duplicates B−) with the standard A11y-grade colour ramp
- **Dark mode** (2 cols): paired light/dark theme tiles with 3-swatch palettes each
- **CI** (2 cols): a terminal-style log with green ✓ and amber ! status glyphs

Section header upgraded:
- Centered eyebrow + h2 + lede
- New stats strip pill: `26 capabilities / 11 output formats / 3 MCP-aware editors / $0 · MIT`

Bento grid is responsive: 6 cols → 6 cols (hero/medium full-width on tablet) → 6 cols stacked single column (mobile <640px).

Bottom CTA row split into a primary 'See all 26 capabilities', a secondary 'Wire it into your editor' that links to the new MCP launch post (PR #92), and a right-aligned mono caveat 'nothing above is paywalled'.