### PR TITLE
feat(chrome): drop version chip in nav + version/PDF pills in hero

### DIFF
--- a/website/app/layout.js
+++ b/website/app/layout.js
@@ -104,7 +104,6 @@ async function Nav() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src="/brand-mark.svg" alt="" className="nav-mark-img" width={26} height={26} />
           <span className="nav-wordmark">designlang</span>
-          <span className="nav-version mono">v12.12</span>
         </a>
 
         <nav className="nav-pillnav" aria-label="primary">

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -72,10 +72,6 @@ function Hero() {
       <div className="wrap">
         <div className="hero-grid">
           <div>
-            <div className="hero-pills">
-              <span className="pill pill-red">v12.12.0</span>
-              <span className="pill">PDF brand books</span>
-            </div>
             <h1 className="h1">
               Reverse-engineer<br />
               any website&rsquo;s<br />


### PR DESCRIPTION
Removes three pieces of chrome the user found redundant:
- The `v12.12` chip in the nav brand block (left of the wordmark)
- The `v12.12.0` pill in the hero
- The `PDF brand books` pill in the hero

Hero now leads straight with the H1. Nav brand is just the mark + wordmark.