### PR TITLE
feat(seo): aggressive 'design-extractor.com alternative' targeting

### DIFF
--- a/website/app/seo-config.js
+++ b/website/app/seo-config.js
@@ -3,15 +3,16 @@ export const SITE_NAME = 'designlang';
 export const TWITTER = '@manavaryasingh';
 
 export const SITE_TITLE =
-  "designlang — Extract any website's design system: DTCG tokens, Tailwind, Figma, MCP, iOS, Android, Flutter, WordPress";
+  "designlang — Open-source design extractor (design-extractor.com alternative). Tokens, Tailwind, Figma, MCP, iOS, Android, Flutter, WordPress.";
 
 export const SITE_DESCRIPTION =
-  'designlang is the open-source CLI that reverse-engineers any URL into a complete design system in seconds. ' +
-  'One command emits W3C DTCG tokens (primitive · semantic · composite), Tailwind config, CSS variables, Figma variables, shadcn/ui theme, ' +
+  'designlang is the open-source design extractor that turns any URL into a complete design system in seconds. ' +
+  'A free, MIT-licensed alternative to design-extractor.com — same DESIGN.md output, no signup, scriptable CLI, ' +
+  'plus W3C DTCG tokens (primitive · semantic · composite), Tailwind config, CSS variables, Figma variables, shadcn/ui theme, ' +
   'React / Vue / Svelte themes, iOS SwiftUI, Android Jetpack Compose, Flutter, WordPress block themes, and a print-ready brand-book PDF. ' +
   'Ships a stdio MCP server for Claude Code, Cursor, and Windsurf, plus auto-generated AGENTS.md / .cursorrules for AI agents. ' +
   'Includes a CSS health audit, WCAG contrast remediation, semantic region classifier, reusable component clustering, dark-mode pairing, ' +
-  'and a CI drift bot. Free, MIT-licensed, no signup. 2,500+ stars on GitHub.';
+  'and a CI drift bot. 2,500+ stars on GitHub.';
 
 export const SITE_KEYWORDS = [
   // Primary product terms
@@ -43,7 +44,17 @@ export const SITE_KEYWORDS = [
   // Tooling adjacency / alternatives
   'style dictionary alternative', 'tokens studio alternative', 'subframe alternative', 'v0 alternative',
   'builder.io alternative', 'project wallace alternative', 'supernova alternative', 'specify alternative',
-  'design-extractor.com alternative', 'design-extractor alternative',
+  'dembrandt alternative', 'html.to.design alternative',
+  // design-extractor.com — every search variant we want to outrank
+  'design-extractor.com', 'design-extractor.com alternative', 'design-extractor.com vs designlang',
+  'design extractor', 'design extractor alternative', 'design extractor open source', 'design extractor cli',
+  'design extractor free', 'design extractor without signup', 'design extractor no signup',
+  'design extractor github', 'design extractor npm', 'design extractor mcp',
+  'design extractor with PDF', 'design extractor with Tailwind', 'design extractor for Cursor',
+  'design extractor for Claude Code', 'design extractor figma',
+  'best design extractor', 'free design extractor cli', 'open source design extractor 2026',
+  'extract design system from url free', 'extract DESIGN.md from website', 'auto generate DESIGN.md',
+  'designextractor', 'design-extractor com',
   // CI / studio
   'design regression CI', 'design drift CI', 'design system CI', 'token drift detection',
   'website to Storybook', 'website to Next.js', 'clone website design', 'one click website clone',

--- a/website/app/vs/design-extractor/page.js
+++ b/website/app/vs/design-extractor/page.js
@@ -1,12 +1,24 @@
 import CopyCmd from '../../components/CopyCmd';
 
 export const metadata = {
-  title: 'designlang vs design-extractor.com — honest comparison',
+  title: 'designlang vs design-extractor.com — best free, open-source design extractor (2026)',
   description:
-    'design-extractor.com ships a DESIGN.md. designlang ships the design system — DESIGN.md plus DTCG tokens, multi-platform emitters, anatomy, voice, motion, drift CI, clone, studio, MCP and a Figma plugin.',
+    'designlang vs design-extractor.com: an honest feature-by-feature comparison. designlang is the free, MIT, open-source design extractor that ships DESIGN.md plus DTCG tokens, Tailwind config, Figma variables, multi-platform emitters (iOS, Android, Flutter, WordPress), brand-book PDF, MCP server for Claude Code / Cursor / Windsurf, drift CI, clone command, and a local studio — without any signup. design-extractor.com is hosted, gated, and ships a single DESIGN.md.',
+  alternates: { canonical: 'https://designlang.app/vs/design-extractor' },
+  keywords: [
+    'designlang vs design-extractor.com',
+    'design-extractor.com alternative',
+    'design extractor alternative',
+    'open source design extractor',
+    'free design extractor',
+    'best design extractor 2026',
+    'design extractor cli',
+    'design-extractor.com vs designlang',
+    'designextractor alternative',
+  ],
   openGraph: {
-    title: 'designlang vs design-extractor.com',
-    description: 'They sell the spec. We ship the system. Honest feature comparison.',
+    title: 'designlang vs design-extractor.com — the open-source alternative',
+    description: 'They sell the spec. designlang ships the system. Honest feature comparison + free CLI.',
   },
 };
 


### PR DESCRIPTION
Goal: when somebody searches `design-extractor`, `design-extractor.com`, `design extractor cli`, `open source design extractor`, `design-extractor alternative`, etc. — designlang shows up.

What changed:

**`seo-config.js`**
- Site title rewritten to lead with **"Open-source design extractor (design-extractor.com alternative)"**.
- Site description rewritten to lead with the alternative claim and explicitly name design-extractor.com.
- 25+ new keyword variants added: `design-extractor.com`, `design-extractor.com alternative`, `design-extractor.com vs designlang`, `design extractor cli`, `design extractor open source`, `design extractor with PDF`, `design extractor for Cursor`, `design extractor for Claude Code`, `extract DESIGN.md from website`, `auto generate DESIGN.md`, `designextractor`, `design-extractor com`, etc.

**`/vs/design-extractor` metadata**
- Title bumped to "designlang vs design-extractor.com — best free, open-source design extractor (2026)"
- Description rewritten as a self-contained AI-Overview-citable answer to "what's the best design extractor".
- Explicit `keywords` array with the targeted phrases.
- Canonical URL set.