### PR TITLE
feat(gallery): /gallery/[slug] per-brand page (beats design-extractor.com layout)

### DIFF
--- a/website/app/gallery/[slug]/GalleryTabs.js
+++ b/website/app/gallery/[slug]/GalleryTabs.js
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function GalleryTabs({ host, slug, designMd, tailwindCfg, cssVars, tokensJson }) {
+  const TABS = [
+    { id: 'design',   label: 'DESIGN.md',         body: designMd,    lang: 'markdown' },
+    { id: 'tokens',   label: 'design-tokens.json', body: tokensJson, lang: 'json'     },
+    { id: 'tailwind', label: 'tailwind.config.js', body: tailwindCfg, lang: 'js'       },
+    { id: 'css',      label: 'variables.css',      body: cssVars,    lang: 'css'      },
+  ].filter(t => t.body);
+
+  const [active, setActive] = useState(TABS[0]?.id);
+  const [copied, setCopied] = useState(false);
+  const tab = TABS.find(t => t.id === active) || TABS[0];
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(tab.body || '');
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    } catch { /* noop */ }
+  }
+
+  return (
+    <div className="gb-source">
+      <div className="gb-source-head">
+        <div className="gb-source-tabs" role="tablist" aria-label="View">
+          {TABS.map(t => (
+            <button
+              key={t.id}
+              role="tab"
+              aria-selected={active === t.id}
+              className={`gb-source-tab ${active === t.id ? 'is-active' : ''}`}
+              onClick={() => setActive(t.id)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <div className="gb-source-actions">
+          <span className="mono faint" style={{ fontSize: 11 }}>{(tab?.body || '').length.toLocaleString()} chars</span>
+          <button type="button" className="gb-copy" onClick={copy}>{copied ? 'copied!' : 'copy'}</button>
+          <a href={`/gallery/${slug}/brand.html`} target="_blank" rel="noreferrer" className="gb-copy gb-pdf">brand book ↗</a>
+        </div>
+      </div>
+      <pre className="gb-source-body">{tab?.body || ''}</pre>
+    </div>
+  );
+}

--- a/website/app/gallery/[slug]/page.js
+++ b/website/app/gallery/[slug]/page.js
@@ -1,0 +1,341 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { notFound } from 'next/navigation';
+import GalleryTabs from './GalleryTabs';
+
+export const revalidate = 86400;
+export const dynamic = 'force-static';
+
+const FEATURED = {
+  'stripe-com':  { host: 'stripe.com'  },
+  'linear-app':  { host: 'linear.app'  },
+  'vercel-com':  { host: 'vercel.com'  },
+  'notion-so':   { host: 'notion.so'   },
+  'figma-com':   { host: 'figma.com'   },
+  'apple-com':   { host: 'apple.com'   },
+  'arc-net':     { host: 'arc.net'     },
+  'spotify-com': { host: 'spotify.com' },
+};
+
+export function generateStaticParams() {
+  return Object.keys(FEATURED).map((slug) => ({ slug }));
+}
+
+function galleryDirs(slug) {
+  // Cover every plausible cwd: Vercel build (website), local dev started from
+  // the website folder, and dev started from the repo root or one level up.
+  return [
+    join(process.cwd(), 'public', 'gallery', slug),
+    join(process.cwd(), 'website', 'public', 'gallery', slug),
+    join(process.cwd(), 'design-extract', 'website', 'public', 'gallery', slug),
+  ];
+}
+
+async function findFile(slug, suffix) {
+  for (const d of galleryDirs(slug)) {
+    try {
+      const files = await readdir(d);
+      const hit = files.find((f) => f.endsWith(suffix));
+      if (hit) return await readFile(join(d, hit), 'utf-8');
+    } catch { /* try next */ }
+  }
+  return null;
+}
+
+export async function generateMetadata({ params }) {
+  const { slug } = await params;
+  const meta = FEATURED[slug];
+  if (!meta) return { title: 'Brand not found — designlang' };
+  const host = meta.host;
+  return {
+    title: `${host} design system — extracted by designlang`,
+    description: `${host} design system: every colour, font, spacing token, shadow, radius, motion curve, anatomy and brand voice — extracted with one command. DTCG tokens, Tailwind config, Figma variables, brand-book PDF, all on one page. The open-source alternative to design-extractor.com.`,
+    alternates: { canonical: `https://designlang.app/gallery/${slug}` },
+    openGraph: {
+      title: `${host} design system — designlang`,
+      description: `Real extraction of ${host}: tokens, typography, spacing, motion, anatomy, voice, brand-book PDF.`,
+    },
+  };
+}
+
+function pickPalette(tokens) {
+  // Walk the DTCG tree and pick all primitive colour leafs.
+  const out = [];
+  const walk = (node, path) => {
+    if (!node || typeof node !== 'object') return;
+    if (node.$value && node.$type === 'color' && typeof node.$value === 'string' && node.$value.startsWith('#')) {
+      out.push({ path, hex: node.$value });
+      return;
+    }
+    for (const k of Object.keys(node)) {
+      if (k.startsWith('$')) continue;
+      walk(node[k], path ? `${path}.${k}` : k);
+    }
+  };
+  walk(tokens?.primitive?.color, 'primitive.color');
+  // dedupe by hex
+  const seen = new Set();
+  return out.filter(({ hex }) => {
+    const k = hex.toLowerCase();
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  }).slice(0, 18);
+}
+
+function pickRadii(tokens) {
+  const out = [];
+  const walk = (node, path) => {
+    if (!node || typeof node !== 'object') return;
+    if (node.$value !== undefined && (node.$type === 'dimension' || node.$type === undefined)) {
+      out.push({ path, value: String(node.$value) });
+      return;
+    }
+    for (const k of Object.keys(node)) { if (!k.startsWith('$')) walk(node[k], path ? `${path}.${k}` : k); }
+  };
+  walk(tokens?.primitive?.radius, '');
+  return out;
+}
+
+function pickSpacing(tokens) {
+  const out = [];
+  const walk = (node, path) => {
+    if (!node || typeof node !== 'object') return;
+    if (node.$value !== undefined) { out.push({ path, value: String(node.$value) }); return; }
+    for (const k of Object.keys(node)) { if (!k.startsWith('$')) walk(node[k], path ? `${path}.${k}` : k); }
+  };
+  walk(tokens?.primitive?.spacing, '');
+  return out.slice(0, 12);
+}
+
+function pickFont(tokens) {
+  const f = tokens?.primitive?.fontFamily;
+  if (!f) return null;
+  for (const k of Object.keys(f || {})) {
+    if (f[k]?.$value) return { name: k, value: f[k].$value };
+  }
+  return null;
+}
+
+export default async function GalleryBrandPage({ params }) {
+  const { slug } = await params;
+  const meta = FEATURED[slug];
+  if (!meta) notFound();
+
+  const [tokensRaw, designMd, voiceRaw, motionRaw, intentRaw, tailwindCfg, cssVars] = await Promise.all([
+    findFile(slug, '-design-tokens.json'),
+    findFile(slug, '-DESIGN.md'),
+    findFile(slug, '-voice.json'),
+    findFile(slug, '-motion-tokens.json'),
+    findFile(slug, '-intent.json'),
+    findFile(slug, '-tailwind.config.js'),
+    findFile(slug, '-variables.css'),
+  ]);
+
+  const tokens = tokensRaw ? JSON.parse(tokensRaw) : null;
+  const voice  = voiceRaw  ? JSON.parse(voiceRaw)  : null;
+  const motion = motionRaw ? JSON.parse(motionRaw) : null;
+  const intent = intentRaw ? JSON.parse(intentRaw) : null;
+
+  const palette = pickPalette(tokens);
+  const radii   = pickRadii(tokens);
+  const spacing = pickSpacing(tokens);
+  const font    = pickFont(tokens);
+
+  const host = meta.host;
+  const url = `https://${host}`;
+  const primary = palette[0]?.hex || '#7f1d1d';
+  const accent  = palette[1]?.hex || '#dc2626';
+
+  return (
+    <main>
+      {/* Hero with extracted-brand-tinted gradient */}
+      <section className="gb-hero">
+        <div
+          className="gb-hero-bg"
+          aria-hidden
+          style={{ background: `linear-gradient(135deg, ${primary} 0%, ${accent} 60%, #050505 100%)` }}
+        />
+        <div className="wrap gb-hero-inner">
+          <a href="/gallery" className="gb-back mono">← Gallery</a>
+          <div className="gb-hero-row">
+            <div className="gb-hero-logo">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={`https://icon.horse/icon/${host}`} alt="" width={72} height={72} />
+            </div>
+            <div className="gb-hero-text">
+              <p className="eyebrow" style={{ marginBottom: 8 }}>extracted · {new Date().toISOString().slice(0, 10)}</p>
+              <h1 className="h1 gb-hero-h1">{host}</h1>
+              <p className="lede" style={{ marginTop: 10 }}>
+                Live extraction of{' '}
+                <a href={url} target="_blank" rel="noreferrer" style={{ color: 'var(--red-3)' }}>{url}</a>{' '}
+                — every colour, font, spacing token, shadow, radius, motion curve, anatomy and brand voice. Generated with one command.
+              </p>
+              <div className="row" style={{ marginTop: 20, gap: 10, flexWrap: 'wrap' }}>
+                <a href={`/gallery/${slug}/brand.html`} target="_blank" rel="noreferrer" className="btn btn-primary">Open brand book ↗</a>
+                <a href="#tokens" className="btn btn-ghost">Browse tokens</a>
+                <a href={`/api/extract`} className="btn btn-ghost" style={{ display: 'none' }}>Re-extract</a>
+              </div>
+            </div>
+            <div className="gb-hero-stats">
+              {intent?.intent && <div className="gb-stat"><span className="gb-stat-num">{intent.intent}</span><span className="gb-stat-label">intent</span></div>}
+              {intent?.material && <div className="gb-stat"><span className="gb-stat-num">{intent.material}</span><span className="gb-stat-label">material</span></div>}
+              <div className="gb-stat"><span className="gb-stat-num">{palette.length}</span><span className="gb-stat-label">colors</span></div>
+              {font && <div className="gb-stat"><span className="gb-stat-num" style={{ fontFamily: `${font.value}, system-ui` }}>Aa</span><span className="gb-stat-label">{font.name}</span></div>}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Two-column body: palette + tabbed code */}
+      <section className="section gb-body" id="tokens">
+        <div className="wrap gb-grid">
+          {/* Left: palette + radii + spacing */}
+          <aside className="gb-side">
+            <header className="gb-side-head">
+              <h2 className="h3" style={{ margin: 0 }}>Palette</h2>
+              <span className="mono faint" style={{ fontSize: 11 }}>{palette.length} colors</span>
+            </header>
+            <div className="gb-swatches">
+              {palette.map((c, i) => (
+                <div key={c.hex + i} className="gb-swatch" title={c.path}>
+                  <div className="gb-swatch-chip" style={{ background: c.hex }} />
+                  <div className="gb-swatch-meta">
+                    <span className="mono">color-{i + 1}</span>
+                    <span className="mono faint">{c.hex}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {radii.length > 0 && (
+              <>
+                <header className="gb-side-head" style={{ marginTop: 28 }}>
+                  <h2 className="h3" style={{ margin: 0 }}>Radii</h2>
+                  <span className="mono faint" style={{ fontSize: 11 }}>{radii.length} steps</span>
+                </header>
+                <div className="gb-radii">
+                  {radii.map((r, i) => {
+                    const px = parseFloat(r.value) || 0;
+                    return (
+                      <div key={i} className="gb-radius">
+                        <div className="gb-radius-tile" style={{ borderRadius: Math.min(px, 32) }} />
+                        <span className="mono">{r.path.split('.').pop()}</span>
+                        <span className="mono faint">{r.value}px</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+
+            {spacing.length > 0 && (
+              <>
+                <header className="gb-side-head" style={{ marginTop: 28 }}>
+                  <h2 className="h3" style={{ margin: 0 }}>Spacing</h2>
+                  <span className="mono faint" style={{ fontSize: 11 }}>{spacing.length} steps</span>
+                </header>
+                <div className="gb-spacing">
+                  {spacing.map((s, i) => {
+                    const px = parseFloat(s.value) || 0;
+                    return (
+                      <div key={i} className="gb-spacing-row">
+                        <span className="mono" style={{ width: 80, color: 'var(--fg-3)' }}>{s.path.split('.').pop()}</span>
+                        <span className="gb-spacing-bar" style={{ width: Math.min(px * 2, 220), background: primary }} />
+                        <span className="mono faint" style={{ width: 50, textAlign: 'right' }}>{s.value}px</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+          </aside>
+
+          {/* Right: tabbed source viewer (client) */}
+          <div className="gb-main">
+            <GalleryTabs
+              host={host}
+              slug={slug}
+              designMd={designMd || ''}
+              tailwindCfg={tailwindCfg || ''}
+              cssVars={cssVars || ''}
+              tokensJson={tokensRaw || ''}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Typography */}
+      {font && (
+        <section className="section gb-typo" style={{ paddingTop: 32 }}>
+          <div className="wrap">
+            <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 22, flexWrap: 'wrap', gap: 10 }}>
+              <h2 className="h2" style={{ fontSize: 28, margin: 0 }}>Typography</h2>
+              <span className="mono faint" style={{ fontSize: 12 }}>{font.value}</span>
+            </header>
+            <div className="card" style={{ padding: '32px 36px' }}>
+              {[
+                { size: 56, weight: 600, lh: 1.05, label: 'display · 56px / 600' },
+                { size: 36, weight: 500, lh: 1.15, label: 'headline · 36px / 500' },
+                { size: 22, weight: 400, lh: 1.35, label: 'subhead · 22px / 400' },
+                { size: 16, weight: 400, lh: 1.55, label: 'body · 16px / 400' },
+                { size: 12, weight: 500, lh: 1.4,  label: 'caption · 12px / 500 · uppercase', upper: true },
+              ].map((row, i) => (
+                <div key={i} style={{ display: 'flex', alignItems: 'baseline', gap: 24, padding: '14px 0', borderBottom: '1px solid var(--hairline)' }}>
+                  <div style={{ fontFamily: `${font.value}, system-ui, sans-serif`, fontSize: row.size, fontWeight: row.weight, lineHeight: row.lh, color: '#fff', letterSpacing: row.size > 30 ? '-0.02em' : 'normal', textTransform: row.upper ? 'uppercase' : 'none' }}>
+                    The quick brown fox jumps
+                  </div>
+                  <span className="mono faint" style={{ fontSize: 11, marginLeft: 'auto', whiteSpace: 'nowrap' }}>{row.label}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Voice */}
+      {Array.isArray(voice?.headlines) && voice.headlines.length > 0 && (
+        <section className="section" style={{ paddingTop: 32 }}>
+          <div className="wrap">
+            <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>Voice</h2>
+            <p className="lede" style={{ marginBottom: 22 }}>Real headlines pulled from the live page.</p>
+            <div className="grid-3">
+              {voice.headlines.slice(0, 6).map((q, i) => (
+                <blockquote key={i} className="voice-quote" style={{ borderLeftColor: primary, fontSize: 16 }}>
+                  &ldquo;{String(q).slice(0, 160)}&rdquo;
+                </blockquote>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Motion */}
+      {motion && (
+        <section className="section" style={{ paddingTop: 32 }}>
+          <div className="wrap">
+            <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>Motion</h2>
+            <p className="lede" style={{ marginBottom: 22 }}>Durations and easing curves captured live.</p>
+            <pre className="mcp-snippet" style={{ maxWidth: 760 }}>{JSON.stringify(motion, null, 2).slice(0, 1200)}</pre>
+          </div>
+        </section>
+      )}
+
+      {/* Bottom CTA */}
+      <section className="section">
+        <div className="wrap" style={{ display: 'flex', justifyContent: 'center' }}>
+          <div className="card" style={{ maxWidth: 720, width: '100%', padding: '32px 32px', textAlign: 'center' }}>
+            <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>Run designlang on your own URL.</h2>
+            <p className="lede" style={{ margin: '0 auto 18px' }}>
+              Same depth as the {host} extraction above. No signup, no API key.
+            </p>
+            <div className="row" style={{ justifyContent: 'center', flexWrap: 'wrap' }}>
+              <code className="kbd" style={{ fontSize: 13, padding: '8px 14px' }}>npx designlang yoursite.com</code>
+              <a href="/" className="btn btn-primary">Try it live</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/website/app/gallery/page.js
+++ b/website/app/gallery/page.js
@@ -64,9 +64,7 @@ export default async function Gallery() {
             {FEATURED.map(g => (
               <a
                 key={g.host}
-                href={`/gallery/${g.slug}/brand.html`}
-                target="_blank"
-                rel="noreferrer"
+                href={`/gallery/${g.slug}`}
                 className="gal-card gal-real"
               >
                 <div

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -842,6 +842,156 @@ code, pre, kbd { font-family: var(--ff-mono); font-size: 13px; }
   .drift-bar, .drift-delta, .drift-meta { display: none; }
 }
 
+/* ── Per-brand gallery page (/gallery/[slug]) ────────────────── */
+
+.gb-hero {
+  position: relative;
+  padding: 64px 0 56px;
+  overflow: hidden;
+  border-bottom: 1px solid var(--hairline);
+}
+.gb-hero-bg {
+  position: absolute; inset: 0; pointer-events: none;
+  opacity: 0.45;
+  mask-image: radial-gradient(ellipse 100% 80% at 50% 0%, #000 30%, transparent 80%);
+  -webkit-mask-image: radial-gradient(ellipse 100% 80% at 50% 0%, #000 30%, transparent 80%);
+}
+.gb-hero-bg::after {
+  content: ''; position: absolute; inset: 0;
+  background: linear-gradient(180deg, rgba(5,5,5,0.0), rgba(5,5,5,0.55) 70%, rgba(5,5,5,1));
+}
+.gb-hero-inner { position: relative; z-index: 1; }
+.gb-back {
+  display: inline-block; font-size: 12px; color: var(--fg-3);
+  margin-bottom: 28px; transition: color .15s;
+}
+.gb-back:hover { color: #fff; }
+.gb-hero-row { display: grid; grid-template-columns: auto 1fr auto; gap: 32px; align-items: center; }
+@media (max-width: 820px) {
+  .gb-hero-row { grid-template-columns: 1fr; }
+}
+.gb-hero-logo img {
+  width: 72px; height: 72px;
+  border-radius: 18px;
+  background: rgba(255,255,255,0.96);
+  padding: 10px;
+  box-shadow:
+    0 16px 40px -8px rgba(0,0,0,0.55),
+    inset 0 1px 0 rgba(255,255,255,0.6);
+  object-fit: contain;
+}
+.gb-hero-h1 { font-size: clamp(36px, 5.5vw, 64px); margin: 0; }
+.gb-hero-stats {
+  display: flex; gap: 22px; flex-wrap: wrap;
+}
+.gb-stat {
+  display: flex; flex-direction: column; gap: 4px;
+  padding: 12px 16px;
+  background: rgba(0,0,0,0.45);
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  min-width: 88px;
+}
+.gb-stat-num   { color: #fff; font-size: 20px; font-weight: 500; line-height: 1; }
+.gb-stat-label { color: var(--fg-3); font-family: var(--ff-mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; }
+
+.gb-body { padding-top: 48px; padding-bottom: 32px; }
+.gb-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 32px;
+  align-items: start;
+}
+@media (max-width: 980px) { .gb-grid { grid-template-columns: 1fr; } }
+
+.gb-side-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin: 0 0 14px;
+}
+
+.gb-swatches { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+.gb-swatch {
+  background: var(--surface-2); border: 1px solid var(--hairline);
+  border-radius: 10px; padding: 8px; transition: border-color .15s, transform .12s;
+}
+.gb-swatch:hover { border-color: rgba(255,255,255,0.18); transform: translateY(-1px); }
+.gb-swatch-chip {
+  height: 64px; border-radius: 6px;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08), 0 4px 14px -6px rgba(0,0,0,0.4);
+}
+.gb-swatch-meta { display: flex; justify-content: space-between; padding: 8px 4px 4px; font-size: 11px; }
+
+.gb-radii { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.gb-radius {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  padding: 10px 8px;
+  background: var(--surface-2); border: 1px solid var(--hairline);
+  border-radius: 8px;
+  font-size: 11px;
+}
+.gb-radius-tile {
+  width: 44px; height: 44px;
+  background: rgba(255,255,255,0.08);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.12);
+  margin-bottom: 4px;
+}
+
+.gb-spacing { display: flex; flex-direction: column; gap: 6px; }
+.gb-spacing-row {
+  display: flex; align-items: center; gap: 12px;
+  font-size: 11px;
+}
+.gb-spacing-bar {
+  height: 8px; border-radius: 999px; min-width: 4px;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.12);
+}
+
+/* tabbed source viewer */
+.gb-source {
+  display: flex; flex-direction: column;
+  background: rgba(0,0,0,0.55);
+  border: 1px solid var(--hairline);
+  border-radius: 16px; overflow: hidden;
+  box-shadow: 0 30px 80px -30px rgba(0,0,0,0.7);
+  min-height: 540px;
+}
+.gb-source-head {
+  display: flex; align-items: center; gap: 16px;
+  padding: 10px 14px;
+  background: rgba(255,255,255,0.03);
+  border-bottom: 1px solid var(--hairline);
+}
+.gb-source-tabs { display: flex; gap: 4px; overflow-x: auto; }
+.gb-source-tab {
+  padding: 6px 12px; border-radius: 8px;
+  font-family: var(--ff-mono); font-size: 12px;
+  color: var(--fg-3); white-space: nowrap;
+  cursor: pointer;
+  transition: color .15s, background .15s;
+}
+.gb-source-tab:hover { color: #fff; }
+.gb-source-tab.is-active { color: #fff; background: rgba(239,68,68,0.18); border: 1px solid rgba(239,68,68,0.35); }
+.gb-source-actions { margin-left: auto; display: flex; gap: 8px; align-items: center; }
+.gb-copy {
+  font-family: var(--ff-mono); font-size: 11px;
+  padding: 6px 10px; border-radius: 7px;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid var(--hairline);
+  color: var(--fg-2); cursor: pointer;
+  transition: color .15s, background .15s;
+}
+.gb-copy:hover { color: #fff; background: rgba(239,68,68,0.18); border-color: rgba(239,68,68,0.4); }
+.gb-pdf { color: #fff; background: rgba(239,68,68,0.18); border-color: rgba(239,68,68,0.4); text-decoration: none; }
+.gb-source-body {
+  margin: 0; padding: 20px 22px;
+  font-family: var(--ff-mono); font-size: 12.5px; line-height: 1.65;
+  color: var(--fg);
+  overflow: auto;
+  flex: 1;
+  white-space: pre;
+  max-height: 720px;
+}
+
 /* ── FAQ ─────────────────────────────────────────────────────── */
 
 .faq-list { display: flex; flex-direction: column; gap: 10px; }

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -380,9 +380,7 @@ function GallerySection() {
           {GALLERY.map(g => (
             <a
               key={g.host}
-              href={`/gallery/${g.slug}/brand.html`}
-              target="_blank"
-              rel="noreferrer"
+              href={`/gallery/${g.slug}`}
               className="gal-card gal-real"
             >
               <div

--- a/website/app/sitemap.js
+++ b/website/app/sitemap.js
@@ -33,12 +33,20 @@ export default function sitemap() {
     priority,
   }));
 
-  const galleryPages = GALLERY_SLUGS.map((slug) => ({
-    url: `${SITE_URL}/gallery/${slug}/brand.html`,
-    lastModified: now,
-    changeFrequency: 'monthly',
-    priority: 0.7,
-  }));
+  const galleryPages = GALLERY_SLUGS.flatMap((slug) => ([
+    {
+      url: `${SITE_URL}/gallery/${slug}`,
+      lastModified: now,
+      changeFrequency: 'weekly',
+      priority: 0.85,
+    },
+    {
+      url: `${SITE_URL}/gallery/${slug}/brand.html`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+  ]));
 
   return [...base, ...galleryPages];
 }


### PR DESCRIPTION
Adds a real per-brand gallery page at `/gallery/<slug>` that goes well beyond design-extractor.com's equivalent. The same data extraction now powers a designed view in our chrome instead of a static `brand.html`.

What's on the page (for any of the 8 featured brands):

**Hero**
- Brand-tinted gradient (uses the *actually extracted* primary + accent for the linear-gradient)
- Brand favicon as a tile
- Hostname H1 + URL link
- Stat cards: page intent, material language, color count, primary font sample (rendered in the real font)
- Primary CTA "Open brand book ↗" (links to the full HTML brand book)
- Ghost CTA "Browse tokens"

**Two-column body**
- **Left side panel:** all extracted colours as a 2-col swatch grid with hex labels; radii tiles; spacing bars (sized to the actual values, coloured with the brand primary)
- **Right side: tabbed source viewer (client component)** — `DESIGN.md` / `design-tokens.json` / `tailwind.config.js` / `variables.css`. Active tab gets a red highlight. Each tab has a "copy" button (clipboard) and a permanent red "brand book ↗" CTA in the toolbar.

**Below:**
- Typography section with 5 type samples (display / headline / subhead / body / caption) rendered in the extracted font family
- Voice section with real headlines pulled from the brand's `-voice.json`
- Motion section with the raw motion-tokens.json dump
- Bottom CTA: "Run designlang on your own URL" with `npx designlang yoursite.com` chip

**Data plumbing**
- `generateStaticParams` over the 8 featured slugs
- File reads from `public/gallery/<slug>/` with a candidate-list fallback so any cwd works (Vercel build, repo-root dev, website-folder dev)

**Routing**
- Homepage gallery cards now link to `/gallery/<slug>` instead of opening `brand.html` in a new tab
- `/gallery` list page same — the brand-book HTML is still 1 click further in
- Sitemap adds the 8 `/gallery/<slug>` routes at priority 0.85, keeps the brand.html entries at 0.7

Why: design-extractor.com's per-brand gallery shows one tab (DESIGN.md), one column of swatches, no motion, no typography preview, no voice, no PDF link, no MCP, no copy buttons. Ours has all of it, theme-tinted by the actually-extracted brand colour. Pairs with the parallel SEO push (`design-extractor.com alternative`) so when someone Googles for design-extractor we own both the comparison page and the gallery view.