### PR TITLE
fix(tui): strip the chrome — just text on a dark block

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -323,118 +323,23 @@ code, pre, kbd { font-family: var(--ff-mono); font-size: 13px; }
 }
 .card-body { padding: 22px 24px; }
 
-/* ── TUI hero card (bespoke "designlang" terminal) ───────────── */
+/* ── TUI hero card (just text. nothing else.) ────────────────── */
 
 .tui {
-  position: relative;
-  display: flex; flex-direction: column;
-  background:
-    linear-gradient(180deg, rgba(18, 8, 8, 0.95) 0%, rgba(8, 4, 4, 0.95) 100%);
-  border: 1px solid rgba(239, 68, 68, 0.18);
-  border-radius: 16px;
-  overflow: hidden;
-  box-shadow:
-    0 40px 100px -30px rgba(0,0,0,0.85),
-    0 0 0 1px rgba(239,68,68,0.08),
-    0 0 100px -20px rgba(239,68,68,0.35),
-    inset 0 1px 0 rgba(255,255,255,0.06);
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  padding: 22px 24px;
   font-family: var(--ff-mono);
 }
-.tui::before {
-  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(255,128,128,0.5), transparent);
-}
-
-.tui-head {
-  display: flex; align-items: center; gap: 14px;
-  padding: 10px 14px;
-  border-bottom: 1px solid rgba(239,68,68,0.12);
-  background: rgba(239,68,68,0.04);
-  font-size: 11px;
-}
-.tui-tag {
-  color: #ffd2d2;
-  padding: 3px 9px; border-radius: 4px;
-  background: rgba(239,68,68,0.16);
-  border: 1px solid rgba(239,68,68,0.35);
-  letter-spacing: 0.04em;
-}
-.tui-route { color: var(--fg-2); flex: 1; letter-spacing: 0.02em; }
-.tui-route::before { content: '~'; opacity: 0.4; margin-right: 4px; }
-.tui-meta {
-  color: var(--fg-3); display: inline-flex; align-items: center; gap: 6px;
-}
-.tui-blip {
-  display: inline-block; width: 6px; height: 6px; border-radius: 999px;
-  background: #4ade80;
-  box-shadow: 0 0 8px rgba(74,222,128,0.7);
-}
-
-.tui-body { padding: 18px 22px; font-size: 12.5px; line-height: 1.65; }
-
-.tui-line { display: flex; align-items: baseline; gap: 10px; margin-bottom: 6px; }
-.tui-prompt { color: var(--red-3); font-weight: 600; }
-.tui-cmd    { color: #fff; }
-.tui-arg    { color: #c4f0a8; }
-.tui-flag   { color: #ffd166; }
-
-.tui-divider {
-  height: 1px;
-  background: linear-gradient(90deg, rgba(239,68,68,0.0) 0%, rgba(239,68,68,0.18) 50%, rgba(239,68,68,0.0) 100%);
-  margin: 12px 0;
-}
-
-.tui-step {
-  display: grid;
-  grid-template-columns: 14px 160px 1fr 56px;
-  gap: 12px; align-items: center;
-  font-size: 11.5px;
-  padding: 2px 0;
-}
-.tui-step-tick { color: #4ade80; font-weight: 600; }
-.tui-step-label { color: var(--fg-2); }
-.tui-step-bar  { display: block; height: 4px; background: rgba(255,255,255,0.05); border-radius: 999px; overflow: hidden; }
-.tui-step-bar span {
-  display: block; height: 100%; border-radius: 999px;
-  background: linear-gradient(90deg, var(--red-2), var(--red-3));
-  width: 0;
-  animation: tui-fill .8s cubic-bezier(.2,.8,.2,1) forwards;
-}
-@keyframes tui-fill { from { width: 0; } }
-.tui-step-ms   { color: var(--fg-3); text-align: right; font-size: 11px; }
-
-.tui-summary { padding: 4px 0 8px; }
-.tui-summary-row {
-  display: flex; align-items: baseline; gap: 12px;
-  font-size: 12px;
-}
-.tui-summary-label {
-  text-transform: uppercase; letter-spacing: 0.16em; font-size: 10px; color: var(--fg-3);
-}
-.tui-summary-val { color: var(--fg); }
-.tui-num         { color: #ffd166; font-weight: 600; }
-
-.tui-files { margin-top: 6px; font-size: 11.5px; }
-.tui-file  { color: var(--fg-2); padding: 1px 0; }
-.tui-file-pre { color: var(--fg-3); margin-right: 6px; }
-.tui-ext { color: #ff8080; }
-
-.tui-foot {
-  display: flex; align-items: center; gap: 14px;
-  padding: 10px 14px;
-  border-top: 1px solid rgba(239,68,68,0.12);
-  background: rgba(0,0,0,0.4);
-  font-size: 10.5px;
-  color: var(--fg-3);
-  letter-spacing: 0.04em;
-}
-.tui-foot-led {
-  display: inline-block; width: 6px; height: 6px; border-radius: 999px;
-  background: #4ade80; margin-right: 6px;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .tui-step-bar span { animation: none !important; width: 100% !important; }
+.tui-out {
+  margin: 0;
+  font-family: var(--ff-mono);
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--fg-2);
+  white-space: pre;
+  overflow-x: auto;
 }
 
 /* ── Code card (terminal) — legacy, still used elsewhere ─────── */

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -91,57 +91,21 @@ function Hero() {
           </div>
 
           <div className="tui">
-            <div className="tui-head">
-              <div className="tui-tag mono">designlang/cli</div>
-              <div className="tui-route mono">~ ▸ stripe.com</div>
-              <div className="tui-meta mono"><span className="tui-blip" />8.9s · cold</div>
-            </div>
-            <div className="tui-body">
-              <div className="tui-line">
-                <span className="tui-prompt">▸</span>
-                <span className="tui-cmd">npx designlang <span className="tui-arg">stripe.com</span> <span className="tui-flag">--pdf</span></span>
-              </div>
-              <div className="tui-divider" />
-              {[
-                { label: 'walking dom',           ms:  640 },
-                { label: 'resolving palette',     ms: 1240 },
-                { label: 'reading type',          ms:  380 },
-                { label: 'measuring rhythm',      ms:  720 },
-                { label: 'clustering components', ms: 1820 },
-                { label: 'auditing contrast',    ms:  510 },
-                { label: 'rendering pdf',        ms: 2110 },
-              ].map((step, i) => (
-                <div key={step.label} className="tui-step">
-                  <span className="tui-step-tick">✓</span>
-                  <span className="tui-step-label">{step.label}</span>
-                  <span className="tui-step-bar" aria-hidden>
-                    <span style={{ width: `${Math.min(100, step.ms / 22)}%`, animationDelay: `${i * 90}ms` }} />
-                  </span>
-                  <span className="tui-step-ms">{step.ms}ms</span>
-                </div>
-              ))}
-              <div className="tui-divider" />
-              <div className="tui-summary">
-                <div className="tui-summary-row">
-                  <span className="tui-summary-label">brand book</span>
-                  <span className="tui-summary-val mono">
-                    <span className="tui-num">42</span> tokens · <span className="tui-num">3</span> fonts · grade <span className="tui-num">A+</span>
-                  </span>
-                </div>
-              </div>
-              <div className="tui-files mono">
-                <div className="tui-file"><span className="tui-file-pre">├</span> stripe-com.brand.<span className="tui-ext">html</span></div>
-                <div className="tui-file"><span className="tui-file-pre">├</span> stripe-com.brand.<span className="tui-ext">pdf</span></div>
-                <div className="tui-file"><span className="tui-file-pre">├</span> stripe-com.tokens.<span className="tui-ext">json</span></div>
-                <div className="tui-file"><span className="tui-file-pre">└</span> stripe-com.tailwind.<span className="tui-ext">config.js</span></div>
-              </div>
-            </div>
-            <div className="tui-foot mono">
-              <span><span className="tui-foot-led" /> done</span>
-              <span>17 files</span>
-              <span>cached for 24h</span>
-              <span style={{ marginLeft: 'auto' }}>↵ press to re-run</span>
-            </div>
+            <pre className="tui-out">
+{'$ npx designlang stripe.com --pdf\n\n'}
+{'  walking dom\n'}
+{'  resolving palette\n'}
+{'  reading type\n'}
+{'  measuring rhythm\n'}
+{'  clustering components\n'}
+{'  auditing contrast\n'}
+{'  rendering pdf\n\n'}
+{'Brand book · 42 tokens · 3 fonts · grade A+\n\n'}
+{'  stripe-com.brand.html\n'}
+{'  stripe-com.brand.pdf\n'}
+{'  stripe-com.tokens.json\n'}
+{'  stripe-com.tailwind.config.js'}
+            </pre>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Per feedback: previous TUI was 'too much / generic / AI'. Removed all the decoration:

- No `designlang/cli` chip
- No `~ ▸ stripe.com` route line
- No green status blip / cold-start meta
- No animated red progress bars or per-step ms readouts
- No tree characters (├ └) on file list
- No bottom status row with green LED + 'press to re-run'

What's left: a single `<pre>` of unstyled mono text inside a dark rounded card. Reads like real `stdout`, not a SaaS-landing fake terminal.