### PR TITLE
feat(mcp): auto-load design context from project files

### DIFF
--- a/skills/extract-design/SKILL.md
+++ b/skills/extract-design/SKILL.md
@@ -22,6 +22,16 @@ Or use npx (no install required):
 npx designlang <url>
 ```
 
+## Auto-Loaded Design Context
+
+When the MCP server starts, it automatically scans the project for existing design config files and pre-loads them as MCP resources — no manual extraction needed for basic context:
+
+- **`design-tokens.json`** — W3C DTCG tokens (searched in `./`, `./src/`, `./app/`, `./styles/`)
+- **`tailwind.config.*`** — Tailwind theme colors, spacing, and font families (searched in `./`)
+- **`globals.css`** — CSS custom properties from `:root` blocks (searched in `./`, `./src/`, `./app/`, `./styles/`)
+
+Running `/extract-design` against a URL produces a richer extraction that supersedes auto-detected context.
+
 ## Process
 
 1. **Run the extraction** on the provided URL:

--- a/src/mcp/project-scan.js
+++ b/src/mcp/project-scan.js
@@ -1,0 +1,155 @@
+// Auto-scan project directory for design config files and return them
+// in the { tokens, design } shape that buildResources/buildTools expect.
+
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+const SEARCH_DIRS = ['', 'src', 'app', 'styles'];
+const TAILWIND_NAMES = ['tailwind.config.js', 'tailwind.config.ts', 'tailwind.config.mjs', 'tailwind.config.cjs'];
+
+function findFile(projectDir, dirs, filename) {
+  for (const dir of dirs) {
+    const p = join(projectDir, dir, filename);
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+function findTailwindConfig(projectDir) {
+  for (const name of TAILWIND_NAMES) {
+    const p = join(projectDir, name);
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+function tryDesignTokens(projectDir) {
+  const path = findFile(projectDir, SEARCH_DIRS, 'design-tokens.json');
+  if (!path) return null;
+  try {
+    const data = JSON.parse(readFileSync(path, 'utf-8'));
+    if (data && typeof data === 'object') {
+      if (data.primitive && data.semantic) return data;
+      return { primitive: data, semantic: {} };
+    }
+  } catch { /* malformed JSON — skip */ }
+  return null;
+}
+
+function extractTailwindValues(text) {
+  const primitive = {};
+
+  const colorRe = /['"]([a-zA-Z][\w-]*)['"]:\s*['"]([#\w().,\s]+)['"]/g;
+
+  const colorsBlock = text.match(/colors\s*:\s*\{([^}]*(?:\{[^}]*\}[^}]*)*)\}/s);
+  if (colorsBlock) {
+    const colorGroup = {};
+    let m;
+    while ((m = colorRe.exec(colorsBlock[1])) !== null) {
+      colorGroup[m[1]] = { $value: m[2].trim(), $type: 'color' };
+    }
+    if (Object.keys(colorGroup).length) primitive.color = colorGroup;
+  }
+
+  const spacingBlock = text.match(/spacing\s*:\s*\{([^}]*)\}/s);
+  if (spacingBlock) {
+    const spacingGroup = {};
+    const spacingRe = /['"]?([\w.-]+)['"]?\s*:\s*['"]([\w.]+(?:rem|px|em))['"]/g;
+    let m;
+    while ((m = spacingRe.exec(spacingBlock[1])) !== null) {
+      spacingGroup[m[1]] = { $value: m[2], $type: 'dimension' };
+    }
+    if (Object.keys(spacingGroup).length) primitive.spacing = spacingGroup;
+  }
+
+  const fontBlock = text.match(/fontFamily\s*:\s*\{([^}]*(?:\[[^\]]*\][^}]*)*)\}/s);
+  if (fontBlock) {
+    const fontGroup = {};
+    const fontRe = /['"]?(\w+)['"]?\s*:\s*\[([^\]]+)\]/g;
+    let m;
+    while ((m = fontRe.exec(fontBlock[1])) !== null) {
+      const fonts = m[2].match(/['"]([^'"]+)['"]/g);
+      if (fonts) {
+        fontGroup[m[1]] = {
+          $value: fonts.map(f => f.replace(/['"]/g, '')).join(', '),
+          $type: 'fontFamily',
+        };
+      }
+    }
+    if (Object.keys(fontGroup).length) primitive.fontFamily = fontGroup;
+  }
+
+  return Object.keys(primitive).length ? primitive : null;
+}
+
+function tryTailwindConfig(projectDir) {
+  const path = findTailwindConfig(projectDir);
+  if (!path) return null;
+  try {
+    const text = readFileSync(path, 'utf-8');
+    const primitive = extractTailwindValues(text);
+    if (primitive) return { primitive, semantic: {} };
+  } catch { /* unreadable — skip */ }
+  return null;
+}
+
+function extractCssVars(text) {
+  const primitive = { cssVar: {} };
+  const rootBlocks = text.match(/:root\s*\{[^}]*\}/gs);
+  if (!rootBlocks) return null;
+
+  const varRe = /--([\w-]+)\s*:\s*([^;]+);/g;
+  for (const block of rootBlocks) {
+    let m;
+    while ((m = varRe.exec(block)) !== null) {
+      const name = m[1].trim();
+      const value = m[2].trim();
+      primitive.cssVar[name] = { $value: value, $type: 'color' };
+    }
+  }
+  return Object.keys(primitive.cssVar).length ? primitive : null;
+}
+
+function tryGlobalsCss(projectDir) {
+  const path = findFile(projectDir, SEARCH_DIRS, 'globals.css');
+  if (!path) return null;
+  try {
+    const text = readFileSync(path, 'utf-8');
+    const primitive = extractCssVars(text);
+    if (primitive) return { primitive, semantic: {} };
+  } catch { /* unreadable — skip */ }
+  return null;
+}
+
+function mergeTokens(base, addition) {
+  if (!addition) return base;
+  if (!base) return addition;
+  const merged = { ...base };
+  for (const key of Object.keys(addition)) {
+    if (!(key in merged)) {
+      merged[key] = addition[key];
+    }
+  }
+  return merged;
+}
+
+export function scanProjectDesignFiles(projectDir) {
+  const dtResult = tryDesignTokens(projectDir);
+  const twResult = tryTailwindConfig(projectDir);
+  const cssResult = tryGlobalsCss(projectDir);
+
+  if (!dtResult && !twResult && !cssResult) return null;
+
+  let primitive = dtResult?.primitive ?? null;
+  let semantic = dtResult?.semantic ?? {};
+
+  if (twResult) primitive = mergeTokens(primitive, twResult.primitive);
+  if (cssResult) primitive = mergeTokens(primitive, cssResult.primitive);
+
+  if (!primitive) return null;
+
+  return {
+    tokens: { primitive, semantic },
+    design: {},
+  };
+}

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -13,6 +13,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { buildResources } from './resources.js';
 import { buildTools } from './tools.js';
+import { scanProjectDesignFiles } from './project-scan.js';
 
 // Best-effort reconstruction of a design object from the files on disk.
 // We only need what the tools/resources consume: tokens + regions +
@@ -61,7 +62,7 @@ function loadExtraction(outputDir) {
 
 export async function run({ outputDir }) {
   const resolved = resolve(outputDir || './design-extract-output');
-  const loaded = loadExtraction(resolved);
+  const loaded = loadExtraction(resolved) || scanProjectDesignFiles(process.cwd());
   const tokens = loaded?.tokens ?? null;
   const design = loaded?.design ?? {};
 

--- a/tests/project-scan.test.js
+++ b/tests/project-scan.test.js
@@ -1,0 +1,197 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { scanProjectDesignFiles } from '../src/mcp/project-scan.js';
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), 'designlang-scan-'));
+}
+
+describe('project-scan: design-tokens.json', () => {
+  it('loads DTCG tokens with primitive/semantic keys', () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'design-tokens.json'), JSON.stringify({
+      primitive: { color: { red: { $value: '#ff0000', $type: 'color' } } },
+      semantic: { action: { primary: { $value: '{color.red}', $type: 'color' } } },
+    }));
+    const result = scanProjectDesignFiles(dir);
+    assert.ok(result);
+    assert.deepStrictEqual(result.tokens.primitive.color.red, { $value: '#ff0000', $type: 'color' });
+    assert.ok(result.tokens.semantic.action);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('wraps flat token objects as primitive tier', () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'design-tokens.json'), JSON.stringify({
+      color: { brand: { $value: '#000', $type: 'color' } },
+    }));
+    const result = scanProjectDesignFiles(dir);
+    assert.ok(result);
+    assert.ok(result.tokens.primitive.color);
+    assert.deepStrictEqual(result.tokens.semantic, {});
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('finds design-tokens.json in app/ subdirectory', () => {
+    const dir = makeTmpDir();
+    const appDir = join(dir, 'app');
+    mkdirSync(appDir);
+    writeFileSync(join(appDir, 'design-tokens.json'), JSON.stringify({
+      primitive: { spacing: { sm: { $value: '4px', $type: 'dimension' } } },
+      semantic: {},
+    }));
+    const result = scanProjectDesignFiles(dir);
+    assert.ok(result);
+    assert.ok(result.tokens.primitive.spacing);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('project-scan: tailwind.config', () => {
+  it('extracts colors from tailwind.config.js', () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'tailwind.config.js'), `
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        'primary': '#3b82f6',
+        'secondary': '#10b981',
+      },
+    },
+  },
+};`);
+    const result = scanProjectDesignFiles(dir);
+    assert.ok(result);
+    assert.deepStrictEqual(result.tokens.primitive.color.primary, { $value: '#3b82f6', $type: 'color' });
+    assert.deepStrictEqual(result.tokens.primitive.color.secondary, { $value: '#10b981', $type: 'color' });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('extracts fontFamily from tailwind.config.ts', () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'tailwind.config.ts'), `
+export default {
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+        mono: ['Fira Code', 'monospace'],
+      },
+    },
+  },
+};`);
+    const result = scanProjectDesignFiles(dir);
+    assert.ok(result);
+    assert.deepStrictEqual(result.tokens.primitive.fontFamily.sans, { $value: 'Inter, sans-serif', $type: 'fontFamily' });
+    assert.deepStrictEqual(result.tokens.primitive.fontFamily.mono, { $value: 'Fira Code, monospace', $type: 'fontFamily' });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('extracts spacing values', () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'tailwind.config.js'), `
+module.exports = {
+  theme: {
+    extend: {
+      spacing: {
+        '18': '4.5rem',
+        '72': '18rem',
+      },
+    },
+  },
+};`);
+    const result = scanProjectDesignFiles(dir);
+    assert.ok(result);
+    assert.deepStrictEqual(result.tokens.primitive.spacing['18'], { $value: '4.5rem', $type: 'dimension' });
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('project-scan: globals.css', () => {
+  it('extracts CSS custom properties from :root', () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'globals.css'), `
+:root {
+  --primary: #3b82f6;
+  --spacing-md: 1rem;
+  --font-sans: Inter, sans-serif;
+}`);
+    const result = scanProjectDesignFiles(dir);
+    assert.ok(result);
+    assert.deepStrictEqual(result.tokens.primitive.cssVar.primary, { $value: '#3b82f6', $type: 'color' });
+    assert.deepStrictEqual(result.tokens.primitive.cssVar['spacing-md'], { $value: '1rem', $type: 'color' });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('extracts from multiple :root blocks', () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'globals.css'), `
+:root { --bg: #fff; }
+:root { --fg: #000; }`);
+    const result = scanProjectDesignFiles(dir);
+    assert.ok(result);
+    assert.ok(result.tokens.primitive.cssVar.bg);
+    assert.ok(result.tokens.primitive.cssVar.fg);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('project-scan: priority and merging', () => {
+  it('design-tokens.json takes priority, globals.css fills gaps', () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'design-tokens.json'), JSON.stringify({
+      primitive: { color: { brand: { $value: '#000', $type: 'color' } } },
+      semantic: {},
+    }));
+    writeFileSync(join(dir, 'globals.css'), ':root { --accent: #ff0; }');
+    const result = scanProjectDesignFiles(dir);
+    assert.ok(result);
+    assert.ok(result.tokens.primitive.color, 'should have color from design-tokens.json');
+    assert.ok(result.tokens.primitive.cssVar, 'should have cssVar from globals.css');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('design-tokens.json color is not overwritten by tailwind colors', () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'design-tokens.json'), JSON.stringify({
+      primitive: { color: { brand: { $value: '#000', $type: 'color' } } },
+      semantic: {},
+    }));
+    writeFileSync(join(dir, 'tailwind.config.js'), `
+module.exports = { theme: { extend: { colors: { 'brand': '#fff' } } } };`);
+    const result = scanProjectDesignFiles(dir);
+    assert.ok(result);
+    assert.deepStrictEqual(result.tokens.primitive.color.brand, { $value: '#000', $type: 'color' },
+      'design-tokens.json color should win over tailwind');
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('project-scan: empty / missing', () => {
+  it('returns null for empty directory', () => {
+    const dir = makeTmpDir();
+    const result = scanProjectDesignFiles(dir);
+    assert.equal(result, null);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns null for malformed design-tokens.json', () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'design-tokens.json'), 'not json{{{');
+    const result = scanProjectDesignFiles(dir);
+    assert.equal(result, null);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns null for globals.css with no :root block', () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'globals.css'), 'body { margin: 0; }');
+    const result = scanProjectDesignFiles(dir);
+    assert.equal(result, null);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Closes #63

  ## Summary

  - Auto-scans the project directory for `design-tokens.json`, `tailwind.config.*`, and `globals.css` at MCP
  server startup
  - Pre-loads detected design files as MCP resources so agent queries start with design system context already in
   scope
  - Falls back silently to empty resources when no design files are found; existing extraction output always
  takes precedence

  ## Changes

  - **`src/mcp/project-scan.js`** (new): Scans project root and common subdirectories (`src/`, `app/`, `styles/`)
   for design config files. Parses each into the `{ tokens, design }` shape consumed by
  `buildResources`/`buildTools`. Priority order: design-tokens.json > tailwind.config > globals.css, with
  lower-priority files filling gaps rather than overwriting.
  - **`src/mcp/server.js`**: Calls `scanProjectDesignFiles(process.cwd())` as a fallback when no extraction
  output exists in the output directory.
  - **`skills/extract-design/SKILL.md`**: Documents the auto-detection behavior and lists the supported file
  patterns.
  - **`tests/project-scan.test.js`**: 13 tests covering all three file types, subdirectory discovery, priority
  merging, and edge cases (malformed JSON, missing :root blocks, empty directories).

  ## Test plan

  - Run `node --test tests/project-scan.test.js` — all 13 tests pass
  - Verify MCP server loads tokens from a project with only a `design-tokens.json` (no prior extraction)
  - Verify existing extraction output in `design-extract-output/` takes precedence over project files
  - Verify empty project directory produces no errors and no resources