### PR TITLE
feat(mobile): hamburger menu + sitewide responsive fixes

### DIFF
--- a/website/app/components/MobileMenu.js
+++ b/website/app/components/MobileMenu.js
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export default function MobileMenu({ stars }) {
+  const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => { setMounted(true); }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('keydown', onKey);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = '';
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="nav-burger"
+        aria-label={open ? 'Close menu' : 'Open menu'}
+        aria-expanded={open}
+        onClick={() => setOpen(o => !o)}
+      >
+        <span className={`nav-burger-bar ${open ? 'is-x1' : ''}`} />
+        <span className={`nav-burger-bar ${open ? 'is-x2' : ''}`} />
+      </button>
+
+      {open && mounted && createPortal(
+        (
+          <div className="nav-sheet" role="dialog" aria-modal="true" aria-label="Site menu">
+            <button type="button" className="nav-sheet-close" onClick={() => setOpen(false)} aria-label="Close menu">
+              <span className="nav-burger-bar is-x1" />
+              <span className="nav-burger-bar is-x2" />
+            </button>
+            <nav className="nav-sheet-links" aria-label="primary">
+              <a href="/features"  onClick={() => setOpen(false)}>Features</a>
+              <a href="/gallery"   onClick={() => setOpen(false)}>Gallery</a>
+              <a href="/spec"      onClick={() => setOpen(false)}>DESIGN.md spec</a>
+              <a href="/vs/design-extractor" onClick={() => setOpen(false)}>vs design-extractor</a>
+              <a href="/changelog" onClick={() => setOpen(false)}>Changelog</a>
+              <a href="/drift"     onClick={() => setOpen(false)}>Drift leaderboard</a>
+              <a href="/build"     onClick={() => setOpen(false)}>Build</a>
+            </nav>
+            <div className="nav-sheet-meta">
+              <a href="https://github.com/Manavarya09/design-extract" target="_blank" rel="noreferrer" className="nav-sheet-row">
+                <span>GitHub</span>
+                <span className="mono">★ {stars ?? '—'}</span>
+              </a>
+              <a href="https://www.npmjs.com/package/designlang" target="_blank" rel="noreferrer" className="nav-sheet-row">
+                <span>npm</span>
+                <span className="mono">npm i designlang ↗</span>
+              </a>
+            </div>
+          </div>
+        ),
+        document.body
+      )}
+    </>
+  );
+}

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -61,9 +61,17 @@ html, body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+  overflow-x: hidden;
 }
 
 body { min-height: 100vh; }
+
+/* mobile: tighter wrap padding so things don't kiss the edge */
+@media (max-width: 540px) {
+  .wrap, .wrap-narrow { padding: 0 18px; }
+  .nav-wrap { padding: 10px 12px 0; }
+  .section { padding: clamp(56px, 12vw, 96px) 0; }
+}
 
 a { color: inherit; text-decoration: none; }
 a:hover { color: #fff; }
@@ -219,16 +227,80 @@ img, svg { display: block; max-width: 100%; }
 .nav-cta-glyph { font-family: var(--ff-sans); opacity: 0.85; transition: transform .15s; }
 .nav-cta:hover .nav-cta-glyph { transform: translate(2px, -2px); }
 
+/* hamburger / mobile sheet */
+.nav-burger {
+  display: none;
+  width: 36px; height: 36px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--hairline-2);
+  cursor: pointer;
+  position: relative;
+}
+.nav-burger-bar {
+  position: absolute;
+  left: 50%; top: 50%;
+  width: 16px; height: 1.5px;
+  background: var(--fg);
+  border-radius: 999px;
+  transform-origin: center;
+  transition: transform .2s ease, opacity .2s ease;
+}
+.nav-burger-bar:first-child { transform: translate(-50%, -4px); }
+.nav-burger-bar:last-child  { transform: translate(-50%, 4px); }
+.nav-burger-bar.is-x1 { transform: translate(-50%, 0) rotate(45deg); }
+.nav-burger-bar.is-x2 { transform: translate(-50%, 0) rotate(-45deg); }
+
+.nav-sheet {
+  position: fixed; inset: 0; z-index: 100;
+  background: #050505;
+  display: flex; flex-direction: column;
+  padding: 80px 28px 36px;
+  animation: dx-fade-in .15s ease;
+  overflow-y: auto;
+}
+.nav-sheet-close {
+  position: absolute; top: 22px; right: 22px;
+  width: 40px; height: 40px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid var(--hairline-2);
+  cursor: pointer;
+  z-index: 1;
+}
+.nav-sheet-close .nav-burger-bar { background: #fff; }
+.nav-sheet-links { display: flex; flex-direction: column; gap: 8px; }
+.nav-sheet-links a {
+  font-family: var(--ff-sans);
+  font-size: 22px; font-weight: 500;
+  color: #fff;
+  padding: 14px 4px;
+  border-bottom: 1px solid var(--hairline);
+  letter-spacing: -0.01em;
+}
+.nav-sheet-meta { margin-top: auto; padding-top: 24px; border-top: 1px solid var(--hairline); display: flex; flex-direction: column; gap: 12px; }
+.nav-sheet-row {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 4px;
+  font-size: 14px; color: var(--fg-2);
+  font-family: var(--ff-mono);
+}
+.nav-sheet-row:hover { color: #fff; }
+
 @media (max-width: 820px) {
   .nav-pillnav { display: none; }
   .nav-version { display: none; }
 }
-@media (max-width: 560px) {
+@media (max-width: 640px) {
+  .nav { padding: 0 6px 0 14px; gap: 8px; }
   .nav-stars { display: none; }
+  .nav-cta {
+    height: 32px; padding: 0 12px; font-size: 11px;
+  }
   .nav-cta span:first-child { display: none; }
-  .nav-cta { padding: 0 14px; }
-  .nav-cta-glyph { font-size: 14px; }
   .nav-cta::before { content: 'Install'; }
+  .nav-cta-glyph { font-size: 12px; }
+  .nav-burger { display: inline-block; }
 }
 
 /* ── Buttons ─────────────────────────────────────────────────── */
@@ -331,6 +403,8 @@ code, pre, kbd { font-family: var(--ff-mono); font-size: 13px; }
   border-radius: 12px;
   padding: 22px 24px;
   font-family: var(--ff-mono);
+  max-width: 100%;
+  overflow-x: hidden;
 }
 .tui-out {
   margin: 0;
@@ -340,6 +414,11 @@ code, pre, kbd { font-family: var(--ff-mono); font-size: 13px; }
   color: var(--fg-2);
   white-space: pre;
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+@media (max-width: 540px) {
+  .tui { padding: 16px 14px; border-radius: 10px; }
+  .tui-out { font-size: 11px; line-height: 1.65; }
 }
 
 /* ── Code card (terminal) — legacy, still used elsewhere ─────── */
@@ -510,6 +589,13 @@ code, pre, kbd { font-family: var(--ff-mono); font-size: 13px; }
   padding: 16px 18px;
   font-family: var(--ff-mono); font-size: 11.5px;
   color: var(--fg-2); line-height: 1.6;
+  overflow-x: auto;
+}
+.dtcg-row { white-space: nowrap; }
+@media (max-width: 540px) {
+  .dtcg-tree { font-size: 10.5px; padding: 12px 14px; }
+  .dtcg-key { max-width: 60vw; overflow: hidden; text-overflow: ellipsis; }
+  .dtcg-val { display: none; }
 }
 .dtcg-row { display: flex; align-items: center; gap: 8px; }
 .dtcg-indent  { padding-left: 14px; color: var(--fg-3); }
@@ -822,6 +908,12 @@ code, pre, kbd { font-family: var(--ff-mono); font-size: 13px; }
   cursor: copy;
   transition: border-color .15s, background .15s, transform .12s;
   text-align: left;
+  max-width: 100%;
+  flex-wrap: wrap;
+}
+.copycmd-cmd { word-break: break-all; min-width: 0; }
+@media (max-width: 480px) {
+  .copycmd { font-size: 12px; padding: 8px 10px; gap: 6px; }
 }
 .copycmd:hover {
   border-color: rgba(239,68,68,0.45);
@@ -1015,9 +1107,18 @@ code, pre, kbd { font-family: var(--ff-mono); font-size: 13px; }
   font-family: var(--ff-mono); font-size: 12.5px; line-height: 1.65;
   color: var(--fg);
   overflow: auto;
+  -webkit-overflow-scrolling: touch;
   flex: 1;
   white-space: pre;
   max-height: 720px;
+}
+@media (max-width: 640px) {
+  .gb-source { min-height: 420px; }
+  .gb-source-body { font-size: 11px; padding: 14px 16px; max-height: 460px; }
+  .gb-source-head { flex-wrap: wrap; gap: 10px; }
+  .gb-source-actions { width: 100%; justify-content: space-between; }
+  .gb-hero { padding-top: 32px; padding-bottom: 36px; }
+  .gb-hero-stats { width: 100%; }
 }
 
 /* ── FAQ ─────────────────────────────────────────────────────── */
@@ -1137,7 +1238,7 @@ footer.ftr {
   grid-column: 1 / -1;
   display: block;
   font-family: var(--ff-sans); font-weight: 500;
-  font-size: clamp(80px, 16vw, 220px);
+  font-size: clamp(60px, 16vw, 220px);
   line-height: 0.85; letter-spacing: -0.05em;
   color: transparent;
   -webkit-text-stroke: 1px rgba(255,255,255,0.08);
@@ -1147,6 +1248,11 @@ footer.ftr {
   text-align: center;
   background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0));
   -webkit-background-clip: text; background-clip: text;
+  white-space: nowrap;
+  overflow: hidden;
+}
+@media (max-width: 540px) {
+  .ftr-wordmark { font-size: 56px; margin-top: 24px; }
 }
 
 .ftr-bottom {
@@ -1276,6 +1382,18 @@ footer.ftr {
   color: #fff;
   outline: none;
   min-width: 0;
+}
+@media (max-width: 540px) {
+  .dx-form { flex-wrap: wrap; }
+  .dx-form-prefix { padding: 0 10px 0 14px; font-size: 13px; border-right: 0; }
+  .dx-form-input { font-size: 15px; padding: 14px 10px; flex: 1 1 auto; min-width: 100px; }
+  .dx-form-submit { width: 100%; padding: 14px 18px; justify-content: center; border-top: 1px solid var(--hairline); }
+  .dx-status { flex-wrap: wrap; }
+  .dx-status-meta { width: 100%; margin-left: 0; }
+  .dx-section-title { font-size: clamp(40px, 12vw, 56px); }
+  .dx-stage { padding: 18px 14px; border-radius: 16px; }
+  .dx-suggest { font-size: 11px; }
+  .dx-chip { font-size: 11px; padding: 5px 9px; }
 }
 .dx-form-input::placeholder { color: var(--fg-3); }
 .dx-form-submit {

--- a/website/app/layout.js
+++ b/website/app/layout.js
@@ -1,6 +1,7 @@
 import { Geist, Geist_Mono } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
 import StructuredData from './components/StructuredData';
+import MobileMenu from './components/MobileMenu';
 import {
   SITE_URL,
   SITE_NAME,
@@ -130,6 +131,7 @@ async function Nav() {
             <span>npm i designlang</span>
             <span className="nav-cta-glyph" aria-hidden>↗</span>
           </a>
+          <MobileMenu stars={formatStars(stars)} />
         </div>
       </header>
     </div>


### PR DESCRIPTION
Mobile audit + comprehensive fix in one PR.

**Nav**
- New `MobileMenu` client component with a hamburger button (visible <640px)
- Full-screen sheet with 7 links + GitHub stars + npm CTA, closes on Esc
- Uses `createPortal` to render the sheet on `document.body` so it escapes the nav's `backdrop-filter` containing block (the bug that made it render as a 333×116px strip)
- Burger only shows below 640px; pillnav stays hidden below 820px

**Sitewide**
- `html { overflow-x: hidden }` hard guard against accidental horizontal scroll
- Tighter `.wrap` / `.section` padding under 540px
- `.dtcg-tree` scrolls horizontally instead of overflowing the bento card
- `.tui` clamps to 100% width with overflow handling
- `.copycmd` wraps when its contents would overflow
- `.ftr-wordmark` capped at 56px on mobile (was overflowing at 220px clamp)
- Live extractor form wraps so Extract button drops below input on narrow screens
- `/gallery/[slug]` source body height capped at 460px on mobile, tabs row wraps with copy/brand-book actions on a second row