### PR TITLE
feat(gallery): /gallery/[slug] surfaces every artefact, not just 4

### DIFF
--- a/website/app/gallery/[slug]/GalleryTabs.js
+++ b/website/app/gallery/[slug]/GalleryTabs.js
@@ -2,25 +2,21 @@
 
 import { useState } from 'react';
 
-export default function GalleryTabs({ host, slug, designMd, tailwindCfg, cssVars, tokensJson }) {
-  const TABS = [
-    { id: 'design',   label: 'DESIGN.md',         body: designMd,    lang: 'markdown' },
-    { id: 'tokens',   label: 'design-tokens.json', body: tokensJson, lang: 'json'     },
-    { id: 'tailwind', label: 'tailwind.config.js', body: tailwindCfg, lang: 'js'       },
-    { id: 'css',      label: 'variables.css',      body: cssVars,    lang: 'css'      },
-  ].filter(t => t.body);
-
+export default function GalleryTabs({ slug, files = [] }) {
+  const TABS = files.filter(t => t.body);
   const [active, setActive] = useState(TABS[0]?.id);
   const [copied, setCopied] = useState(false);
   const tab = TABS.find(t => t.id === active) || TABS[0];
 
   async function copy() {
     try {
-      await navigator.clipboard.writeText(tab.body || '');
+      await navigator.clipboard.writeText(tab?.body || '');
       setCopied(true);
       setTimeout(() => setCopied(false), 1400);
     } catch { /* noop */ }
   }
+
+  if (TABS.length === 0) return null;
 
   return (
     <div className="gb-source">

--- a/website/app/gallery/[slug]/page.js
+++ b/website/app/gallery/[slug]/page.js
@@ -22,8 +22,6 @@ export function generateStaticParams() {
 }
 
 function galleryDirs(slug) {
-  // Cover every plausible cwd: Vercel build (website), local dev started from
-  // the website folder, and dev started from the repo root or one level up.
   return [
     join(process.cwd(), 'public', 'gallery', slug),
     join(process.cwd(), 'website', 'public', 'gallery', slug),
@@ -42,24 +40,58 @@ async function findFile(slug, suffix) {
   return null;
 }
 
+async function listFiles(slug) {
+  for (const d of galleryDirs(slug)) {
+    try {
+      const all = await readdir(d, { withFileTypes: true });
+      const flat = [];
+      for (const f of all) {
+        if (f.isDirectory()) {
+          try {
+            const sub = await readdir(join(d, f.name));
+            for (const s of sub) flat.push(`${f.name}/${s}`);
+          } catch { /* skip */ }
+        } else {
+          flat.push(f.name);
+        }
+      }
+      return flat.sort();
+    } catch { /* try next */ }
+  }
+  return [];
+}
+
+async function readPrompt(slug, name) {
+  for (const d of galleryDirs(slug)) {
+    try {
+      const dirs = await readdir(d);
+      const promptDir = dirs.find((f) => f.endsWith('-prompts'));
+      if (promptDir) {
+        const path = join(d, promptDir, name);
+        try { return await readFile(path, 'utf-8'); } catch { /* missing */ }
+      }
+    } catch { /* try next */ }
+  }
+  return null;
+}
+
 export async function generateMetadata({ params }) {
   const { slug } = await params;
   const meta = FEATURED[slug];
   if (!meta) return { title: 'Brand not found — designlang' };
   const host = meta.host;
   return {
-    title: `${host} design system — extracted by designlang`,
-    description: `${host} design system: every colour, font, spacing token, shadow, radius, motion curve, anatomy and brand voice — extracted with one command. DTCG tokens, Tailwind config, Figma variables, brand-book PDF, all on one page. The open-source alternative to design-extractor.com.`,
+    title: `${host} design system — every token, every emitter, every prompt — designlang`,
+    description: `Real extraction of ${host}: 17+ files including DTCG tokens, Tailwind, Figma variables, shadcn theme, brand-book PDF, MCP server payload, AGENTS.md, component anatomy, icon system, voice, motion, prompt pack for v0/Lovable/Cursor/Claude. Open-source alternative to design-extractor.com (4 outputs).`,
     alternates: { canonical: `https://designlang.app/gallery/${slug}` },
     openGraph: {
       title: `${host} design system — designlang`,
-      description: `Real extraction of ${host}: tokens, typography, spacing, motion, anatomy, voice, brand-book PDF.`,
+      description: `Tokens, emitters, anatomy, icons, voice, motion, MCP, prompts, brand-book PDF — all 17+ artefacts on one page.`,
     },
   };
 }
 
 function pickPalette(tokens) {
-  // Walk the DTCG tree and pick all primitive colour leafs.
   const out = [];
   const walk = (node, path) => {
     if (!node || typeof node !== 'object') return;
@@ -67,30 +99,18 @@ function pickPalette(tokens) {
       out.push({ path, hex: node.$value });
       return;
     }
-    for (const k of Object.keys(node)) {
-      if (k.startsWith('$')) continue;
-      walk(node[k], path ? `${path}.${k}` : k);
-    }
+    for (const k of Object.keys(node)) { if (!k.startsWith('$')) walk(node[k], path ? `${path}.${k}` : k); }
   };
   walk(tokens?.primitive?.color, 'primitive.color');
-  // dedupe by hex
   const seen = new Set();
-  return out.filter(({ hex }) => {
-    const k = hex.toLowerCase();
-    if (seen.has(k)) return false;
-    seen.add(k);
-    return true;
-  }).slice(0, 18);
+  return out.filter(({ hex }) => { const k = hex.toLowerCase(); if (seen.has(k)) return false; seen.add(k); return true; }).slice(0, 18);
 }
 
 function pickRadii(tokens) {
   const out = [];
   const walk = (node, path) => {
     if (!node || typeof node !== 'object') return;
-    if (node.$value !== undefined && (node.$type === 'dimension' || node.$type === undefined)) {
-      out.push({ path, value: String(node.$value) });
-      return;
-    }
+    if (node.$value !== undefined && (node.$type === 'dimension' || node.$type === undefined)) { out.push({ path, value: String(node.$value) }); return; }
     for (const k of Object.keys(node)) { if (!k.startsWith('$')) walk(node[k], path ? `${path}.${k}` : k); }
   };
   walk(tokens?.primitive?.radius, '');
@@ -111,18 +131,65 @@ function pickSpacing(tokens) {
 function pickFont(tokens) {
   const f = tokens?.primitive?.fontFamily;
   if (!f) return null;
-  for (const k of Object.keys(f || {})) {
-    if (f[k]?.$value) return { name: k, value: f[k].$value };
-  }
+  for (const k of Object.keys(f || {})) { if (f[k]?.$value) return { name: k, value: f[k].$value }; }
   return null;
 }
+
+function fileGroup(name) {
+  if (name === 'brand.html') return 'brand';
+  if (/-DESIGN\.md$/.test(name)) return 'spec';
+  if (/-design-tokens\.json$/.test(name)) return 'tokens';
+  if (/-tailwind\.config\.js$/.test(name)) return 'tokens';
+  if (/-variables\.css$/.test(name)) return 'tokens';
+  if (/-shadcn-theme\.css$/.test(name)) return 'tokens';
+  if (/-figma-variables\.json$/.test(name)) return 'tokens';
+  if (/-theme\.js$/.test(name)) return 'tokens';
+  if (/-wordpress-theme\.json$/.test(name)) return 'tokens';
+  if (/-anatomy\.tsx$/.test(name)) return 'anatomy';
+  if (/-voice\.json$/.test(name)) return 'voice';
+  if (/-motion-tokens\.json$/.test(name)) return 'motion';
+  if (/-icon-system\.json$/.test(name)) return 'icons';
+  if (/-form-states\.json$/.test(name)) return 'states';
+  if (/-mcp\.json$/.test(name)) return 'mcp';
+  if (/-design-language\.md$/.test(name)) return 'spec';
+  if (/-intent\.json$/.test(name)) return 'intent';
+  if (/-library\.json$/.test(name)) return 'intent';
+  if (/-stack-intel\.json$/.test(name)) return 'intent';
+  if (/-seo\.json$/.test(name)) return 'intent';
+  if (/-visual-dna\.json$/.test(name)) return 'intent';
+  if (/-preview\.html$/.test(name)) return 'spec';
+  if (name.startsWith(/.+-prompts\//.test(name) ? '' : '__')) return 'prompts';
+  if (name.includes('-prompts/')) return 'prompts';
+  return 'other';
+}
+
+const GROUP_LABEL = {
+  brand:    'Brand book',
+  spec:     'Spec',
+  tokens:   'Tokens & emitters',
+  anatomy:  'Anatomy',
+  voice:    'Voice',
+  motion:   'Motion',
+  icons:    'Icons',
+  states:   'Form states',
+  mcp:      'MCP / Agent rules',
+  intent:   'Page intel',
+  prompts:  'Prompt pack',
+  other:    'Other',
+};
 
 export default async function GalleryBrandPage({ params }) {
   const { slug } = await params;
   const meta = FEATURED[slug];
   if (!meta) notFound();
 
-  const [tokensRaw, designMd, voiceRaw, motionRaw, intentRaw, tailwindCfg, cssVars] = await Promise.all([
+  const [
+    tokensRaw, designMd, voiceRaw, motionRaw, intentRaw,
+    tailwindCfg, cssVars, shadcnCss, themeJs, wpThemeRaw,
+    anatomyTsx, mcpRaw, iconRaw, formStatesRaw,
+    promptV0, promptLovable, promptCursor, promptClaude,
+    fileList,
+  ] = await Promise.all([
     findFile(slug, '-design-tokens.json'),
     findFile(slug, '-DESIGN.md'),
     findFile(slug, '-voice.json'),
@@ -130,12 +197,25 @@ export default async function GalleryBrandPage({ params }) {
     findFile(slug, '-intent.json'),
     findFile(slug, '-tailwind.config.js'),
     findFile(slug, '-variables.css'),
+    findFile(slug, '-shadcn-theme.css'),
+    findFile(slug, '-theme.js'),
+    findFile(slug, '-wordpress-theme.json'),
+    findFile(slug, '-anatomy.tsx'),
+    findFile(slug, '-mcp.json'),
+    findFile(slug, '-icon-system.json'),
+    findFile(slug, '-form-states.json'),
+    readPrompt(slug, 'v0.txt'),
+    readPrompt(slug, 'lovable.txt'),
+    readPrompt(slug, 'cursor.md'),
+    readPrompt(slug, 'claude-artifacts.md'),
+    listFiles(slug),
   ]);
 
   const tokens = tokensRaw ? JSON.parse(tokensRaw) : null;
   const voice  = voiceRaw  ? JSON.parse(voiceRaw)  : null;
   const motion = motionRaw ? JSON.parse(motionRaw) : null;
   const intent = intentRaw ? JSON.parse(intentRaw) : null;
+  const icons  = iconRaw   ? JSON.parse(iconRaw)   : null;
 
   const palette = pickPalette(tokens);
   const radii   = pickRadii(tokens);
@@ -147,9 +227,28 @@ export default async function GalleryBrandPage({ params }) {
   const primary = palette[0]?.hex || '#7f1d1d';
   const accent  = palette[1]?.hex || '#dc2626';
 
+  // Group files for the downloads strip
+  const fileCount = fileList.length;
+  const grouped = {};
+  for (const f of fileList) {
+    const g = fileGroup(f);
+    (grouped[g] ||= []).push(f);
+  }
+  const groups = Object.keys(grouped).sort((a, b) =>
+    Object.keys(GROUP_LABEL).indexOf(a) - Object.keys(GROUP_LABEL).indexOf(b)
+  );
+
+  // Pull a sample of CTA verbs for the voice section
+  const ctaVerbs = (voice?.ctaVerbs || []).slice(0, 8);
+  const headings = (voice?.headlines || voice?.headings || []).slice(0, 6);
+
+  // Motion durations / easings as flat lists
+  const motionDurations = motion?.duration ? Object.entries(motion.duration).slice(0, 6) : [];
+  const motionEasings   = motion?.easing   ? Object.entries(motion.easing).slice(0, 6)   : [];
+
   return (
     <main>
-      {/* Hero with extracted-brand-tinted gradient */}
+      {/* Hero */}
       <section className="gb-hero">
         <div
           className="gb-hero-bg"
@@ -164,17 +263,17 @@ export default async function GalleryBrandPage({ params }) {
               <img src={`https://icon.horse/icon/${host}`} alt="" width={72} height={72} />
             </div>
             <div className="gb-hero-text">
-              <p className="eyebrow" style={{ marginBottom: 8 }}>extracted · {new Date().toISOString().slice(0, 10)}</p>
+              <p className="eyebrow" style={{ marginBottom: 8 }}>extracted · {fileCount} artefacts</p>
               <h1 className="h1 gb-hero-h1">{host}</h1>
               <p className="lede" style={{ marginTop: 10 }}>
-                Live extraction of{' '}
-                <a href={url} target="_blank" rel="noreferrer" style={{ color: 'var(--red-3)' }}>{url}</a>{' '}
-                — every colour, font, spacing token, shadow, radius, motion curve, anatomy and brand voice. Generated with one command.
+                Live extraction of <a href={url} target="_blank" rel="noreferrer" style={{ color: 'var(--red-3)' }}>{url}</a> —
+                tokens, emitters, anatomy, icons, voice, motion, MCP server, AGENTS.md, prompt pack and a 13-chapter brand book.
+                Generated with one command.
               </p>
               <div className="row" style={{ marginTop: 20, gap: 10, flexWrap: 'wrap' }}>
                 <a href={`/gallery/${slug}/brand.html`} target="_blank" rel="noreferrer" className="btn btn-primary">Open brand book ↗</a>
                 <a href="#tokens" className="btn btn-ghost">Browse tokens</a>
-                <a href={`/api/extract`} className="btn btn-ghost" style={{ display: 'none' }}>Re-extract</a>
+                <a href="#downloads" className="btn btn-ghost">All {fileCount} files</a>
               </div>
             </div>
             <div className="gb-hero-stats">
@@ -187,10 +286,22 @@ export default async function GalleryBrandPage({ params }) {
         </div>
       </section>
 
-      {/* Two-column body: palette + tabbed code */}
+      {/* "vs them" strip */}
+      <section className="gb-vs-strip">
+        <div className="wrap gb-vs-row">
+          <div>
+            <span className="mono faint" style={{ fontSize: 11, letterSpacing: '0.16em', textTransform: 'uppercase' }}>vs design-extractor.com</span>
+            <p style={{ margin: '6px 0 0', color: 'var(--fg-2)', fontSize: 14 }}>
+              They surface <strong style={{ color: '#fff' }}>4 sections</strong> per brand (DESIGN.md · Tailwind · CSS · Tokens). designlang ships <strong style={{ color: '#fff' }}>{fileCount} artefacts</strong> for {host} and renders <strong style={{ color: '#fff' }}>12+ sections</strong> below.
+            </p>
+          </div>
+          <a href="/vs/design-extractor" className="btn btn-ghost btn-sm">See full comparison ↗</a>
+        </div>
+      </section>
+
+      {/* Tokens & code (expanded tabs) */}
       <section className="section gb-body" id="tokens">
         <div className="wrap gb-grid">
-          {/* Left: palette + radii + spacing */}
           <aside className="gb-side">
             <header className="gb-side-head">
               <h2 className="h3" style={{ margin: 0 }}>Palette</h2>
@@ -208,58 +319,60 @@ export default async function GalleryBrandPage({ params }) {
               ))}
             </div>
 
-            {radii.length > 0 && (
-              <>
-                <header className="gb-side-head" style={{ marginTop: 28 }}>
-                  <h2 className="h3" style={{ margin: 0 }}>Radii</h2>
-                  <span className="mono faint" style={{ fontSize: 11 }}>{radii.length} steps</span>
-                </header>
-                <div className="gb-radii">
-                  {radii.map((r, i) => {
-                    const px = parseFloat(r.value) || 0;
-                    return (
-                      <div key={i} className="gb-radius">
-                        <div className="gb-radius-tile" style={{ borderRadius: Math.min(px, 32) }} />
-                        <span className="mono">{r.path.split('.').pop()}</span>
-                        <span className="mono faint">{r.value}px</span>
-                      </div>
-                    );
-                  })}
-                </div>
-              </>
-            )}
+            {radii.length > 0 && (<>
+              <header className="gb-side-head" style={{ marginTop: 28 }}>
+                <h2 className="h3" style={{ margin: 0 }}>Radii</h2>
+                <span className="mono faint" style={{ fontSize: 11 }}>{radii.length} steps</span>
+              </header>
+              <div className="gb-radii">
+                {radii.map((r, i) => {
+                  const px = parseFloat(r.value) || 0;
+                  return (
+                    <div key={i} className="gb-radius">
+                      <div className="gb-radius-tile" style={{ borderRadius: Math.min(px, 32) }} />
+                      <span className="mono">{r.path.split('.').pop()}</span>
+                      <span className="mono faint">{r.value}px</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </>)}
 
-            {spacing.length > 0 && (
-              <>
-                <header className="gb-side-head" style={{ marginTop: 28 }}>
-                  <h2 className="h3" style={{ margin: 0 }}>Spacing</h2>
-                  <span className="mono faint" style={{ fontSize: 11 }}>{spacing.length} steps</span>
-                </header>
-                <div className="gb-spacing">
-                  {spacing.map((s, i) => {
-                    const px = parseFloat(s.value) || 0;
-                    return (
-                      <div key={i} className="gb-spacing-row">
-                        <span className="mono" style={{ width: 80, color: 'var(--fg-3)' }}>{s.path.split('.').pop()}</span>
-                        <span className="gb-spacing-bar" style={{ width: Math.min(px * 2, 220), background: primary }} />
-                        <span className="mono faint" style={{ width: 50, textAlign: 'right' }}>{s.value}px</span>
-                      </div>
-                    );
-                  })}
-                </div>
-              </>
-            )}
+            {spacing.length > 0 && (<>
+              <header className="gb-side-head" style={{ marginTop: 28 }}>
+                <h2 className="h3" style={{ margin: 0 }}>Spacing</h2>
+                <span className="mono faint" style={{ fontSize: 11 }}>{spacing.length} steps</span>
+              </header>
+              <div className="gb-spacing">
+                {spacing.map((s, i) => {
+                  const px = parseFloat(s.value) || 0;
+                  return (
+                    <div key={i} className="gb-spacing-row">
+                      <span className="mono" style={{ width: 80, color: 'var(--fg-3)' }}>{s.path.split('.').pop()}</span>
+                      <span className="gb-spacing-bar" style={{ width: Math.min(px * 2, 220), background: primary }} />
+                      <span className="mono faint" style={{ width: 50, textAlign: 'right' }}>{s.value}px</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </>)}
           </aside>
 
-          {/* Right: tabbed source viewer (client) */}
           <div className="gb-main">
             <GalleryTabs
               host={host}
               slug={slug}
-              designMd={designMd || ''}
-              tailwindCfg={tailwindCfg || ''}
-              cssVars={cssVars || ''}
-              tokensJson={tokensRaw || ''}
+              files={[
+                { id: 'design',   label: 'DESIGN.md',          body: designMd    || '' },
+                { id: 'tokens',   label: 'design-tokens.json', body: tokensRaw   || '' },
+                { id: 'tailwind', label: 'tailwind.config.js', body: tailwindCfg || '' },
+                { id: 'css',      label: 'variables.css',      body: cssVars     || '' },
+                { id: 'shadcn',   label: 'shadcn-theme.css',   body: shadcnCss   || '' },
+                { id: 'theme',    label: 'theme.js',           body: themeJs     || '' },
+                { id: 'wp',       label: 'wordpress-theme.json', body: wpThemeRaw || '' },
+                { id: 'anatomy',  label: 'anatomy.tsx',        body: anatomyTsx  || '' },
+                { id: 'mcp',      label: 'mcp.json',           body: mcpRaw      || '' },
+              ].filter(t => t.body)}
             />
           </div>
         </div>
@@ -267,7 +380,7 @@ export default async function GalleryBrandPage({ params }) {
 
       {/* Typography */}
       {font && (
-        <section className="section gb-typo" style={{ paddingTop: 32 }}>
+        <section className="section" style={{ paddingTop: 32 }} id="typography">
           <div className="wrap">
             <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 22, flexWrap: 'wrap', gap: 10 }}>
               <h2 className="h2" style={{ fontSize: 28, margin: 0 }}>Typography</h2>
@@ -294,29 +407,205 @@ export default async function GalleryBrandPage({ params }) {
       )}
 
       {/* Voice */}
-      {Array.isArray(voice?.headlines) && voice.headlines.length > 0 && (
-        <section className="section" style={{ paddingTop: 32 }}>
+      {(headings.length > 0 || ctaVerbs.length > 0) && (
+        <section className="section" style={{ paddingTop: 32 }} id="voice">
           <div className="wrap">
-            <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>Voice</h2>
-            <p className="lede" style={{ marginBottom: 22 }}>Real headlines pulled from the live page.</p>
-            <div className="grid-3">
-              {voice.headlines.slice(0, 6).map((q, i) => (
-                <blockquote key={i} className="voice-quote" style={{ borderLeftColor: primary, fontSize: 16 }}>
-                  &ldquo;{String(q).slice(0, 160)}&rdquo;
-                </blockquote>
+            <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 22, flexWrap: 'wrap', gap: 10 }}>
+              <div>
+                <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>Voice</h2>
+                <p className="lede" style={{ margin: 0 }}>Tone, CTA verbs, headlines and pronoun stance — pulled from the live page.</p>
+              </div>
+              {voice?.tone && <span className="mono faint" style={{ fontSize: 12 }}>tone · {voice.tone}{voice.pronoun ? ` · ${voice.pronoun}` : ''}</span>}
+            </header>
+
+            {ctaVerbs.length > 0 && (
+              <div className="card" style={{ padding: '20px 24px', marginBottom: 18 }}>
+                <p className="mono faint" style={{ fontSize: 11, letterSpacing: '0.16em', textTransform: 'uppercase', margin: '0 0 12px' }}>top CTA verbs</p>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                  {ctaVerbs.map((v, i) => (
+                    <span key={i} className="pill mono" style={{ fontSize: 12 }}>
+                      {v.value || v}
+                      {typeof v === 'object' && v.count ? <span className="faint" style={{ marginLeft: 6 }}>×{v.count}</span> : null}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {headings.length > 0 && (
+              <div className="grid-3">
+                {headings.map((q, i) => (
+                  <blockquote key={i} className="voice-quote" style={{ borderLeftColor: primary, fontSize: 16 }}>
+                    &ldquo;{String(q?.text || q).slice(0, 160)}&rdquo;
+                  </blockquote>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* Motion */}
+      {(motionDurations.length > 0 || motionEasings.length > 0) && (
+        <section className="section" style={{ paddingTop: 32 }} id="motion">
+          <div className="wrap">
+            <header style={{ marginBottom: 22 }}>
+              <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>Motion</h2>
+              <p className="lede" style={{ margin: 0 }}>Durations and easing curves captured from real CSS transitions.</p>
+            </header>
+            <div className="grid-2">
+              {motionDurations.length > 0 && (
+                <div className="card" style={{ padding: '20px 24px' }}>
+                  <p className="mono faint" style={{ fontSize: 11, letterSpacing: '0.16em', textTransform: 'uppercase', margin: '0 0 14px' }}>durations</p>
+                  <div className="gb-spacing">
+                    {motionDurations.map(([k, v]) => {
+                      const ms = parseInt(String(v?.$value || v || '0'), 10) || 0;
+                      return (
+                        <div key={k} className="gb-spacing-row">
+                          <span className="mono" style={{ width: 80, color: 'var(--fg-3)' }}>{k}</span>
+                          <span className="gb-spacing-bar" style={{ width: Math.min(ms / 3, 220), background: primary }} />
+                          <span className="mono faint" style={{ width: 60, textAlign: 'right' }}>{v?.$value || v}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+              {motionEasings.length > 0 && (
+                <div className="card" style={{ padding: '20px 24px' }}>
+                  <p className="mono faint" style={{ fontSize: 11, letterSpacing: '0.16em', textTransform: 'uppercase', margin: '0 0 14px' }}>easings</p>
+                  <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {motionEasings.map(([k, v]) => (
+                      <li key={k} style={{ display: 'flex', justifyContent: 'space-between', gap: 12, fontSize: 12 }}>
+                        <span className="mono" style={{ color: '#fff' }}>{k}</span>
+                        <span className="mono faint">{v?.$value || v}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Component anatomy */}
+      {anatomyTsx && (
+        <section className="section" style={{ paddingTop: 32 }} id="anatomy">
+          <div className="wrap">
+            <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 22, flexWrap: 'wrap', gap: 10 }}>
+              <div>
+                <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>Component anatomy</h2>
+                <p className="lede" style={{ margin: 0 }}>Typed React stubs — variants, slots and props detected from clustered DOM patterns.</p>
+              </div>
+              <span className="mono faint" style={{ fontSize: 12 }}>{anatomyTsx.length.toLocaleString()} chars · TypeScript</span>
+            </header>
+            <pre className="mcp-snippet" style={{ maxHeight: 420, overflow: 'auto' }}>{anatomyTsx.slice(0, 2400)}</pre>
+          </div>
+        </section>
+      )}
+
+      {/* Icon system */}
+      {icons && (
+        <section className="section" style={{ paddingTop: 32 }} id="icons">
+          <div className="wrap">
+            <header style={{ marginBottom: 22 }}>
+              <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>Icon system</h2>
+              <p className="lede" style={{ margin: 0 }}>SVG icon census — count, style mix, grid and stroke profile.</p>
+            </header>
+            <div className="card" style={{ padding: '20px 24px' }}>
+              <div className="dx-summary-grid" style={{ marginBottom: 0 }}>
+                <div className="dx-num"><div className="dx-num-value">{icons.stats?.count ?? '—'}</div><div className="dx-num-label mono">total icons</div></div>
+                <div className="dx-num"><div className="dx-num-value">{icons.stats?.strokeOnly ?? 0}</div><div className="dx-num-label mono">stroke-only</div></div>
+                <div className="dx-num"><div className="dx-num-value">{icons.stats?.fillOnly ?? 0}</div><div className="dx-num-label mono">fill-only</div></div>
+                <div className="dx-num"><div className="dx-num-value">{icons.stats?.avgStrokeWidth?.toFixed?.(2) ?? '—'}</div><div className="dx-num-label mono">avg stroke</div></div>
+                <div className="dx-num"><div className="dx-num-value">{icons.library !== 'unknown' ? icons.library : '—'}</div><div className="dx-num-label mono">library</div></div>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* MCP / Agent rules */}
+      {mcpRaw && (
+        <section className="section" style={{ paddingTop: 32 }} id="mcp">
+          <div className="wrap">
+            <header style={{ marginBottom: 22 }}>
+              <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>MCP / Agent rules</h2>
+              <p className="lede" style={{ marginBottom: 16 }}>
+                The same payload the stdio MCP server hands to Claude Code, Cursor and Windsurf. Wire it into your editor and the agent
+                answers brand-system questions with the actual extraction — not a guess.
+              </p>
+              <div className="row" style={{ gap: 10, flexWrap: 'wrap' }}>
+                <a href="/blog/mcp-launch" className="btn btn-ghost btn-sm">How to wire MCP →</a>
+                <code className="kbd" style={{ fontSize: 12, padding: '6px 10px' }}>npx designlang mcp --url {url}</code>
+              </div>
+            </header>
+            <pre className="mcp-snippet" style={{ maxHeight: 420, overflow: 'auto' }}>{mcpRaw.slice(0, 2400)}</pre>
+          </div>
+        </section>
+      )}
+
+      {/* Prompt pack */}
+      {(promptV0 || promptLovable || promptCursor || promptClaude) && (
+        <section className="section" style={{ paddingTop: 32 }} id="prompts">
+          <div className="wrap">
+            <header style={{ marginBottom: 22 }}>
+              <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>Prompt pack</h2>
+              <p className="lede" style={{ margin: 0 }}>
+                Paste-ready prompts pre-loaded with the {host} system, for v0, Lovable, Cursor and Claude Artifacts.
+              </p>
+            </header>
+            <div className="grid-2">
+              {[
+                ['v0',     promptV0],
+                ['Lovable', promptLovable],
+                ['Cursor', promptCursor],
+                ['Claude Artifacts', promptClaude],
+              ].filter(([, body]) => body).map(([label, body]) => (
+                <div key={label} className="card" style={{ padding: '18px 20px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+                  <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+                    <span className="h3" style={{ margin: 0, fontSize: 16 }}>{label}</span>
+                    <span className="mono faint" style={{ fontSize: 11 }}>{body.length.toLocaleString()} chars</span>
+                  </header>
+                  <pre style={{ margin: 0, padding: '12px 14px', background: 'rgba(0,0,0,0.4)', border: '1px solid var(--hairline)', borderRadius: 8, fontFamily: 'var(--ff-mono)', fontSize: 11.5, lineHeight: 1.55, color: 'var(--fg-2)', maxHeight: 200, overflow: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{body.slice(0, 600)}{body.length > 600 ? '…' : ''}</pre>
+                </div>
               ))}
             </div>
           </div>
         </section>
       )}
 
-      {/* Motion */}
-      {motion && (
-        <section className="section" style={{ paddingTop: 32 }}>
+      {/* All downloads */}
+      {fileCount > 0 && (
+        <section className="section" style={{ paddingTop: 32 }} id="downloads">
           <div className="wrap">
-            <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>Motion</h2>
-            <p className="lede" style={{ marginBottom: 22 }}>Durations and easing curves captured live.</p>
-            <pre className="mcp-snippet" style={{ maxWidth: 760 }}>{JSON.stringify(motion, null, 2).slice(0, 1200)}</pre>
+            <header style={{ marginBottom: 22 }}>
+              <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>All artefacts</h2>
+              <p className="lede" style={{ margin: 0 }}>
+                Every file designlang produced for {host} — {fileCount} in total. Download anything.
+              </p>
+            </header>
+            <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+              {groups.map((g) => (
+                <div key={g} className="gb-dl-group">
+                  <div className="gb-dl-group-head">
+                    <span className="mono">{GROUP_LABEL[g] || g}</span>
+                    <span className="mono faint" style={{ fontSize: 11 }}>{grouped[g].length} {grouped[g].length === 1 ? 'file' : 'files'}</span>
+                  </div>
+                  <ul className="gb-dl-list">
+                    {grouped[g].map((f) => (
+                      <li key={f}>
+                        <a href={`/gallery/${slug}/${f}`} target="_blank" rel="noreferrer">
+                          <span className="mono">{f}</span>
+                          <span className="mono faint">↗</span>
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
           </div>
         </section>
       )}
@@ -327,7 +616,7 @@ export default async function GalleryBrandPage({ params }) {
           <div className="card" style={{ maxWidth: 720, width: '100%', padding: '32px 32px', textAlign: 'center' }}>
             <h2 className="h2" style={{ fontSize: 28, marginBottom: 8 }}>Run designlang on your own URL.</h2>
             <p className="lede" style={{ margin: '0 auto 18px' }}>
-              Same depth as the {host} extraction above. No signup, no API key.
+              Same {fileCount}-artefact depth as the {host} extraction above. No signup, no API key.
             </p>
             <div className="row" style={{ justifyContent: 'center', flexWrap: 'wrap' }}>
               <code className="kbd" style={{ fontSize: 13, padding: '8px 14px' }}>npx designlang yoursite.com</code>

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -1066,6 +1066,41 @@ code, pre, kbd { font-family: var(--ff-mono); font-size: 13px; }
   box-shadow: inset 0 0 0 1px rgba(255,255,255,0.12);
 }
 
+/* "vs design-extractor" strip on the brand page */
+.gb-vs-strip {
+  border-top: 1px solid var(--hairline);
+  border-bottom: 1px solid var(--hairline);
+  background: rgba(255,255,255,0.02);
+}
+.gb-vs-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 18px; padding: 16px 0; flex-wrap: wrap;
+}
+@media (max-width: 640px) {
+  .gb-vs-row { padding: 14px 0; }
+}
+
+/* downloads list (artefact roll-up) */
+.gb-dl-group + .gb-dl-group { border-top: 1px solid var(--hairline); }
+.gb-dl-group-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding: 14px 20px;
+  background: rgba(255,255,255,0.02);
+  font-family: var(--ff-mono); font-size: 12px;
+  letter-spacing: 0.04em; color: var(--fg);
+  border-bottom: 1px solid var(--hairline);
+}
+.gb-dl-list { list-style: none; margin: 0; padding: 0; }
+.gb-dl-list li { border-bottom: 1px solid var(--hairline); }
+.gb-dl-list li:last-child { border-bottom: 0; }
+.gb-dl-list a {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 20px;
+  font-size: 13px; color: var(--fg-2);
+  transition: background .15s, color .15s;
+}
+.gb-dl-list a:hover { background: rgba(255,255,255,0.03); color: #fff; }
+
 /* tabbed source viewer */
 .gb-source {
   display: flex; flex-direction: column;


### PR DESCRIPTION
Per feedback: the per-brand gallery page mirrored design-extractor.com's 4-section layout, but designlang ships way more. Now surfaces all of it.

**New sections** (in addition to the existing palette + tokens viewer + typography):

- **vs strip** below the hero: 'They show 4 sections per brand. designlang ships {N} artefacts for this brand and renders 12+ sections below.'
- **Voice** — tone + pronoun stance + CTA-verb pills + 6 real headlines as colour-tinted blockquotes
- **Motion** — durations as a bar chart (sized to ms, coloured with the brand primary) + easings list (was a raw JSON dump)
- **Component anatomy** — typed React stub from `<slug>-anatomy.tsx` (variants, slots, props detected from clustered DOM)
- **Icon system** — count / stroke-only / fill-only / avg stroke / detected library (Heroicons / Lucide / etc.)
- **MCP / Agent rules** — the actual `<slug>-mcp.json` payload + "how to wire MCP" link + `npx designlang mcp --url <host>` snippet
- **Prompt pack** — paste-ready v0 / Lovable / Cursor / Claude Artifacts prompt cards (loaded from `<slug>-prompts/{v0.txt,lovable.txt,cursor.md,claude-artifacts.md}`)
- **All artefacts** — full file roll-up grouped by kind (brand book, tokens, anatomy, voice, motion, icons, form states, page intel, prompt pack), every file linked

**Source viewer** (`GalleryTabs`) refactored to take a generic `files[]` array. Now exposes **9 tabs** by default: DESIGN.md, design-tokens.json, tailwind.config.js, variables.css, shadcn-theme.css, theme.js, wordpress-theme.json, anatomy.tsx, mcp.json (was 4).

**Metadata** bumped: title leads with 'every token, every emitter, every prompt'; description names every artefact class and calls out '17+ files vs design-extractor.com (4 outputs)' for SEO.