### PR TITLE
feat(api): `/api/pdf/[hash]` — server-rendered brand-book PDF

### DIFF
--- a/website/app/api/pdf/[hash]/route.js
+++ b/website/app/api/pdf/[hash]/route.js
@@ -1,0 +1,93 @@
+// GET /api/pdf/[hash] — render the cached extraction's brand book as PDF.
+//
+// Reuses the same Playwright route as /api/extract (Browserless if a
+// token is set, bundled @sparticuz/chromium on Vercel otherwise) so
+// the deploy doesn't need a separate browser dependency. Output is
+// streamed as application/pdf, downloadable as <host>-brand.pdf.
+
+import { getCachedByHash } from '../../../../lib/cache.js';
+import { formatBrandBook } from '../../../../../src/formatters/brand-book.js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+async function getBrowserOptions() {
+  if (process.env.BROWSERLESS_TOKEN) {
+    const region = process.env.BROWSERLESS_REGION || 'production-sfo';
+    return { wsEndpoint: `wss://${region}.browserless.io/?token=${process.env.BROWSERLESS_TOKEN}` };
+  }
+  if (process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME) {
+    const chromium = (await import('@sparticuz/chromium')).default;
+    return {
+      executablePath: await chromium.executablePath(),
+      browserArgs: chromium.args,
+    };
+  }
+  return {};
+}
+
+function safeHost(url) {
+  try { return new URL(url).hostname.replace(/^www\./, ''); } catch { return 'site'; }
+}
+
+function err(status, message) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+export async function GET(_req, { params }) {
+  const { hash } = await params;
+  if (!hash || !/^[a-z0-9-]{4,80}$/i.test(hash)) return err(400, 'bad hash');
+
+  const cached = await getCachedByHash(hash).catch(() => null);
+  if (!cached?.design) return err(404, 'extraction not found');
+
+  const design = cached.design;
+  const host = safeHost(design?.meta?.url);
+  const html = formatBrandBook(design);
+
+  // Spin up a browser via the same path /api/extract uses.
+  const { chromium } = await import('playwright-core');
+  const opts = await getBrowserOptions();
+  let browser;
+  try {
+    if (opts.wsEndpoint) {
+      browser = await chromium.connect(opts.wsEndpoint);
+    } else if (opts.executablePath) {
+      browser = await chromium.launch({ executablePath: opts.executablePath, args: opts.browserArgs || [] });
+    } else {
+      browser = await chromium.launch();
+    }
+  } catch (e) {
+    return err(500, `browser launch failed: ${e.message}`);
+  }
+
+  try {
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'networkidle' });
+    const pdfBuf = await page.pdf({
+      format: 'a4',
+      printBackground: true,
+      margin: { top: '24mm', right: '18mm', bottom: '20mm', left: '18mm' },
+      displayHeaderFooter: true,
+      headerTemplate: '<div></div>',
+      footerTemplate: `<div style="font-family: -apple-system, sans-serif; font-size: 9px; color: #888; width: 100%; padding: 0 18mm; display: flex; justify-content: space-between;"><span>designlang · ${host} brand guidelines</span><span><span class="pageNumber"></span> of <span class="totalPages"></span></span></div>`,
+    });
+
+    return new Response(pdfBuf, {
+      status: 200,
+      headers: {
+        'content-type': 'application/pdf',
+        'content-disposition': `attachment; filename="${host}-brand.pdf"`,
+        'cache-control': 'public, max-age=3600, stale-while-revalidate=86400',
+      },
+    });
+  } catch (e) {
+    return err(500, `pdf render failed: ${e.message}`);
+  } finally {
+    try { await browser.close(); } catch { /* ignore */ }
+  }
+}


### PR DESCRIPTION
Every extraction gets a permalink at `/x/<hash>` and a brand-book HTML. This PR adds the matching server-side PDF render so users can download a real, paginated, bookmarked, embed-fonted PDF without installing the CLI.

## Route

```
GET /api/pdf/<hash>
→ application/pdf
  content-disposition: attachment; filename=<host>-brand.pdf
  cache-control: public, max-age=3600, stale-while-revalidate=86400
```

## Browser path

Reuses the same options helper as `/api/extract`:

- **Browserless WS endpoint** if `BROWSERLESS_TOKEN` is set (preferred — no Chromium in the function, ~50ms cold-start)
- **`@sparticuz/chromium`** on Vercel / Lambda otherwise (CPU cost)
- **Local `chromium.launch()`** in dev

## Rendering

`page.pdf({...})` with A4 paper, print backgrounds on (so the brand-colour cover band renders), 24/18/20/18 mm margins, and a running footer showing `designlang · <host> brand guidelines · <page> of <total>`.

## Cache

1 hour direct + 24 hour stale-while-revalidate so a popular brand-book PDF (say, /api/pdf/stripe-com-…) is served straight from CDN edge after the first render.

Pairs with PR #119 (CLI `--pdf`) and PR #118 (`AGENT.md`) to complete the v12.14 "every extraction is shippable" loop.