### PR TITLE
feat(web): footer sponsor slot + Vercel Speed Insights

### DIFF
--- a/website/app/components/SponsorSlot.js
+++ b/website/app/components/SponsorSlot.js
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+// Footer sponsor slot. Renders one of three providers depending on the
+// NEXT_PUBLIC_SPONSOR_PROVIDER env var. Renders NOTHING until the
+// provider and its required ids are set, so the site stays clean
+// until the publisher accounts exist.
+//
+// Vercel env vars:
+//   NEXT_PUBLIC_SPONSOR_PROVIDER     ethicalads | carbon | adsense
+//   NEXT_PUBLIC_ETHICALADS_PUBLISHER <publisher slug>
+//   NEXT_PUBLIC_CARBON_SERVE         <serve id>
+//   NEXT_PUBLIC_CARBON_PLACEMENT     <placement id>
+//   NEXT_PUBLIC_ADSENSE_CLIENT       ca-pub-XXXXXXXXXXXXXXXX
+//   NEXT_PUBLIC_ADSENSE_SLOT         <slot id>
+
+const PROVIDER  = process.env.NEXT_PUBLIC_SPONSOR_PROVIDER || '';
+const EA_PUB    = process.env.NEXT_PUBLIC_ETHICALADS_PUBLISHER || '';
+const CARBON_S  = process.env.NEXT_PUBLIC_CARBON_SERVE || '';
+const CARBON_P  = process.env.NEXT_PUBLIC_CARBON_PLACEMENT || '';
+const ADS_CLIENT = process.env.NEXT_PUBLIC_ADSENSE_CLIENT || '';
+const ADS_SLOT   = process.env.NEXT_PUBLIC_ADSENSE_SLOT || '';
+
+export default function SponsorSlot() {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const host = ref.current;
+    if (!host) return;
+
+    if (PROVIDER === 'ethicalads' && EA_PUB) {
+      const s = document.createElement('script');
+      s.async = true;
+      s.src = 'https://media.ethicalads.io/media/client/ethicalads.min.js';
+      host.appendChild(s);
+      return () => { try { host.removeChild(s); } catch { /* ignore */ } };
+    }
+
+    if (PROVIDER === 'carbon' && CARBON_S && CARBON_P) {
+      const s = document.createElement('script');
+      s.async = true;
+      s.type = 'text/javascript';
+      s.id = '_carbonads_js';
+      s.src = `//cdn.carbonads.com/carbon.js?serve=${encodeURIComponent(CARBON_S)}&placement=${encodeURIComponent(CARBON_P)}`;
+      host.appendChild(s);
+      return () => { try { host.removeChild(s); } catch { /* ignore */ } };
+    }
+
+    if (PROVIDER === 'adsense' && ADS_CLIENT && ADS_SLOT) {
+      // The loader script is added once via <head>; here we just push.
+      try {
+        (window.adsbygoogle = window.adsbygoogle || []).push({});
+      } catch { /* ignore */ }
+    }
+  }, []);
+
+  // Nothing configured → render nothing. Site stays clean.
+  const configured =
+    (PROVIDER === 'ethicalads' && EA_PUB) ||
+    (PROVIDER === 'carbon' && CARBON_S && CARBON_P) ||
+    (PROVIDER === 'adsense' && ADS_CLIENT && ADS_SLOT);
+  if (!configured) return null;
+
+  return (
+    <div className="sponsor-wrap">
+      <div className="sponsor-rule" aria-hidden />
+      <div className="sponsor-inner" ref={ref}>
+        <span className="sponsor-tag mono">sponsored</span>
+
+        {PROVIDER === 'ethicalads' && (
+          <div
+            data-ea-publisher={EA_PUB}
+            data-ea-type="text"
+            data-ea-style="stickybox"
+            className="sponsor-ea"
+          />
+        )}
+
+        {PROVIDER === 'carbon' && <div className="sponsor-carbon" />}
+
+        {PROVIDER === 'adsense' && (
+          <ins
+            className="adsbygoogle sponsor-adsense"
+            style={{ display: 'block' }}
+            data-ad-client={ADS_CLIENT}
+            data-ad-slot={ADS_SLOT}
+            data-ad-format="auto"
+            data-full-width-responsive="true"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -1346,6 +1346,44 @@ code, pre, kbd { font-family: var(--ff-mono); font-size: 13px; }
 .seo-prose a { color: var(--red-3); border-bottom: 1px solid rgba(255,128,128,0.3); }
 .seo-prose a:hover { color: #fff; border-bottom-color: rgba(255,255,255,0.5); }
 
+/* ── Footer sponsor slot ─────────────────────────────────────── */
+
+.sponsor-wrap {
+  display: flex; flex-direction: column; align-items: center;
+  padding: 0 24px;
+}
+.sponsor-rule {
+  width: 100%; max-width: var(--maxw); height: 1px;
+  background: linear-gradient(90deg, transparent, var(--hairline-2), transparent);
+}
+.sponsor-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 10px;
+  padding: 28px 0 8px;
+  min-height: 1px;
+}
+.sponsor-tag {
+  font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-3);
+}
+.sponsor-ea, .sponsor-carbon, .sponsor-adsense {
+  max-width: 360px; width: 100%;
+}
+/* EthicalAds dark-theme nudge so it sits in the black footer */
+.sponsor-ea[data-ea-style] { color: var(--fg-2); }
+#carbonads {
+  font-family: var(--ff-sans); font-size: 12px;
+  background: var(--surface-2); border: 1px solid var(--hairline);
+  border-radius: 12px; overflow: hidden; max-width: 360px;
+}
+#carbonads a { color: var(--fg-2); }
+#carbonads a:hover { color: #fff; }
+.carbon-text { padding: 10px 12px; display: block; }
+.carbon-poweredby {
+  display: block; padding: 6px 12px; font-size: 9px;
+  letter-spacing: 0.1em; text-transform: uppercase; color: var(--fg-3);
+  border-top: 1px solid var(--hairline);
+}
+
 /* ── Footer ──────────────────────────────────────────────────── */
 
 footer.ftr {

--- a/website/app/layout.js
+++ b/website/app/layout.js
@@ -1,5 +1,7 @@
 import { Geist, Geist_Mono } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
+import SponsorSlot from './components/SponsorSlot';
 import StructuredData from './components/StructuredData';
 import MobileMenu from './components/MobileMenu';
 import {
@@ -209,6 +211,11 @@ function Footer() {
 }
 
 export default function RootLayout({ children }) {
+  const adsenseClient =
+    process.env.NEXT_PUBLIC_SPONSOR_PROVIDER === 'adsense'
+      ? process.env.NEXT_PUBLIC_ADSENSE_CLIENT
+      : null;
+
   return (
     <html lang="en" className={`${sans.variable} ${mono.variable}`}>
       <head>
@@ -217,12 +224,22 @@ export default function RootLayout({ children }) {
         <link rel="author" href="https://manavaryasingh.com" />
         <link rel="me" href="https://github.com/Manavarya09" />
         <StructuredData />
+        {adsenseClient ? (
+          // eslint-disable-next-line @next/next/no-sync-scripts
+          <script
+            async
+            src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${adsenseClient}`}
+            crossOrigin="anonymous"
+          />
+        ) : null}
       </head>
       <body>
         <Nav />
         {children}
         <Footer />
+        <SponsorSlot />
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,6 +11,7 @@
         "@sparticuz/chromium": "^147.0.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/blob": "^2.3.3",
+        "@vercel/speed-insights": "^2.0.0",
         "jszip": "^3.10.1",
         "motion": "^12.38.0",
         "next": "16.2.6",
@@ -708,6 +709,44 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/async-retry": {

--- a/website/package.json
+++ b/website/package.json
@@ -11,6 +11,7 @@
     "@sparticuz/chromium": "^147.0.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/blob": "^2.3.3",
+    "@vercel/speed-insights": "^2.0.0",
     "jszip": "^3.10.1",
     "motion": "^12.38.0",
     "next": "16.2.6",


### PR DESCRIPTION
## Footer sponsor slot

A configurable `SponsorSlot` placement above the footer, sitewide. Supports three providers, picked via `NEXT_PUBLIC_SPONSOR_PROVIDER`:

| Provider | Env vars |
|---|---|
| `ethicalads` | `NEXT_PUBLIC_ETHICALADS_PUBLISHER` |
| `carbon` | `NEXT_PUBLIC_CARBON_SERVE`, `NEXT_PUBLIC_CARBON_PLACEMENT` |
| `adsense` | `NEXT_PUBLIC_ADSENSE_CLIENT`, `NEXT_PUBLIC_ADSENSE_SLOT` |

Key behaviour: **renders `null` until the provider and its ids are set** — so the live site stays exactly as it is now until the publisher accounts exist. No empty boxes, no layout shift. The AdSense loader script is injected into `<head>` only when that provider is selected.

Placement: just above the footer, behind a soft gradient divider, with a small `sponsored` label. Styled to match the black/red footer (EthicalAds + Carbon both get dark-theme CSS nudges).

To go live: pick a provider, set the env vars in Vercel, redeploy. Nothing else changes.

## Vercel Speed Insights

Adds `@vercel/speed-insights` and mounts `<SpeedInsights />` in the root layout next to the existing `<Analytics />` — Core Web Vitals (LCP / CLS / INP) reporting for the traffic the site already gets.

Verified: dev build clean, footer unchanged with no env vars set (`.sponsor-wrap` correctly absent from the DOM).