### PR TITLE
fix(api): fall back to bundled Chromium when Browserless fails

### DIFF
--- a/website/app/api/extract/route.js
+++ b/website/app/api/extract/route.js
@@ -31,6 +31,18 @@ const STAGES = [
   'score',
 ];
 
+// Bundled Chromium via @sparticuz on Vercel/Lambda; bare launch in dev.
+async function getLocalBrowserOptions() {
+  if (process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME) {
+    const chromium = (await import('@sparticuz/chromium')).default;
+    return {
+      executablePath: await chromium.executablePath(),
+      browserArgs: chromium.args,
+    };
+  }
+  return {};
+}
+
 async function getBrowserOptions() {
   // Preferred path: connect to a remote Playwright browser (Browserless v2).
   // No Chromium binary on the function — cold starts drop from ~3s to ~50ms,
@@ -41,15 +53,22 @@ async function getBrowserOptions() {
       wsEndpoint: `wss://${region}.browserless.io/?token=${process.env.BROWSERLESS_TOKEN}`,
     };
   }
-  // Fallback: bundled Chromium via @sparticuz on Vercel/Lambda. Costs CPU.
-  if (process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME) {
-    const chromium = (await import('@sparticuz/chromium')).default;
-    return {
-      executablePath: await chromium.executablePath(),
-      browserArgs: chromium.args,
-    };
-  }
-  return {};
+  return getLocalBrowserOptions();
+}
+
+// A Browserless failure (quota exhausted → 401, region down, ws error)
+// should not break extraction — it just means we fall back to the
+// bundled Chromium for that request.
+function isBrowserlessFailure(err) {
+  const m = String(err?.message || err || '').toLowerCase();
+  return (
+    m.includes('browserless') ||
+    m.includes('401') ||
+    m.includes('unauthorized') ||
+    m.includes('usage limit') ||
+    m.includes('connectovercdp') ||
+    m.includes('websocket')
+  );
 }
 
 function ndjson(obj) {
@@ -159,7 +178,21 @@ export async function POST(request) {
         controller.enqueue(ndjson({ type: 'stage', name: 'crawl' }));
 
         const browserOpts = await getBrowserOptions();
-        const design = await extractDesignLanguage(targetUrl, browserOpts);
+        let design;
+        try {
+          design = await extractDesignLanguage(targetUrl, browserOpts);
+        } catch (err) {
+          // Browserless quota / auth / connection failure — retry once on
+          // the bundled Chromium so a dead remote browser never takes the
+          // whole extractor down.
+          if (browserOpts.wsEndpoint && isBrowserlessFailure(err)) {
+            console.warn('[extract] browserless failed, falling back to bundled chromium', err?.message);
+            const fallback = await getLocalBrowserOptions();
+            design = await extractDesignLanguage(targetUrl, fallback);
+          } else {
+            throw err;
+          }
+        }
 
         // Post-stage markers once extraction resolves.
         for (const stage of STAGES.slice(1)) {

--- a/website/app/api/pdf/[hash]/route.js
+++ b/website/app/api/pdf/[hash]/route.js
@@ -12,11 +12,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
-async function getBrowserOptions() {
-  if (process.env.BROWSERLESS_TOKEN) {
-    const region = process.env.BROWSERLESS_REGION || 'production-sfo';
-    return { wsEndpoint: `wss://${region}.browserless.io/?token=${process.env.BROWSERLESS_TOKEN}` };
-  }
+async function getLocalBrowserOptions() {
   if (process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME) {
     const chromium = (await import('@sparticuz/chromium')).default;
     return {
@@ -25,6 +21,21 @@ async function getBrowserOptions() {
     };
   }
   return {};
+}
+
+async function getBrowserOptions() {
+  if (process.env.BROWSERLESS_TOKEN) {
+    const region = process.env.BROWSERLESS_REGION || 'production-sfo';
+    return { wsEndpoint: `wss://${region}.browserless.io/?token=${process.env.BROWSERLESS_TOKEN}` };
+  }
+  return getLocalBrowserOptions();
+}
+
+// Open a browser from options; never let a dead remote browser win.
+async function openBrowser(chromium, opts) {
+  if (opts.wsEndpoint) return chromium.connect(opts.wsEndpoint);
+  if (opts.executablePath) return chromium.launch({ executablePath: opts.executablePath, args: opts.browserArgs || [] });
+  return chromium.launch();
 }
 
 function safeHost(url) {
@@ -49,20 +60,23 @@ export async function GET(_req, { params }) {
   const host = safeHost(design?.meta?.url);
   const html = formatBrandBook(design);
 
-  // Spin up a browser via the same path /api/extract uses.
+  // Spin up a browser via the same path /api/extract uses. If Browserless
+  // is down or out of quota, fall back to the bundled Chromium.
   const { chromium } = await import('playwright-core');
   const opts = await getBrowserOptions();
   let browser;
   try {
-    if (opts.wsEndpoint) {
-      browser = await chromium.connect(opts.wsEndpoint);
-    } else if (opts.executablePath) {
-      browser = await chromium.launch({ executablePath: opts.executablePath, args: opts.browserArgs || [] });
-    } else {
-      browser = await chromium.launch();
-    }
+    browser = await openBrowser(chromium, opts);
   } catch (e) {
-    return err(500, `browser launch failed: ${e.message}`);
+    if (opts.wsEndpoint) {
+      try {
+        browser = await openBrowser(chromium, await getLocalBrowserOptions());
+      } catch (e2) {
+        return err(500, `browser launch failed: ${e2.message}`);
+      }
+    } else {
+      return err(500, `browser launch failed: ${e.message}`);
+    }
   }
 
   try {


### PR DESCRIPTION
## Problem

`browserType.connectOverCDP: WebSocket error: wss://production-sfo.browserless.io/ 401 Unauthorized — You've reached the units usage limit allowed under our free plan`

Once the Browserless free-plan quota was exhausted, every live extraction on the website broke. `/api/extract` and `/api/pdf` connect to Browserless for the headless browser and hard-failed with a 401 — no fallback.

## Fix

Both routes now treat a Browserless failure as recoverable, not fatal:

- **`/api/extract`** — `getLocalBrowserOptions()` is split out from `getBrowserOptions()`. The extraction call is wrapped in try/catch; if it throws and `isBrowserlessFailure()` matches (401 / `unauthorized` / `usage limit` / `connectovercdp` / `websocket` / `browserless`), it retries once on the bundled `@sparticuz/chromium`.
- **`/api/pdf/[hash]`** — new `openBrowser()` helper; if the `wsEndpoint` connect throws, it retries on the local Chromium path before giving up.

A dead or rate-limited Browserless instance no longer takes the whole extractor down — the request just costs a little Vercel CPU instead of the remote browser. When Browserless quota resets (or you upgrade), it transparently goes back to the fast remote path; no config change needed.

Both route files pass `node --check`.