### PR TITLE
Living Studio: interactive design-system editor + /studio on the website (v12.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [12.19.0] — 2026-06-14
+
+**`studio` becomes a living design-system editor — and ships on the website.**
+
+Until now `designlang studio` was a read-only viewer: editorial swatches you
+could copy, static type specimens. This release turns it into a real
+playground — and brings the exact same experience to the web.
+
+- **`designlang studio`** — a local, interactive studio over the latest
+  extraction. An **inspector** (color pickers + the extracted palette, type,
+  shape, spacing, motion) writes a small set of `--p-*` CSS variables; a
+  **tabbed live preview** — a wall of real components (nav, buttons, form,
+  cards, badges, alert, type specimen) and a **rebuilt page** assembled from the
+  extraction's reading order — restyles instantly because everything renders off
+  those variables. Edit a token, watch the whole system move.
+
+  - **Live WCAG contrast grading** under every color (text-on-surface,
+    accent-on-surface, label-on-accent) updates as you edit — AAA / AA / AA-large
+    / fail, in real time.
+  - **Paper / white / dark backdrops** to judge components on any canvas, an
+    **edit counter**, and smooth token-driven transitions.
+  - **Export** the edited system as DTCG tokens, CSS variables, or a Tailwind
+    theme (zero-dependency client-side downloads), and **share via URL** — edits
+    are encoded as deltas in the location hash, so a tweaked variant is just a
+    link.
+
+- **`/studio` on the website** — paste any URL and the same studio opens right
+  in the browser: it extracts the live design language and embeds the editable
+  studio in a framed viewport. Shareable via `?url=`; counts against the same
+  free 2/day demo budget as the extractor.
+
+- **Internals** — the token-derivation engine is now a pure, dependency-free
+  module (`src/studio-tokens.js`) shared by the CLI and the website route, so
+  both surfaces stay in lock-step. New unit tests cover derivation, the WCAG
+  contrast math, and the rendered studio document.
+
 ## [12.18.0] — 2026-06-12
 
 **`verify` closes the loop — designlang now *proves* its extraction with a fidelity score.**

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It also goes where extractors don't: **layout patterns**, **responsive behavior 
 
 ```bash
 npx designlang https://stripe.com                      # extract everything
+npx designlang studio                                  # live token editor: edit, preview, export, share ← v12.19
 npx designlang verify stripe.com                       # fidelity score: rebuild from tokens vs live ← v12.18
 npx designlang pair stripe.com linear.app              # fuse two designs (visuals A × voice B)    ← v12.8
 npx designlang brand stripe.com                        # full brand-guidelines book (13 chapters)  ← v12.7

--- a/bin/design-extract.js
+++ b/bin/design-extract.js
@@ -2061,7 +2061,7 @@ program
 // ── Studio — local web studio over the latest extraction ──
 program
   .command('studio')
-  .description('Launch a local web studio over the latest extraction (editorial token browser, voice, motion, DNA).')
+  .description('Launch a live design studio over the latest extraction — edit tokens, watch components restyle, export DTCG/CSS/Tailwind, share via URL.')
   .option('-d, --dir <path>', 'extraction directory', './design-extract-output')
   .option('-p, --port <n>', 'port', parseInt, 4837)
   .option('--prefix <name>', 'extraction prefix (default: newest *-design-tokens.json)')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designlang",
-  "version": "12.18.0",
+  "version": "12.19.0",
   "description": "Extract the complete design language from any website and ship it — clone to a working Next.js starter, guard tokens with a CI drift bot, or browse everything in a local studio. Outputs W3C DTCG tokens, motion tokens, typed anatomy stubs, Tailwind config, and ready-to-paste v0 / Lovable / Cursor / Claude-Artifacts prompts.",
   "type": "module",
   "bin": {

--- a/src/studio-tokens.js
+++ b/src/studio-tokens.js
@@ -1,0 +1,137 @@
+// studio-tokens — pure, dependency-free token derivation for the studio.
+//
+// No node built-ins are imported here, so this module is safe to bundle into
+// a browser/React context (the website studio) as well as the CLI server.
+// It reduces an arbitrary DTCG token tree into the small set of high-impact
+// CSS variables that drive the live preview, with sane fallbacks throughout.
+
+export function hexToRgb(hex) {
+  const h = String(hex || '').replace('#', '');
+  if (h.length === 3) {
+    return { r: parseInt(h[0] + h[0], 16), g: parseInt(h[1] + h[1], 16), b: parseInt(h[2] + h[2], 16) };
+  }
+  return { r: parseInt(h.slice(0, 2), 16) || 0, g: parseInt(h.slice(2, 4), 16) || 0, b: parseInt(h.slice(4, 6), 16) || 0 };
+}
+
+export function luminance(hex) {
+  const { r, g, b } = hexToRgb(hex);
+  return r * 0.299 + g * 0.587 + b * 0.114; // perceptual, 0..255
+}
+
+export function saturation(hex) {
+  const { r, g, b } = hexToRgb(hex);
+  const max = Math.max(r, g, b), min = Math.min(r, g, b);
+  return max === 0 ? 0 : (max - min) / max;
+}
+
+export function blend(a, b, t) {
+  const ca = hexToRgb(a), cb = hexToRgb(b);
+  const mix = (x, y) => Math.round(x + (y - x) * t);
+  const to2 = (n) => n.toString(16).padStart(2, '0');
+  return '#' + to2(mix(ca.r, cb.r)) + to2(mix(ca.g, cb.g)) + to2(mix(ca.b, cb.b));
+}
+
+// WCAG 2.x relative-luminance contrast ratio between two hex colors.
+export function contrastRatio(a, b) {
+  const lin = (c) => { c /= 255; return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4); };
+  const rl = (hex) => { const { r, g, b } = hexToRgb(hex); return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b); };
+  const l1 = rl(a), l2 = rl(b);
+  const hi = Math.max(l1, l2), lo = Math.min(l1, l2);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// Walk a token tree collecting { hex, path } for every color leaf, plus the
+// first dimension / family / shadow values found under helpful keys.
+export function collectTokens(tokens) {
+  const colors = [];
+  const seen = new Set();
+  let radius = null, shadow = null, space = null;
+  const families = [];
+
+  const isHex = (v) => typeof v === 'string' && /^#[0-9a-f]{3,8}$/i.test(v);
+  const isDim = (v) => typeof v === 'string' && /^-?\d+(\.\d+)?(px|rem|em)$/i.test(v);
+
+  const walk = (obj, path) => {
+    if (!obj || typeof obj !== 'object') return;
+    if ('$value' in obj && typeof obj.$value !== 'object') {
+      const v = obj.$value;
+      const key = path.join('.').toLowerCase();
+      if (isHex(v)) {
+        const h = v.toLowerCase();
+        if (!seen.has(h)) { seen.add(h); colors.push({ hex: h, path: key }); }
+      } else if (typeof v === 'string') {
+        if (!radius && /radius|rounded/.test(key) && isDim(v)) radius = v;
+        if (!space && /space|spacing|gap/.test(key) && isDim(v)) space = v;
+        if (!shadow && /shadow|elevation/.test(key) && /\d/.test(v)) shadow = v;
+        if (/font.*family|family.*sans|fontfamily|typeface/.test(key) && !isDim(v) && !isHex(v)) {
+          families.push(v);
+        }
+      }
+      return;
+    }
+    // Typography composite leaves carry fontFamily inside $value objects.
+    if (obj.$value && typeof obj.$value === 'object' && typeof obj.$value.fontFamily === 'string') {
+      families.push(obj.$value.fontFamily);
+    }
+    for (const k of Object.keys(obj)) walk(obj[k], path.concat(k));
+  };
+  walk(tokens || {}, []);
+  return { colors, radius, shadow, space, families };
+}
+
+function pickColor(colors, re, fallbackFn) {
+  const hit = colors.find(c => re.test(c.path));
+  if (hit) return hit.hex;
+  return fallbackFn ? fallbackFn() : null;
+}
+
+export function deriveTokens(data) {
+  const tokens = (data && data.tokens) || {};
+  const { colors, radius, shadow, space, families } = collectTokens(tokens);
+
+  const byLum = colors.slice().sort((a, b) => luminance(a.hex) - luminance(b.hex));
+  const lightest = byLum.length ? byLum[byLum.length - 1].hex : '#ffffff';
+  const darkest = byLum.length ? byLum[0].hex : '#0a0908';
+  const mostSaturated = colors.slice().sort((a, b) => saturation(b.hex) - saturation(a.hex))[0];
+
+  const bg = pickColor(colors, /background|surface|\bbg\b|paper|canvas/, () => lightest);
+  const fg = pickColor(colors, /text|ink|foreground|\bfg\b|body|heading/, () => darkest);
+  const accent = pickColor(colors, /brand|primary|accent|action|cta|link/, () =>
+    (mostSaturated && mostSaturated.hex) || darkest);
+
+  const accentFg = luminance(accent) > 150 ? '#0a0908' : '#ffffff';
+  const muted = blend(fg, bg, 0.55);
+  const border = blend(fg, bg, 0.82);
+  const card = blend(bg, fg, 0.03);
+
+  const family = (families.find(Boolean) || '').replace(/['"]/g, '').split(',')[0].trim();
+  const fontSans = family || 'Instrument Sans';
+  const displayFamily = families.length > 1 ? families[1].replace(/['"]/g, '').split(',')[0].trim() : fontSans;
+
+  const motion = (data && data.motion) || {};
+  const dur = motion.duration?.base || motion.durations?.base || '200ms';
+  const ease = motion.easing?.standard || motion.easings?.standard || 'cubic-bezier(0.2, 0, 0, 1)';
+
+  const vars = {
+    '--p-bg': bg,
+    '--p-card': card,
+    '--p-fg': fg,
+    '--p-muted': muted,
+    '--p-border': border,
+    '--p-accent': accent,
+    '--p-accent-fg': accentFg,
+    '--p-radius': radius || '10px',
+    '--p-fs': '16px',
+    '--p-space': space || '16px',
+    '--p-shadow': shadow || '0 1px 2px rgba(0,0,0,0.06), 0 8px 24px rgba(0,0,0,0.08)',
+    '--p-font': "'" + fontSans + "', system-ui, sans-serif",
+    '--p-font-display': "'" + displayFamily + "', " + "'" + fontSans + "', serif",
+    '--p-dur': dur,
+    '--p-ease': ease,
+  };
+
+  const palette = colors.slice(0, 24).map(c => c.hex);
+  const fonts = Array.from(new Set([fontSans, displayFamily,
+    'Inter', 'Instrument Sans', 'Fraunces', 'Georgia', 'system-ui', 'JetBrains Mono'].filter(Boolean)));
+  return { vars, palette, fonts };
+}

--- a/src/studio.js
+++ b/src/studio.js
@@ -1,14 +1,20 @@
-// studio — a local web studio for the latest extraction.
+// studio — a local, interactive design studio for the latest extraction.
 //
-// Launches a tiny zero-dep HTTP server on localhost that serves an
-// editorial viewer of the last extraction: live-editable token swatches,
-// typography specimens, section reading order, voice, and prompt pack.
+// Launches a tiny zero-dep HTTP server on localhost that serves a living
+// playground over the last extraction: edit a token in the inspector and a
+// wall of real components (plus a rebuilt page) restyles instantly. Export
+// the edited system back out as DTCG tokens, CSS variables, and a Tailwind
+// theme — or copy a shareable link that encodes your edits in the URL.
 //
 // Usage: designlang studio [--dir ./design-extract-output] [--port 4837]
 
 import { createServer } from 'http';
 import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
 import { resolve, join, extname } from 'path';
+import { deriveTokens } from './studio-tokens.js';
+
+// Re-export so existing importers (and tests) can keep reaching it here.
+export { deriveTokens } from './studio-tokens.js';
 
 const MIME = {
   '.html': 'text/html; charset=utf-8',
@@ -58,17 +64,248 @@ function esc(v) {
   return String(v).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
 
-function studioHtml(data) {
-  const tokens = data.tokens || {};
+// ── HTML fragments ────────────────────────────────────────────────────
+
+function styleBlock() {
+  return `<style>
+  :root {
+    --paper: #f3f1ea; --paper-2: #ece8dd; --paper-3: #d8d3c5;
+    --ink: #0a0908; --ink-2: #403c34; --ink-3: #8b8778;
+    --hi: #ff4800;
+    --mono: 'JetBrains Mono', ui-monospace, monospace;
+    --display: 'Fraunces', Georgia, serif;
+    --body: 'Instrument Sans', -apple-system, system-ui, sans-serif;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; background: var(--paper); color: var(--ink); font-family: var(--body); font-size: 14px; line-height: 1.5; }
+  .app { display: grid; grid-template-columns: 320px 1fr; grid-template-rows: auto 1fr; height: 100vh; }
+  .topbar { grid-column: 1 / -1; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 12px 20px; border-bottom: 1px solid var(--ink); background: var(--paper); }
+  .mark { font-family: var(--mono); font-size: 13px; letter-spacing: 0.02em; white-space: nowrap; }
+  .mark em { color: var(--hi); font-style: italic; font-family: var(--display); }
+  .tabs { display: flex; gap: 4px; }
+  .tab { font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; padding: 6px 12px; border: 1px solid var(--ink); background: transparent; color: var(--ink); cursor: pointer; }
+  .tab[aria-selected="true"] { background: var(--ink); color: var(--paper); }
+  .actions { display: flex; gap: 8px; align-items: center; }
+  .btn { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; padding: 7px 12px; border: 1px solid var(--ink); background: var(--paper); color: var(--ink); cursor: pointer; }
+  .btn:hover { background: var(--ink); color: var(--paper); }
+  .btn.hi { background: var(--hi); border-color: var(--hi); color: #fff; }
+  .btn.hi:hover { filter: brightness(1.08); }
+  .menu { position: relative; }
+  .menu-list { position: absolute; right: 0; top: calc(100% + 6px); background: var(--paper); border: 1px solid var(--ink); min-width: 200px; z-index: 20; display: none; }
+  .menu-list.open { display: block; }
+  .menu-list button { display: block; width: 100%; text-align: left; padding: 9px 14px; border: 0; border-bottom: 1px solid var(--paper-3); background: transparent; font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; cursor: pointer; color: var(--ink); }
+  .menu-list button:last-child { border-bottom: 0; }
+  .menu-list button:hover { background: var(--paper-2); }
+
+  .inspector { border-right: 1px solid var(--ink); overflow-y: auto; padding: 8px 0 40px; }
+  .grp { border-bottom: 1px solid var(--paper-3); padding: 16px 20px; }
+  .grp h3 { font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-3); margin-bottom: 14px; }
+  .field { display: grid; grid-template-columns: 70px 1fr; align-items: center; gap: 12px; margin-bottom: 12px; }
+  .field:last-child { margin-bottom: 0; }
+  .field label { font-family: var(--mono); font-size: 11px; color: var(--ink-2); letter-spacing: 0.02em; }
+  .field input[type="color"] { width: 100%; height: 28px; border: 1px solid var(--ink); background: none; padding: 2px; cursor: pointer; }
+  .field input[type="range"] { width: 100%; accent-color: var(--hi); }
+  .field select { width: 100%; font-family: var(--mono); font-size: 11px; padding: 5px; border: 1px solid var(--ink); background: var(--paper); }
+  .field .val { font-family: var(--mono); font-size: 10px; color: var(--ink-3); text-align: right; }
+  .swatches { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 8px; grid-column: 1 / -1; }
+  .swatches button { width: 18px; height: 18px; border: 1px solid var(--ink-3); cursor: pointer; padding: 0; }
+
+  .stage-wrap { overflow: auto; background: repeating-conic-gradient(var(--paper-2) 0% 25%, var(--paper) 0% 50%) 50% / 22px 22px; }
+  #stage { min-height: 100%; padding: 40px clamp(20px, 4vw, 64px); }
+  .panel { display: none; max-width: 1080px; margin: 0 auto; }
+  .panel.show { display: block; }
+
+  /* ── live preview surface (driven entirely by --p-* vars) ── */
+  .preview { color: var(--p-fg); font-family: var(--p-font); }
+  .pv-section { background: var(--p-bg); border: 1px solid var(--p-border); border-radius: var(--p-radius); padding: calc(var(--p-space) * 2); margin-bottom: var(--p-space); box-shadow: var(--p-shadow); }
+  .pv-h { font-family: var(--p-font-display); font-size: calc(var(--p-fs) * 2.4); line-height: 1.05; letter-spacing: -0.02em; margin-bottom: calc(var(--p-space) * 0.75); }
+  .pv-h2 { font-family: var(--p-font-display); font-size: calc(var(--p-fs) * 1.5); letter-spacing: -0.01em; margin-bottom: var(--p-space); }
+  .pv-p { font-size: var(--p-fs); color: var(--p-muted); max-width: 56ch; margin-bottom: var(--p-space); }
+  .pv-row { display: flex; flex-wrap: wrap; gap: var(--p-space); align-items: center; }
+  .pv-btn { font-family: var(--p-font); font-size: var(--p-fs); padding: calc(var(--p-space) * 0.6) calc(var(--p-space) * 1.1); border-radius: var(--p-radius); border: 1px solid var(--p-accent); background: var(--p-accent); color: var(--p-accent-fg); cursor: pointer; transition: transform var(--p-dur) var(--p-ease), filter var(--p-dur) var(--p-ease); }
+  .pv-btn:hover { filter: brightness(1.06); transform: translateY(-1px); }
+  .pv-btn.ghost { background: transparent; color: var(--p-fg); border-color: var(--p-border); }
+  .pv-input { font-family: var(--p-font); font-size: var(--p-fs); padding: calc(var(--p-space) * 0.55) calc(var(--p-space) * 0.8); border-radius: var(--p-radius); border: 1px solid var(--p-border); background: var(--p-card); color: var(--p-fg); width: 240px; }
+  .pv-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: var(--p-space); }
+  .pv-card { background: var(--p-card); border: 1px solid var(--p-border); border-radius: var(--p-radius); padding: calc(var(--p-space) * 1.2); box-shadow: var(--p-shadow); }
+  .pv-card h4 { font-family: var(--p-font-display); font-size: calc(var(--p-fs) * 1.15); margin-bottom: calc(var(--p-space) * 0.5); }
+  .pv-card p { font-size: calc(var(--p-fs) * 0.92); color: var(--p-muted); }
+  .pv-badge { display: inline-block; font-size: calc(var(--p-fs) * 0.75); font-family: var(--p-font); letter-spacing: 0.04em; text-transform: uppercase; padding: 3px 9px; border-radius: 999px; background: var(--p-accent); color: var(--p-accent-fg); }
+  .pv-badge.soft { background: transparent; color: var(--p-accent); border: 1px solid var(--p-accent); }
+  .pv-alert { display: flex; gap: var(--p-space); align-items: flex-start; border-left: 3px solid var(--p-accent); background: var(--p-card); padding: var(--p-space); border-radius: var(--p-radius); }
+  .pv-nav { display: flex; align-items: center; justify-content: space-between; padding: calc(var(--p-space) * 0.8) var(--p-space); border: 1px solid var(--p-border); border-radius: var(--p-radius); background: var(--p-card); margin-bottom: var(--p-space); }
+  .pv-nav .links { display: flex; gap: var(--p-space); font-size: calc(var(--p-fs) * 0.9); color: var(--p-muted); }
+  .pv-swatch-row { display: flex; gap: 0; border-radius: var(--p-radius); overflow: hidden; border: 1px solid var(--p-border); }
+  .pv-swatch-row > div { flex: 1; height: 44px; }
+  .lab { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-3); margin: 28px 0 12px; }
+  .lab:first-child { margin-top: 0; }
+
+  .info { max-width: 760px; margin: 0 auto; font-family: var(--mono); }
+  .info dl { display: grid; grid-template-columns: 160px 1fr; gap: 8px 20px; font-size: 12px; line-height: 1.7; }
+  .info dt { color: var(--ink-3); letter-spacing: 0.04em; }
+  .info dd em { color: var(--hi); font-style: normal; }
+  .info pre { margin-top: 24px; font-size: 11px; background: var(--ink); color: var(--paper); padding: 16px; overflow-x: auto; }
+  .toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%) translateY(20px); background: var(--ink); color: var(--paper); font-family: var(--mono); font-size: 12px; letter-spacing: 0.04em; padding: 10px 18px; opacity: 0; transition: all .25s ease; pointer-events: none; z-index: 50; }
+  .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+  /* polish — smooth restyle, contrast readouts, edited counter, backdrops */
+  .preview, .preview * { transition: background-color var(--p-dur, .2s) var(--p-ease, ease), border-color var(--p-dur, .2s) var(--p-ease, ease), color var(--p-dur, .2s) var(--p-ease, ease), border-radius .2s ease; }
+  .contrast { grid-column: 1 / -1; display: flex; flex-direction: column; gap: 5px; margin-top: 12px; }
+  .contrast .c-row { display: flex; align-items: center; justify-content: space-between; font-family: var(--mono); font-size: 10px; letter-spacing: 0.02em; color: var(--ink-2); }
+  .contrast .c-row b { font-weight: 500; }
+  .grade { font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; padding: 2px 6px; border: 1px solid currentColor; border-radius: 3px; }
+  .grade.aaa { color: #2e7d32; } .grade.aa { color: #2e7d32; } .grade.large { color: #b26a00; } .grade.fail { color: #c0341d; }
+  .count { display: none; margin-left: 6px; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 999px; background: var(--hi); color: #fff; font-size: 10px; line-height: 16px; text-align: center; }
+  .count.show { display: inline-block; }
+  #reset { display: inline-flex; align-items: center; }
+  .stage-wrap[data-bd="white"] { background: #ffffff; }
+  .stage-wrap[data-bd="dark"] { background: #14110e; }
+  .bd { display: flex; gap: 0; border: 1px solid var(--ink); }
+  .bd button { width: 26px; height: 28px; border: 0; border-left: 1px solid var(--ink); background: var(--paper); cursor: pointer; padding: 0; }
+  .bd button:first-child { border-left: 0; }
+  .bd button[aria-pressed="true"] { outline: 2px solid var(--hi); outline-offset: -2px; }
+  .bd .b-paper { background: repeating-conic-gradient(#ece8dd 0% 25%, #f3f1ea 0% 50%) 50% / 10px 10px; }
+  .bd .b-white { background: #fff; } .bd .b-dark { background: #14110e; }
+  .pv-specimen { padding: calc(var(--p-space) * 1.2) 0; border-top: 1px solid var(--p-border); border-bottom: 1px solid var(--p-border); }
+  .pv-specimen .aa { font-family: var(--p-font-display); font-size: calc(var(--p-fs) * 4); line-height: 1; letter-spacing: -0.03em; }
+  .pv-specimen .ln { font-family: var(--p-font); font-size: var(--p-fs); color: var(--p-muted); margin-top: calc(var(--p-space) * 0.5); }
+  @media (max-width: 860px) { .app { grid-template-columns: 1fr; grid-template-rows: auto auto 1fr; } .inspector { border-right: 0; border-bottom: 1px solid var(--ink); max-height: 38vh; } }
+</style>`;
+}
+
+function inspectorHtml() {
+  // Controls are generic: each carries data-var (+ optional data-unit). The
+  // client wires them all through one handler.
+  const colorField = (key, label) =>
+    `<div class="field"><label>${esc(label)}</label><input type="color" data-var="${esc(key)}" /></div>`;
+  const range = (key, label, min, max, step, unit) =>
+    `<div class="field"><label>${esc(label)}</label><input type="range" data-var="${esc(key)}" data-unit="${esc(unit)}" min="${min}" max="${max}" step="${step}" /><span class="val" data-for="${esc(key)}"></span></div>`;
+
+  return `<aside class="inspector">
+    <div class="grp">
+      <h3>Color</h3>
+      ${colorField('--p-bg', 'surface')}
+      ${colorField('--p-fg', 'text')}
+      ${colorField('--p-accent', 'accent')}
+      ${colorField('--p-muted', 'muted')}
+      ${colorField('--p-border', 'border')}
+      <div class="swatches" id="palette"></div>
+      <div class="contrast" id="contrast">
+        <div class="c-row"><span>text on surface</span><span><b id="c-text">—</b> <span class="grade" id="g-text">—</span></span></div>
+        <div class="c-row"><span>accent on surface</span><span><b id="c-accent">—</b> <span class="grade" id="g-accent">—</span></span></div>
+        <div class="c-row"><span>label on accent</span><span><b id="c-onacc">—</b> <span class="grade" id="g-onacc">—</span></span></div>
+      </div>
+    </div>
+    <div class="grp">
+      <h3>Type</h3>
+      <div class="field"><label>body</label><select data-var="--p-font" id="font-body"></select></div>
+      <div class="field"><label>display</label><select data-var="--p-font-display" id="font-display"></select></div>
+      ${range('--p-fs', 'size', 13, 21, 1, 'px')}
+    </div>
+    <div class="grp">
+      <h3>Shape</h3>
+      ${range('--p-radius', 'radius', 0, 32, 1, 'px')}
+    </div>
+    <div class="grp">
+      <h3>Spacing</h3>
+      ${range('--p-space', 'unit', 8, 32, 1, 'px')}
+    </div>
+    <div class="grp">
+      <h3>Motion</h3>
+      ${range('--p-dur', 'duration', 80, 600, 20, 'ms')}
+      <div class="field"><label>easing</label><select data-var="--p-ease" id="ease-sel">
+        <option value="cubic-bezier(0.2, 0, 0, 1)">standard</option>
+        <option value="cubic-bezier(0.4, 0, 1, 1)">accelerate</option>
+        <option value="cubic-bezier(0, 0, 0.2, 1)">decelerate</option>
+        <option value="cubic-bezier(0.34, 1.56, 0.64, 1)">spring</option>
+        <option value="linear">linear</option>
+      </select></div>
+    </div>
+  </aside>`;
+}
+
+function wallHtml(voice) {
+  const cta = (voice && voice.ctaVerbs && voice.ctaVerbs[0] && voice.ctaVerbs[0].value) || 'Get started';
+  const heading = (voice && voice.sampleHeadings && voice.sampleHeadings[0]) || 'Components, restyled live.';
+  return `<div class="panel preview" id="panel-wall" data-panel="wall">
+    <div class="pv-nav"><strong>brand</strong><div class="links"><span>Product</span><span>Pricing</span><span>Docs</span></div><button class="pv-btn">${esc(cta)}</button></div>
+    <div class="lab">Type</div>
+    <div class="pv-specimen"><div class="aa">Ag</div><div class="ln">${esc(heading)} — the quick brown fox jumps over the lazy dog.</div></div>
+    <div class="lab">Buttons</div>
+    <div class="pv-row"><button class="pv-btn">${esc(cta)}</button><button class="pv-btn ghost">Learn more</button><span class="pv-badge">New</span><span class="pv-badge soft">Beta</span></div>
+    <div class="lab">Form</div>
+    <div class="pv-row"><input class="pv-input" placeholder="you@company.com" /><button class="pv-btn">Subscribe</button></div>
+    <div class="lab">Cards</div>
+    <div class="pv-grid">
+      <div class="pv-card"><span class="pv-badge soft">Plan</span><h4>${esc(heading)}</h4><p>Tweak a token on the left and watch every element here restyle in real time.</p></div>
+      <div class="pv-card"><h4>Tokens, not screenshots</h4><p>Everything renders off CSS variables derived from the live extraction.</p></div>
+      <div class="pv-card"><h4>Export anywhere</h4><p>Ship your edits as DTCG tokens, CSS variables, or a Tailwind theme.</p></div>
+    </div>
+    <div class="lab">Alert</div>
+    <div class="pv-alert"><span class="pv-badge">!</span><div><strong>Heads up.</strong><div class="pv-p" style="margin:4px 0 0">This is what an inline notice looks like in this system.</div></div></div>
+    <div class="lab">Palette</div>
+    <div class="pv-swatch-row"><div style="background:var(--p-accent)"></div><div style="background:var(--p-fg)"></div><div style="background:var(--p-muted)"></div><div style="background:var(--p-border)"></div><div style="background:var(--p-card)"></div></div>
+  </div>`;
+}
+
+function pageHtml(intent, voice) {
+  const order = (intent && intent.sectionRoles && intent.sectionRoles.readingOrder) || ['hero', 'features', 'cta'];
+  const heading = (voice && voice.sampleHeadings && voice.sampleHeadings[0]) || 'The design language, rebuilt from its own tokens.';
+  const cta = (voice && voice.ctaVerbs && voice.ctaVerbs[0] && voice.ctaVerbs[0].value) || 'Start now';
+  const sectionFor = (role) => {
+    const r = String(role).toLowerCase();
+    if (/hero|header|intro/.test(r)) {
+      return `<section class="pv-section"><span class="pv-badge soft">${esc(role)}</span><h1 class="pv-h">${esc(heading)}</h1><p class="pv-p">An approximate rebuild of the scraped page's reading order, restyled entirely by the tokens on the left.</p><div class="pv-row"><button class="pv-btn">${esc(cta)}</button><button class="pv-btn ghost">Docs</button></div></section>`;
+    }
+    if (/feature|grid|card|benefit/.test(r)) {
+      return `<section class="pv-section"><h2 class="pv-h2">${esc(role)}</h2><div class="pv-grid"><div class="pv-card"><h4>One</h4><p>Driven by the extracted system.</p></div><div class="pv-card"><h4>Two</h4><p>Driven by the extracted system.</p></div><div class="pv-card"><h4>Three</h4><p>Driven by the extracted system.</p></div></div></section>`;
+    }
+    if (/cta|footer|sign|contact/.test(r)) {
+      return `<section class="pv-section" style="text-align:center"><h2 class="pv-h2">${esc(heading)}</h2><div class="pv-row" style="justify-content:center"><button class="pv-btn">${esc(cta)}</button></div></section>`;
+    }
+    return `<section class="pv-section"><h2 class="pv-h2">${esc(role)}</h2><p class="pv-p">Section content placeholder, styled by the live token set.</p></section>`;
+  };
+  return `<div class="panel preview" id="panel-page" data-panel="page">
+    <div class="pv-nav"><strong>brand</strong><div class="links"><span>Product</span><span>Pricing</span><span>Docs</span></div><button class="pv-btn">${esc(cta)}</button></div>
+    ${order.slice(0, 8).map(sectionFor).join('\n    ')}
+  </div>`;
+}
+
+function infoHtml(data) {
   const intent = data.intent || {};
   const visualDna = data.visualDna || {};
   const library = data.library || {};
   const voice = data.voice || {};
-  const motion = data.motion || {};
-  const json = JSON.stringify({ tokens, intent, visualDna, library, voice, motion });
   const readingOrder = (intent.sectionRoles?.readingOrder || []).join(' → ');
   const ctaList = (voice.ctaVerbs || []).slice(0, 5).map(c => `${c.value} (${c.count})`).join(' · ');
-  const sampleHeadings = (voice.sampleHeadings || []).slice(0, 4).map(h => `“${h}”`).join(' · ');
+  const motionJson = JSON.stringify(data.motion || {}, null, 2);
+  return `<div class="panel info" id="panel-info" data-panel="info">
+    <dl>
+      <dt>page intent</dt><dd>${intent.pageIntent?.type ? `<em>${esc(intent.pageIntent.type)}</em> · ${esc(intent.pageIntent.confidence ?? '')}` : '—'}</dd>
+      <dt>reading order</dt><dd>${esc(readingOrder) || '—'}</dd>
+      <dt>material</dt><dd>${esc(visualDna.materialLanguage?.label) || '—'}</dd>
+      <dt>imagery</dt><dd>${esc(visualDna.imageryStyle?.label) || '—'}</dd>
+      <dt>component library</dt><dd>${library.library ? `${esc(library.library)} · ${esc(library.confidence ?? '')}` : '—'}</dd>
+      <dt>tone</dt><dd><em>${esc(voice.tone) || '—'}</em></dd>
+      <dt>pronoun</dt><dd>${esc(voice.pronoun) || '—'}</dd>
+      <dt>top CTAs</dt><dd>${esc(ctaList) || '—'}</dd>
+    </dl>
+    <pre>${esc(motionJson)}</pre>
+  </div>`;
+}
+
+export function studioHtml(data) {
+  const derived = deriveTokens(data);
+  const meta = (data.tokens && data.tokens.$metadata) || {};
+  const boot = {
+    prefix: data.prefix,
+    base: derived.vars,
+    palette: derived.palette,
+    fonts: derived.fonts,
+    source: meta.source || '',
+    version: meta.version || '',
+  };
+  const json = JSON.stringify(boot).replace(/</g, '\\u003c');
 
   return `<!doctype html>
 <html lang="en">
@@ -78,180 +315,287 @@ function studioHtml(data) {
 <title>designlang studio · ${esc(data.prefix)}</title>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500&family=Instrument+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<style>
-  :root {
-    --paper: #f3f1ea; --paper-2: #ece8dd; --paper-3: #d8d3c5;
-    --ink: #0a0908; --ink-2: #403c34; --ink-3: #8b8778;
-    --accent: #ff4800;
-    --mono: 'JetBrains Mono', ui-monospace, monospace;
-    --display: 'Fraunces', Georgia, serif;
-    --body: 'Instrument Sans', -apple-system, system-ui, sans-serif;
-  }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  html, body { background: var(--paper); color: var(--ink); font-family: var(--body); font-size: 15px; line-height: 1.5; }
-  body { padding: 48px clamp(20px, 4vw, 56px); max-width: 1440px; margin: 0 auto; }
-  header { display: flex; justify-content: space-between; align-items: baseline; gap: 24px; padding-bottom: 16px; border-bottom: 1px solid var(--ink); }
-  .mark { font-family: var(--mono); font-size: 13px; letter-spacing: 0.02em; }
-  .mark em { color: var(--accent); font-style: italic; font-family: var(--display); }
-  nav { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; display: flex; gap: 24px; }
-  nav a { color: var(--ink); text-decoration: none; border-bottom: 1px solid transparent; }
-  nav a:hover { color: var(--accent); }
-  h1.display { font-family: var(--display); font-size: clamp(40px, 6vw, 72px); letter-spacing: -0.03em; line-height: 1.02; font-weight: 400; margin: 64px 0 24px; max-width: 14ch; }
-  h1.display em { font-style: italic; color: var(--accent); }
-  h2 { font-family: var(--display); font-size: 28px; letter-spacing: -0.02em; font-weight: 500; }
-  .rule { display: flex; align-items: center; gap: 12px; margin: 56px 0 24px; }
-  .rule-line { flex: 1; height: 1px; background: var(--ink); }
-  .chip { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; padding: 4px 10px; border: 1px solid var(--ink); }
-  .grid { display: grid; gap: 16px; }
-  .swatch { aspect-ratio: 1; border: 1px solid var(--ink); padding: 10px; display: flex; flex-direction: column; justify-content: space-between; font-family: var(--mono); font-size: 10px; letter-spacing: 0.04em; cursor: copy; position: relative; }
-  .swatch:hover::after { content: 'click to copy'; position: absolute; inset: 0; display: grid; place-items: center; background: rgba(0,0,0,0.55); color: white; font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; }
-  .kv { display: grid; grid-template-columns: 180px 1fr; gap: 8px 24px; font-family: var(--mono); font-size: 13px; line-height: 1.8; }
-  .kv dt { color: var(--ink-2); letter-spacing: 0.04em; }
-  .kv dd em { color: var(--accent); font-style: normal; }
-  pre.code { font-family: var(--mono); font-size: 12px; background: var(--ink); color: var(--paper); padding: 16px 20px; overflow-x: auto; white-space: pre; }
-  .type-spec { display: grid; gap: 12px; padding: 32px 0; border-top: 1px solid var(--paper-3); border-bottom: 1px solid var(--paper-3); }
-  .type-row { display: flex; align-items: baseline; gap: 24px; border-bottom: 1px solid var(--paper-3); padding-bottom: 12px; }
-  .type-row:last-child { border-bottom: 0; }
-  .type-meta { font-family: var(--mono); font-size: 10px; color: var(--ink-3); letter-spacing: 0.1em; text-transform: uppercase; min-width: 120px; }
-  footer { margin-top: 80px; padding-top: 24px; border-top: 1px solid var(--paper-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; color: var(--ink-3); display: flex; justify-content: space-between; }
-  @media (max-width: 700px) { .kv { grid-template-columns: 1fr; } .type-row { flex-direction: column; gap: 4px; } }
-</style>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500&family=Instrument+Sans:wght@400;500;600&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+${styleBlock()}
 </head>
 <body>
-  <header>
-    <div class="mark">designlang <em>studio</em> · ${esc(data.prefix)}</div>
-    <nav>
-      <a href="#dna">DNA</a>
-      <a href="#tokens">Tokens</a>
-      <a href="#type">Type</a>
-      <a href="#voice">Voice</a>
-      <a href="#motion">Motion</a>
-      <a href="/raw" target="_blank">Raw JSON</a>
-    </nav>
-  </header>
+  <div class="app">
+    <div class="topbar">
+      <div class="mark">designlang <em>studio</em> · ${esc(data.prefix)}</div>
+      <div class="tabs" role="tablist">
+        <button class="tab" role="tab" data-tab="wall" aria-selected="true">Components</button>
+        <button class="tab" role="tab" data-tab="page" aria-selected="false">Page</button>
+        <button class="tab" role="tab" data-tab="info" aria-selected="false">Info</button>
+      </div>
+      <div class="actions">
+        <div class="bd" role="group" aria-label="preview backdrop">
+          <button class="b-paper" data-bd="paper" aria-pressed="true" title="Paper"></button>
+          <button class="b-white" data-bd="white" aria-pressed="false" title="White"></button>
+          <button class="b-dark" data-bd="dark" aria-pressed="false" title="Dark"></button>
+        </div>
+        <button class="btn" id="reset">Reset<span class="count" id="editcount"></span></button>
+        <button class="btn" id="copylink">Copy link</button>
+        <div class="menu">
+          <button class="btn hi" id="exportbtn">Export ▾</button>
+          <div class="menu-list" id="exportmenu">
+            <button data-export="tokens">DTCG tokens · .json</button>
+            <button data-export="css">CSS variables · .css</button>
+            <button data-export="tailwind">Tailwind theme · .js</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    ${inspectorHtml()}
+    <div class="stage-wrap" data-bd="paper">
+      <div id="stage">
+        ${wallHtml(data.voice || {})}
+        ${pageHtml(data.intent || {}, data.voice || {})}
+        ${infoHtml(data)}
+      </div>
+    </div>
+  </div>
+  <div class="toast" id="toast"></div>
 
-  <h1 class="display">An extraction you can <em>read</em>, not just paste.</h1>
-  <p style="max-width:48ch;color:var(--ink-2);font-size:17px;line-height:1.55">
-    Every swatch is clickable — copy hex or token to your clipboard.
-    The studio runs locally; no account, no upload, no telemetry.
-  </p>
-
-  <div class="rule" id="dna"><div class="rule-line"></div><div class="chip">§01 — DNA</div></div>
-  <dl class="kv">
-    <dt>page intent</dt><dd>${intent.pageIntent?.type ? `<em>${esc(intent.pageIntent.type)}</em> · ${esc(intent.pageIntent.confidence ?? '')}` : '—'}</dd>
-    <dt>reading order</dt><dd>${esc(readingOrder) || '—'}</dd>
-    <dt>material</dt><dd>${visualDna.materialLanguage?.label ? `${esc(visualDna.materialLanguage.label)} · ${esc(visualDna.materialLanguage.confidence ?? '')}` : '—'}</dd>
-    <dt>imagery</dt><dd>${esc(visualDna.imageryStyle?.label) || '—'}</dd>
-    <dt>component library</dt><dd>${library.library ? `${esc(library.library)} · ${esc(library.confidence ?? '')}` : '—'}</dd>
-  </dl>
-
-  <div class="rule" id="tokens"><div class="rule-line"></div><div class="chip">§02 — Tokens</div></div>
-  <h2>Color</h2>
-  <div class="grid" style="grid-template-columns:repeat(auto-fill,minmax(120px,1fr));margin-top:24px" id="color-grid"></div>
-
-  <h2 style="margin-top:56px" id="type">Typography</h2>
-  <div class="type-spec" id="type-spec"></div>
-
-  <div class="rule" id="voice"><div class="rule-line"></div><div class="chip">§03 — Voice</div></div>
-  <dl class="kv">
-    <dt>tone</dt><dd><em>${esc(voice.tone) || '—'}</em></dd>
-    <dt>pronoun</dt><dd>${esc(voice.pronoun) || '—'}</dd>
-    <dt>heading style</dt><dd>${esc(voice.headingStyle) || '—'} · ${esc(voice.headingLengthClass) || '—'}</dd>
-    <dt>top CTAs</dt><dd>${esc(ctaList) || '—'}</dd>
-    <dt>sample headings</dt><dd>${esc(sampleHeadings) || '—'}</dd>
-  </dl>
-
-  <div class="rule" id="motion"><div class="rule-line"></div><div class="chip">§04 — Motion</div></div>
-  <pre class="code" id="motion-block"></pre>
-
-  <footer>
-    <div>designlang studio · served from localhost</div>
-    <div><a href="/raw" style="color:inherit">raw.json</a></div>
-  </footer>
-
-<script id="__data" type="application/json">${json.replace(/</g, '\\u003c')}</script>
+<script id="__boot" type="application/json">${json}</script>
 <script>
-  const DATA = JSON.parse(document.getElementById('__data').textContent);
-  document.getElementById('motion-block').textContent = JSON.stringify(DATA.motion || {}, null, 2);
+  var BOOT = JSON.parse(document.getElementById('__boot').textContent);
+  var BASE = BOOT.base;
+  var edits = {};
+  var stage = document.getElementById('stage');
 
-  // Color grid — built with safe DOM APIs only.
-  const palette = [];
-  const seen = new Set();
-  const add = (hex, label) => {
-    if (!hex) return;
-    const h = String(hex).toLowerCase();
-    if (seen.has(h)) return;
-    seen.add(h);
-    palette.push({ hex: h, label: String(label || '') });
+  // Map preview vars to friendly token names for export.
+  var VARMAP = {
+    '--p-bg': ['color', 'surface', 'color'],
+    '--p-card': ['color', 'card', 'color'],
+    '--p-fg': ['color', 'text', 'color'],
+    '--p-muted': ['color', 'muted', 'color'],
+    '--p-border': ['color', 'border', 'color'],
+    '--p-accent': ['color', 'accent', 'color'],
+    '--p-accent-fg': ['color', 'accentForeground', 'color'],
+    '--p-radius': ['radius', 'DEFAULT', 'dimension'],
+    '--p-fs': ['fontSize', 'base', 'dimension'],
+    '--p-space': ['spacing', 'unit', 'dimension'],
+    '--p-shadow': ['boxShadow', 'DEFAULT', 'shadow'],
+    '--p-font': ['fontFamily', 'sans', 'fontFamily'],
+    '--p-font-display': ['fontFamily', 'display', 'fontFamily'],
+    '--p-dur': ['motion', 'duration', 'duration'],
+    '--p-ease': ['motion', 'easing', 'cubicBezier']
   };
-  const walk = (obj, path) => {
-    if (!obj || typeof obj !== 'object') return;
-    if (obj.$value && typeof obj.$value === 'string' && /^#[0-9a-f]{3,8}$/i.test(obj.$value)) {
-      add(obj.$value, path.join('.'));
-      return;
+
+  function effective() {
+    var out = {};
+    for (var k in BASE) out[k] = (edits[k] != null ? edits[k] : BASE[k]);
+    return out;
+  }
+  function apply() {
+    var e = effective();
+    for (var k in e) stage.style.setProperty(k, e[k]);
+    updateBadges(e);
+    updateCount();
+  }
+  function stripUnit(v) { return String(v == null ? '' : v).replace(/(px|ms)$/,''); }
+
+  // ── WCAG contrast readouts (live) ──
+  function ratio(a, b) {
+    function hx(h){ h=String(h||'').replace('#',''); if(h.length===3) h=h[0]+h[0]+h[1]+h[1]+h[2]+h[2]; return [parseInt(h.slice(0,2),16)||0,parseInt(h.slice(2,4),16)||0,parseInt(h.slice(4,6),16)||0]; }
+    function L(rgb){ var s=rgb.map(function(c){c/=255;return c<=0.03928?c/12.92:Math.pow((c+0.055)/1.055,2.4);}); return 0.2126*s[0]+0.7152*s[1]+0.0722*s[2]; }
+    var l1=L(hx(a)), l2=L(hx(b)); var hi=Math.max(l1,l2), lo=Math.min(l1,l2);
+    return (hi+0.05)/(lo+0.05);
+  }
+  function grade(r) {
+    if (r >= 7) return ['AAA', 'aaa'];
+    if (r >= 4.5) return ['AA', 'aa'];
+    if (r >= 3) return ['AA large', 'large'];
+    return ['fail', 'fail'];
+  }
+  function setBadge(valId, gradeId, r) {
+    var g = grade(r);
+    var v = document.getElementById(valId), gel = document.getElementById(gradeId);
+    if (v) v.textContent = r.toFixed(2);
+    if (gel) { gel.textContent = g[0]; gel.className = 'grade ' + g[1]; }
+  }
+  function updateBadges(e) {
+    setBadge('c-text', 'g-text', ratio(e['--p-fg'], e['--p-bg']));
+    setBadge('c-accent', 'g-accent', ratio(e['--p-accent'], e['--p-bg']));
+    setBadge('c-onacc', 'g-onacc', ratio(e['--p-accent-fg'], e['--p-accent']));
+  }
+  function updateCount() {
+    var n = Object.keys(edits).length;
+    var el = document.getElementById('editcount');
+    if (!el) return;
+    el.textContent = n; el.classList.toggle('show', n > 0);
+  }
+
+  function toast(msg) {
+    var t = document.getElementById('toast');
+    t.textContent = msg; t.classList.add('show');
+    clearTimeout(t._h); t._h = setTimeout(function(){ t.classList.remove('show'); }, 1600);
+  }
+
+  // ── URL state (only deltas are encoded) ──
+  var hashTimer = null;
+  function writeHash() {
+    var keys = Object.keys(edits);
+    if (!keys.length) { history.replaceState(null, '', location.pathname); return; }
+    try { history.replaceState(null, '', '#' + btoa(JSON.stringify(edits))); } catch (e) {}
+  }
+  function scheduleHash() { clearTimeout(hashTimer); hashTimer = setTimeout(writeHash, 250); }
+  function readHash() {
+    try {
+      if (location.hash.length > 1) {
+        var o = JSON.parse(atob(location.hash.slice(1)));
+        if (o && typeof o === 'object') edits = o;
+      }
+    } catch (e) {}
+  }
+
+  function clean() { for (var k in edits) if (edits[k] === BASE[k]) delete edits[k]; }
+
+  // ── Inspector wiring ──
+  function syncControls() {
+    var ctrls = document.querySelectorAll('[data-var]');
+    for (var i = 0; i < ctrls.length; i++) {
+      var el = ctrls[i];
+      var v = effective()[el.getAttribute('data-var')];
+      if (v == null) continue;
+      if (el.type === 'range') {
+        el.value = stripUnit(v);
+        var out = document.querySelector('[data-for="' + el.getAttribute('data-var') + '"]');
+        if (out) out.textContent = v;
+      } else if (el.type === 'color') {
+        if (/^#[0-9a-f]{6}$/i.test(v)) el.value = v;
+      } else {
+        el.value = v;
+      }
     }
-    for (const k of Object.keys(obj)) walk(obj[k], path.concat(k));
-  };
-  walk(DATA.tokens && (DATA.tokens.color || DATA.tokens), []);
+  }
+  function onInput(e) {
+    var el = e.target;
+    if (!el.hasAttribute('data-var')) return;
+    var unit = el.getAttribute('data-unit');
+    var v = el.value;
+    if (unit) v = v + unit;
+    edits[el.getAttribute('data-var')] = v;
+    clean(); apply(); scheduleHash();
+    var out = document.querySelector('[data-for="' + el.getAttribute('data-var') + '"]');
+    if (out) out.textContent = effective()[el.getAttribute('data-var')];
+  }
+  document.querySelector('.inspector').addEventListener('input', onInput);
 
-  const grid = document.getElementById('color-grid');
-  for (const p of palette.slice(0, 48)) {
-    const el = document.createElement('div');
-    el.className = 'swatch';
-    const r = parseInt(p.hex.slice(1, 3), 16) || 0;
-    const g = parseInt(p.hex.slice(3, 5), 16) || 0;
-    const b = parseInt(p.hex.slice(5, 7), 16) || 0;
-    const luminance = r * 0.299 + g * 0.587 + b * 0.114;
-    el.style.background = p.hex;
-    el.style.color = luminance > 160 ? '#0a0908' : '#f3f1ea';
-    if (luminance > 220) el.style.borderColor = '#0a0908';
-    const lab = document.createElement('div');
-    lab.textContent = p.label.split('.').slice(-2).join('.');
-    const val = document.createElement('div');
-    val.textContent = p.hex;
-    val.style.opacity = '0.85';
-    el.appendChild(lab);
-    el.appendChild(val);
-    el.addEventListener('click', () => {
-      navigator.clipboard.writeText(p.hex);
-      el.style.outline = '2px solid #ff4800';
-      setTimeout(() => { el.style.outline = ''; }, 400);
+  // Font dropdowns
+  function fillFonts(sel, varName) {
+    var cur = effective()[varName];
+    BOOT.fonts.forEach(function (f) {
+      var o = document.createElement('option');
+      o.value = "'" + f + "', system-ui, sans-serif";
+      o.textContent = f;
+      sel.appendChild(o);
     });
-    grid.appendChild(el);
+    // mark current
+    for (var i = 0; i < sel.options.length; i++) {
+      if (cur && cur.indexOf(sel.options[i].textContent) !== -1) sel.selectedIndex = i;
+    }
   }
+  fillFonts(document.getElementById('font-body'), '--p-font');
+  fillFonts(document.getElementById('font-display'), '--p-font-display');
 
-  // Typography specimens
-  const typeSpec = document.getElementById('type-spec');
-  const tokensObj = DATA.tokens || {};
-  const ff =
-    (tokensObj.font && tokensObj.font.family && tokensObj.font.family.sans && tokensObj.font.family.sans.$value) ||
-    (tokensObj.fontFamily && tokensObj.fontFamily.sans && tokensObj.fontFamily.sans.$value) ||
-    'inherit';
-  const sizes = [
-    { label: 'display', px: 56, w: 700 },
-    { label: 'h1', px: 40, w: 600 },
-    { label: 'h2', px: 28, w: 600 },
-    { label: 'body', px: 16, w: 400 },
-    { label: 'small', px: 13, w: 400 },
-  ];
-  for (const s of sizes) {
-    const row = document.createElement('div');
-    row.className = 'type-row';
-    const meta = document.createElement('div');
-    meta.className = 'type-meta';
-    meta.textContent = s.label + ' · ' + s.px + 'px';
-    const sample = document.createElement('div');
-    sample.style.fontFamily = ff;
-    sample.style.fontSize = s.px + 'px';
-    sample.style.fontWeight = String(s.w);
-    sample.style.lineHeight = '1.1';
-    sample.style.letterSpacing = '-0.01em';
-    sample.textContent = 'The brown fox leaps.';
-    row.appendChild(meta);
-    row.appendChild(sample);
-    typeSpec.appendChild(row);
+  // Palette quick-pick → applies to whichever color field was last focused (default accent)
+  var lastColorVar = '--p-accent';
+  document.querySelectorAll('input[type="color"]').forEach(function (el) {
+    el.addEventListener('focus', function () { lastColorVar = el.getAttribute('data-var'); });
+  });
+  var pal = document.getElementById('palette');
+  (BOOT.palette || []).forEach(function (hex) {
+    var b = document.createElement('button');
+    b.style.background = hex; b.title = hex;
+    b.addEventListener('click', function () {
+      edits[lastColorVar] = hex; clean(); apply(); syncControls(); scheduleHash();
+    });
+    pal.appendChild(b);
+  });
+
+  // ── Tabs ──
+  document.querySelector('.tabs').addEventListener('click', function (e) {
+    var t = e.target.closest('.tab'); if (!t) return;
+    var name = t.getAttribute('data-tab');
+    document.querySelectorAll('.tab').forEach(function (x) { x.setAttribute('aria-selected', x === t ? 'true' : 'false'); });
+    document.querySelectorAll('.panel').forEach(function (p) { p.classList.toggle('show', p.getAttribute('data-panel') === name); });
+  });
+  document.getElementById('panel-wall').classList.add('show');
+
+  // ── Backdrop ──
+  var stageWrap = document.querySelector('.stage-wrap');
+  document.querySelector('.bd').addEventListener('click', function (e) {
+    var b = e.target.closest('button'); if (!b) return;
+    stageWrap.setAttribute('data-bd', b.getAttribute('data-bd'));
+    document.querySelectorAll('.bd button').forEach(function (x) { x.setAttribute('aria-pressed', x === b ? 'true' : 'false'); });
+  });
+
+  // ── Actions ──
+  document.getElementById('reset').addEventListener('click', function () {
+    edits = {}; apply(); syncControls(); writeHash(); toast('Reset to extracted tokens');
+  });
+  document.getElementById('copylink').addEventListener('click', function () {
+    writeHash();
+    navigator.clipboard.writeText(location.href).then(function () { toast('Shareable link copied'); });
+  });
+
+  // ── Export ──
+  var menu = document.getElementById('exportmenu');
+  document.getElementById('exportbtn').addEventListener('click', function (e) {
+    e.stopPropagation(); menu.classList.toggle('open');
+  });
+  document.addEventListener('click', function () { menu.classList.remove('open'); });
+  function download(name, text, mime) {
+    var blob = new Blob([text], { type: mime });
+    var a = document.createElement('a');
+    a.href = URL.createObjectURL(blob); a.download = name;
+    document.body.appendChild(a); a.click();
+    setTimeout(function () { URL.revokeObjectURL(a.href); a.remove(); }, 0);
   }
+  function buildTokens() {
+    var e = effective();
+    var out = { $metadata: { generator: 'designlang studio', source: BOOT.source, editedAt: new Date().toISOString() } };
+    for (var k in VARMAP) {
+      var m = VARMAP[k];
+      if (!out[m[0]]) out[m[0]] = {};
+      out[m[0]][m[1]] = { $value: e[k], $type: m[2] };
+    }
+    return JSON.stringify(out, null, 2);
+  }
+  function buildCss() {
+    var e = effective();
+    var lines = [':root {'];
+    for (var k in VARMAP) { lines.push('  --' + VARMAP[k][1].replace(/[A-Z]/g, function(c){return '-'+c.toLowerCase();}) + ': ' + e[k] + ';'); }
+    lines.push('}');
+    return lines.join('\\n');
+  }
+  function buildTailwind() {
+    var e = effective();
+    var theme = {
+      colors: {
+        surface: e['--p-bg'], card: e['--p-card'], text: e['--p-fg'],
+        muted: e['--p-muted'], border: e['--p-border'],
+        accent: e['--p-accent'], 'accent-fg': e['--p-accent-fg']
+      },
+      borderRadius: { DEFAULT: e['--p-radius'] },
+      fontFamily: { sans: e['--p-font'], display: e['--p-font-display'] },
+      boxShadow: { DEFAULT: e['--p-shadow'] }
+    };
+    return '/** Generated by designlang studio */\\nmodule.exports = {\\n  theme: { extend: ' + JSON.stringify(theme, null, 2) + ' }\\n};\\n';
+  }
+  menu.addEventListener('click', function (e) {
+    var b = e.target.closest('[data-export]'); if (!b) return;
+    var kind = b.getAttribute('data-export');
+    var p = BOOT.prefix || 'studio';
+    if (kind === 'tokens') download(p + '.studio.tokens.json', buildTokens(), 'application/json');
+    if (kind === 'css') download(p + '.studio.css', buildCss(), 'text/css');
+    if (kind === 'tailwind') download(p + '.studio.tailwind.js', buildTailwind(), 'text/javascript');
+    menu.classList.remove('open'); toast('Exported ' + kind);
+  });
+
+  // ── Boot ──
+  readHash(); clean(); apply(); syncControls();
 </script>
 </body>
 </html>`;

--- a/tests/studio.test.js
+++ b/tests/studio.test.js
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveTokens, studioHtml } from '../src/studio.js';
+import { contrastRatio } from '../src/studio-tokens.js';
+
+const fixture = {
+  prefix: 'example-com',
+  tokens: {
+    $metadata: { source: 'https://example.com', version: '7.0.0' },
+    color: {
+      brand: { primary: { $value: '#ff4800', $type: 'color' } },
+      background: { bg0: { $value: '#ffffff', $type: 'color' } },
+      text: { text0: { $value: '#101010', $type: 'color' } },
+    },
+    radius: { md: { $value: '12px', $type: 'dimension' } },
+    font: { family: { sans: { $value: 'Sohne', $type: 'fontFamily' } } },
+  },
+  intent: { pageIntent: { type: 'marketing', confidence: 0.9 }, sectionRoles: { readingOrder: ['hero', 'features', 'cta'] } },
+  visualDna: { materialLanguage: { label: 'flat' }, imageryStyle: { label: 'photographic' } },
+  library: { library: 'custom', confidence: 0.5 },
+  voice: { tone: 'confident', ctaVerbs: [{ value: 'Start now', count: 4 }], sampleHeadings: ['Payments for the internet'] },
+  motion: { duration: { base: '180ms' }, easing: { standard: 'cubic-bezier(0.2,0,0,1)' } },
+};
+
+test('deriveTokens picks brand/background/text colors into preview vars', () => {
+  const { vars } = deriveTokens(fixture);
+  assert.equal(vars['--p-accent'], '#ff4800');
+  assert.equal(vars['--p-bg'], '#ffffff');
+  assert.equal(vars['--p-fg'], '#101010');
+  assert.equal(vars['--p-radius'], '12px');
+  assert.match(vars['--p-font'], /Sohne/);
+});
+
+test('deriveTokens computes a readable accent foreground', () => {
+  const { vars } = deriveTokens(fixture);
+  // #ff4800 is mid-luminance → white text
+  assert.equal(vars['--p-accent-fg'], '#ffffff');
+});
+
+test('deriveTokens falls back cleanly on an empty extraction', () => {
+  const { vars, palette } = deriveTokens({ prefix: 'x', tokens: {} });
+  assert.ok(vars['--p-bg'] && vars['--p-fg'] && vars['--p-accent']);
+  assert.equal(vars['--p-radius'], '10px');
+  assert.deepEqual(palette, []);
+});
+
+test('studioHtml renders the live preview surface and inspector', () => {
+  const html = studioHtml(fixture);
+  assert.match(html, /class="inspector"/);
+  assert.match(html, /data-panel="wall"/);
+  assert.match(html, /data-panel="page"/);
+  assert.match(html, /pv-btn/);
+  assert.match(html, /data-export="tokens"/);
+  // boot payload carries the derived base + palette
+  assert.match(html, /"--p-accent":"#ff4800"/);
+});
+
+test('studioHtml escapes the prefix into the title and never breaks the data island', () => {
+  const html = studioHtml({ ...fixture, prefix: '<script>x</script>' });
+  assert.ok(!html.includes('<title>designlang studio · <script>'));
+  assert.match(html, /&lt;script&gt;/);
+});
+
+test('studioHtml includes the polish: contrast readouts, edit count, backdrop, specimen', () => {
+  const html = studioHtml(fixture);
+  assert.match(html, /id="contrast"/);
+  assert.match(html, /id="editcount"/);
+  assert.match(html, /class="bd"/);
+  assert.match(html, /pv-specimen/);
+});
+
+test('contrastRatio matches known WCAG values', () => {
+  // black on white is the maximum, 21:1
+  assert.equal(Math.round(contrastRatio('#000000', '#ffffff')), 21);
+  // identical colors are 1:1
+  assert.equal(contrastRatio('#ff4800', '#ff4800'), 1);
+  // symmetric
+  assert.equal(contrastRatio('#101010', '#ffffff'), contrastRatio('#ffffff', '#101010'));
+});

--- a/website/app/api/studio/route.js
+++ b/website/app/api/studio/route.js
@@ -1,0 +1,109 @@
+// POST /api/studio
+// Extract a site's design language and return a fully self-contained,
+// interactive studio document (HTML) that the page renders in an iframe.
+// Reuses the exact same `studioHtml` engine that powers `designlang studio`
+// on the CLI, so both surfaces stay in lock-step.
+//
+// Body:  { url: string }
+// 200:   { html, hostname, cached }
+// 429:   { error, resetAt, cli }   — shared 2/day demo budget with /api/extract
+
+import { extractDesignLanguage } from '../../../../src/index.js';
+import { formatDtcgTokens } from '../../../../src/formatters/dtcg-tokens.js';
+import { studioHtml } from '../../../../src/studio.js';
+import { validateTargetUrl } from '../../../../website/lib/url-safety.js';
+import { checkRate, checkRateBlob } from '../../../../website/lib/rate-limit.js';
+import { cacheKey, getCached, putCached } from '../../../../website/lib/cache.js';
+import { getBrowserOptions, getLocalBrowserOptions, isBrowserlessFailure } from '../../../../website/lib/browser.js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+function hostPrefix(u) {
+  try { return new URL(u).hostname.replace(/^www\./, '').replace(/[^a-z0-9]+/gi, '-'); }
+  catch { return 'site'; }
+}
+
+function extractIp(request) {
+  const xff = request.headers.get('x-forwarded-for');
+  if (xff) return xff.split(',')[0].trim();
+  const real = request.headers.get('x-real-ip');
+  return real ? real.trim() : 'unknown';
+}
+
+// Shape the extraction's `design` object into what `studioHtml` expects.
+// Missing side-panel fields degrade gracefully inside the studio.
+function buildStudioData(design, targetUrl) {
+  return {
+    prefix: hostPrefix(targetUrl),
+    tokens: formatDtcgTokens(design),
+    intent: { pageIntent: design.pageIntent, sectionRoles: design.sectionRoles },
+    visualDna: design.visualDna || { materialLanguage: design.materialLanguage, imageryStyle: design.imageryStyle },
+    library: design.componentLibrary,
+    voice: design.voice,
+    motion: design.motion,
+  };
+}
+
+function rateLimited(targetUrl, resetAt) {
+  let host = 'site';
+  try { host = new URL(targetUrl).hostname; } catch {}
+  return Response.json(
+    {
+      error: 'Free demo: 2 extractions per day. Use the CLI for unlimited: npx designlang ' + host + ' && designlang studio',
+      resetAt,
+      cli: 'npx designlang ' + host,
+    },
+    { status: 429, headers: { 'retry-after': String(Math.ceil((resetAt - Date.now()) / 1000)) } }
+  );
+}
+
+export async function POST(request) {
+  let body;
+  try { body = await request.json(); }
+  catch { return Response.json({ error: 'Invalid JSON body' }, { status: 400 }); }
+
+  const validation = validateTargetUrl(body?.url);
+  if (!validation.ok) return Response.json({ error: validation.reason }, { status: validation.status });
+  const targetUrl = validation.url;
+  const ip = extractIp(request);
+
+  // Cache hit serves free — repeats cost nothing and skip rate accounting.
+  const key = cacheKey(targetUrl);
+  const cached = await getCached(key);
+
+  let design;
+  let wasCached = false;
+  try {
+    if (cached) {
+      design = cached.design;
+      wasCached = true;
+    } else {
+      // Shared 2/day budget with /api/extract (a studio IS an extraction).
+      const memRate = checkRate(`extract:${ip}`, { limit: 2 });
+      if (!memRate.allowed) return rateLimited(targetUrl, memRate.resetAt);
+      const blobRate = await checkRateBlob(`extract:${ip}`, { limit: 2 });
+      if (!blobRate.allowed) return rateLimited(targetUrl, blobRate.resetAt);
+
+      const browserOpts = await getBrowserOptions();
+      try {
+        design = await extractDesignLanguage(targetUrl, browserOpts);
+      } catch (err) {
+        // Browserless quota/auth/connection failure — retry once on bundled Chromium.
+        if (browserOpts.wsEndpoint && isBrowserlessFailure(err)) {
+          design = await extractDesignLanguage(targetUrl, await getLocalBrowserOptions());
+        } else {
+          throw err;
+        }
+      }
+      await putCached(key, { design });
+    }
+
+    const html = studioHtml(buildStudioData(design, targetUrl));
+    return Response.json({ html, hostname: hostPrefix(targetUrl), cached: wasCached });
+  } catch (err) {
+    console.error('[studio] failed', { url: targetUrl, ip, message: err?.message });
+    return Response.json({ error: err?.message || 'Extraction failed' }, { status: 500 });
+  }
+}

--- a/website/app/components/MobileMenu.js
+++ b/website/app/components/MobileMenu.js
@@ -43,6 +43,7 @@ export default function MobileMenu({ stars }) {
             <nav className="nav-sheet-links" aria-label="primary">
               <a href="/features"  onClick={() => setOpen(false)}>Features</a>
               <a href="/gallery"   onClick={() => setOpen(false)}>Gallery</a>
+              <a href="/studio"    onClick={() => setOpen(false)}>Studio — live editor</a>
               <a href="/motion"    onClick={() => setOpen(false)}>Motion analyzer</a>
               <a href="/spec"      onClick={() => setOpen(false)}>DESIGN.md spec</a>
               <a href="/vs/design-extractor" onClick={() => setOpen(false)}>vs design-extractor</a>

--- a/website/app/layout.js
+++ b/website/app/layout.js
@@ -112,6 +112,7 @@ async function Nav() {
         <nav className="nav-pillnav" aria-label="primary">
           <a href="/features"><span>Features</span></a>
           <a href="/gallery"><span>Gallery</span></a>
+          <a href="/studio"><span>Studio</span></a>
           <a href="/motion"><span>Motion</span></a>
           <a href="/spec"><span>Spec</span></a>
           <a href="/vs/design-extractor"><span>vs</span></a>

--- a/website/app/sitemap.js
+++ b/website/app/sitemap.js
@@ -17,6 +17,7 @@ export default function sitemap() {
     { path: '',                       priority: 1.0,  freq: 'daily'   },
     { path: '/features',              priority: 0.9,  freq: 'weekly'  },
     { path: '/gallery',               priority: 0.9,  freq: 'hourly'  },
+    { path: '/studio',                priority: 0.9,  freq: 'weekly'  },
     { path: '/motion',                priority: 0.85, freq: 'weekly'  },
     { path: '/spec',                  priority: 0.9,  freq: 'monthly' },
     { path: '/vs/design-extractor',   priority: 0.9,  freq: 'weekly'  },

--- a/website/app/studio/StudioPlayground.js
+++ b/website/app/studio/StudioPlayground.js
@@ -1,0 +1,198 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const EXAMPLES = ['stripe.com', 'linear.app', 'vercel.com', 'notion.so'];
+
+export default function StudioPlayground() {
+  const [status, setStatus] = useState('idle'); // idle | loading | done | error
+  const [html, setHtml] = useState(null);
+  const [host, setHost] = useState(null);
+  const [docUrl, setDocUrl] = useState(null);
+  const [errorMsg, setErrorMsg] = useState(null);
+  const inputRef = useRef(null);
+
+  // A standalone Blob URL of the studio doc, for "Open full ↗" in a new tab.
+  useEffect(() => {
+    if (!html) { setDocUrl(null); return; }
+    const url = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
+    setDocUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [html]);
+
+  const run = useCallback(async (rawUrl) => {
+    const raw = (rawUrl != null ? rawUrl : (inputRef.current?.value || '')).trim();
+    if (!raw) return;
+    const url = /^https?:\/\//i.test(raw) ? raw : 'https://' + raw;
+    setStatus('loading');
+    setErrorMsg(null);
+    try {
+      const res = await fetch('/api/studio', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setErrorMsg(json.error || 'Could not open the studio for that URL.');
+        setStatus('error');
+        return;
+      }
+      setHtml(json.html);
+      setHost(json.hostname);
+      setStatus('done');
+      // Reflect the target in the URL so the page is shareable.
+      try {
+        const u = new URL(window.location.href);
+        u.searchParams.set('url', raw.replace(/^https?:\/\//i, ''));
+        window.history.replaceState(null, '', u);
+      } catch {}
+    } catch {
+      setErrorMsg('Network error — please try again.');
+      setStatus('error');
+    }
+  }, []);
+
+  const onSubmit = (e) => {
+    e.preventDefault();
+    run();
+  };
+
+  // Auto-run from ?url= so shared links open straight into the studio.
+  useEffect(() => {
+    try {
+      const q = new URL(window.location.href).searchParams.get('url');
+      if (q) {
+        if (inputRef.current) inputRef.current.value = q.replace(/^https?:\/\//i, '');
+        run(q);
+      }
+    } catch {}
+  }, [run]);
+
+  const loading = status === 'loading';
+
+  return (
+    <main className="studio-page">
+      <section className="studio-hero">
+        <div className="studio-eyebrow"><span>§ studio — live design-system editor</span></div>
+        <h1 className="studio-title">
+          Edit a website’s design system, <em>live</em>.
+        </h1>
+        <p className="studio-sub">
+          Paste any URL. Tweak the extracted tokens in the inspector and watch a wall of real
+          components — and a rebuilt page — restyle in real time. Then export DTCG tokens, CSS
+          variables, or a Tailwind theme.
+        </p>
+
+        <form className="dx-form studio-form" onSubmit={onSubmit}>
+          <span className="dx-form-prefix">https://</span>
+          <label htmlFor="studio-url" className="visually-hidden">URL</label>
+          <input
+            id="studio-url"
+            ref={inputRef}
+            type="text"
+            inputMode="url"
+            autoComplete="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            placeholder="stripe.com"
+            disabled={loading}
+            className="dx-form-input"
+          />
+          <button type="submit" className="dx-form-submit" disabled={loading} aria-busy={loading}>
+            {loading
+              ? (<><span className="dx-spinner" aria-hidden /><span>Opening studio…</span></>)
+              : (<><span>Open studio</span><span className="dx-form-kbd">↵</span></>)}
+          </button>
+        </form>
+
+        <div className="dx-suggest">
+          <span className="dx-suggest-label">try</span>
+          {EXAMPLES.map((s) => (
+            <button
+              key={s}
+              type="button"
+              className="dx-chip"
+              disabled={loading}
+              onClick={() => { if (inputRef.current) inputRef.current.value = s; run(s); }}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+
+        {status === 'error' && (
+          <p className="studio-error" role="alert">{errorMsg}</p>
+        )}
+      </section>
+
+      <section className="studio-stage-shell">
+        {status === 'idle' && (
+          <div className="studio-empty">
+            <p>Your editable studio appears here.</p>
+            <ul>
+              <li>Inspector with color pickers, type, shape, spacing &amp; motion</li>
+              <li>Live <strong>WCAG contrast</strong> grading as you edit</li>
+              <li>Component wall + a rebuilt page, paper / white / dark backdrops</li>
+              <li>Export DTCG · CSS variables · Tailwind theme</li>
+            </ul>
+          </div>
+        )}
+        {loading && (
+          <div className="studio-empty studio-loading">
+            <span className="dx-spinner" aria-hidden />
+            <p>Reading the design language off the live DOM…</p>
+          </div>
+        )}
+        {status === 'done' && html && (
+          <div className="studio-frame-wrap">
+            <div className="studio-frame-bar">
+              <span className="studio-frame-dot" /><span className="studio-frame-dot" /><span className="studio-frame-dot" />
+              <span className="studio-frame-host">{host}</span>
+              {docUrl && (
+                <a className="studio-frame-pop" href={docUrl} target="_blank" rel="noreferrer">
+                  Open full ↗
+                </a>
+              )}
+            </div>
+            <iframe
+              className="studio-frame"
+              title={`designlang studio — ${host || 'site'}`}
+              srcDoc={html}
+              sandbox="allow-scripts allow-downloads allow-popups allow-forms"
+              allow="clipboard-write"
+            />
+          </div>
+        )}
+      </section>
+
+      <style jsx>{`
+        .studio-page { max-width: 1180px; margin: 0 auto; padding: var(--r7) var(--r4) var(--r8); }
+        .studio-hero { padding-top: var(--r5); }
+        .studio-eyebrow { font-family: var(--font-mono, ui-monospace, monospace); font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-3); margin-bottom: var(--r3); }
+        .studio-title { font-size: clamp(34px, 6vw, 64px); letter-spacing: -0.03em; line-height: 1.03; margin: var(--r3) 0; color: var(--fg); }
+        .studio-title :global(em) { font-family: var(--font-display); font-style: italic; color: var(--accent); }
+        .studio-sub { max-width: 60ch; color: var(--fg-2); font-size: 17px; line-height: 1.55; margin-bottom: var(--r5); }
+        .studio-form { margin-top: var(--r4); }
+        .studio-error { margin-top: var(--r3); color: #ff6a52; font-size: 14px; }
+
+        .studio-stage-shell { margin-top: var(--r6); }
+        .studio-empty { border: 1px dashed var(--hairline-2); border-radius: var(--r4); padding: var(--r7) var(--r5); color: var(--fg-2); background: var(--surface); }
+        .studio-empty p { font-size: 16px; color: var(--fg); margin-bottom: var(--r3); }
+        .studio-empty ul { display: grid; gap: 8px; padding-left: 18px; color: var(--fg-2); font-size: 14px; }
+        .studio-empty strong { color: var(--fg); }
+        .studio-loading { display: flex; align-items: center; gap: var(--r3); text-align: left; }
+
+        .studio-frame-wrap { border: 1px solid var(--hairline-2); border-radius: var(--r4); overflow: hidden; background: #14110e; box-shadow: 0 24px 80px -28px rgba(0,0,0,0.7); }
+        .studio-frame-bar { display: flex; align-items: center; gap: 8px; padding: 10px 14px; background: #0c0c0c; border-bottom: 1px solid var(--hairline); }
+        .studio-frame-dot { width: 10px; height: 10px; border-radius: 999px; background: var(--hairline-2); }
+        .studio-frame-host { margin-left: 8px; font-family: var(--font-mono, ui-monospace, monospace); font-size: 12px; color: var(--fg-2); letter-spacing: 0.02em; }
+        .studio-frame-pop { margin-left: auto; font-family: var(--font-mono, ui-monospace, monospace); font-size: 12px; color: var(--fg-2); text-decoration: none; border: 1px solid var(--hairline-2); padding: 4px 10px; border-radius: 999px; }
+        .studio-frame-pop:hover { color: var(--fg); border-color: var(--accent); }
+        .studio-frame { width: 100%; height: min(82vh, 920px); border: 0; display: block; background: #f3f1ea; }
+
+        @media (max-width: 640px) { .studio-frame { height: 78vh; } }
+      `}</style>
+    </main>
+  );
+}

--- a/website/app/studio/page.js
+++ b/website/app/studio/page.js
@@ -1,0 +1,18 @@
+import { SITE_URL } from '../seo-config';
+import StudioPlayground from './StudioPlayground';
+
+export const metadata = {
+  title: 'Studio — edit a website’s design system live, then export',
+  description:
+    'Paste any URL and get a living design studio: edit the extracted tokens in an inspector and watch a wall of real components — and a rebuilt page — restyle in real time. Live WCAG contrast grading, paper/white/dark backdrops, then export DTCG tokens, CSS variables, or a Tailwind theme. Share your variant as a link.',
+  alternates: { canonical: `${SITE_URL}/studio` },
+  openGraph: {
+    title: 'Studio — edit a website’s design system live',
+    description: 'Extract any site, edit its tokens in an inspector, watch real components restyle instantly, and export DTCG / CSS / Tailwind.',
+    url: `${SITE_URL}/studio`,
+  },
+};
+
+export default function StudioPage() {
+  return <StudioPlayground />;
+}


### PR DESCRIPTION
## What

Turns `designlang studio` from a **read-only viewer** into a **living, editable design-system playground** — and ships the same experience on the website at **`/studio`**.

Edit a token in the inspector → a wall of real components *and* a rebuilt page restyle instantly, because everything renders off a small `--p-*` CSS-variable set. Then export the edited system, or share it as a link.

## CLI — `designlang studio`

- **Inspector**: color pickers + the extracted palette, type (font + size), shape (radius), spacing, motion (duration + easing).
- **Tabbed live preview**: a **component wall** (nav, buttons, form, cards, badges, alert, `Ag` type specimen) and a **rebuilt page** assembled from the extraction's reading order.
- **Live WCAG contrast grading** under every color (text-on-surface / accent-on-surface / label-on-accent), AAA / AA / AA-large / fail — updates as you edit.
- **Paper / white / dark backdrops**, an **edit counter**, smooth token-driven transitions.
- **Export** → DTCG tokens · CSS variables · Tailwind theme (zero-dependency client downloads).
- **Share via URL** — edits are encoded as deltas in the location hash; a tweaked variant is just a link, and reloading it restores the edits.

## Website — `/studio`

- Paste any URL → it extracts the live design language and **embeds the identical studio** in a framed viewport.
- Shareable via `?url=` (auto-runs on load). New `POST /api/studio` reuses the same `studioHtml` engine server-side and shares the existing free **2/day** demo budget with `/api/extract`.
- Added to desktop + mobile nav and the sitemap.

## Internals

- Token derivation extracted into a **pure, dependency-free module** (`src/studio-tokens.js`) shared by the CLI and the website route, so both surfaces stay in lock-step.
- The studio document is fully self-contained (inline CSS/JS, zero new deps).

## Tests / verification

- New unit tests (`tests/studio.test.js`): token derivation, fallback on a thin extraction, WCAG contrast math against known values, and the rendered studio document (markup + boot payload + prefix escaping). **Full suite: 445 passing.**
- Verified the CLI studio in a real browser: editing accent/radius restyles components, contrast badges + edit-count update, backdrop switches, and the shareable URL round-trips (fresh load restores edits and re-syncs the inspector).
- Verified `/studio` end-to-end against a live extraction (`example.com`): `POST /api/studio` → 200, editable studio rendered in the iframe (correct navy accent + Times font, live AAA grades), 0 console errors.

## Notes

- CLI is an engine change (`src/`), so it needs the version bump (→ **12.19.0**) + an `npm publish` to reach users. The website imports `src/` directly, so it picks up the studio on deploy without a publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)