### PR TITLE
feat(crawler): detect dark mode via prefers-color-scheme media queries

### DIFF
--- a/src/crawler.js
+++ b/src/crawler.js
@@ -1,6 +1,7 @@
 import { chromium } from 'playwright';
 import { mkdirSync } from 'fs';
 import { join } from 'path';
+import { extractMediaDarkColors } from './extractors/dark-mode-pair.js';
 
 const MAX_ELEMENTS = 5000;
 
@@ -168,6 +169,10 @@ export async function crawlPage(url, options = {}) {
     // Dark mode extraction
     let darkData = null;
     if (dark) {
+      // Issue #110: capture dark themes shipped purely via
+      // @media (prefers-color-scheme: dark) by flipping just the media feature
+      // on the already-loaded page (no reload) before the class/context pass.
+      const mediaColors = await extractMediaDarkColors(page).catch(() => null);
       await context.close();
       const darkContext = await browser.newContext({
         viewport: { width, height },
@@ -178,6 +183,7 @@ export async function crawlPage(url, options = {}) {
       await darkPage.waitForLoadState('networkidle').catch(() => {});
       await darkPage.evaluate(() => document.fonts.ready).catch(() => {});
       darkData = await extractPageData(darkPage);
+      darkData.mediaColors = mediaColors;
       await darkContext.close();
     } else {
       await context.close();

--- a/src/extractors/dark-mode-pair.js
+++ b/src/extractors/dark-mode-pair.js
@@ -10,6 +10,64 @@
 // Pure function. No Page handle, no side effects — takes the finished design
 // object and returns a plain JSON structure.
 
+import { extractColors } from './colors.js';
+
+// Issue #110 — many sites ship dark mode *only* through
+// `@media (prefers-color-scheme: dark)` and never toggle a class, so the
+// class/context dark pass yields no delta for them. This emulates just the
+// media feature on the already-loaded page (no reload) via Playwright's
+// `page.emulateMedia({ colorScheme: 'dark' })`, re-reads the computed styles
+// and pulls the dark colours out of them. Returns null when the page can't be
+// emulated (e.g. a stub without the API) or produced no styles.
+export async function extractMediaDarkColors(page) {
+  if (!page || typeof page.emulateMedia !== 'function') return null;
+  await page.emulateMedia({ colorScheme: 'dark' });
+  const styles = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('*')).slice(0, 5000).map(el => {
+      const cs = getComputedStyle(el);
+      const r = el.getBoundingClientRect();
+      return {
+        tag: el.tagName.toLowerCase(),
+        classList: Array.from(el.classList).join(' '),
+        role: el.getAttribute('role') || '',
+        area: r.width * r.height,
+        color: cs.color,
+        backgroundColor: cs.backgroundColor,
+        backgroundImage: cs.backgroundImage,
+        borderColor: cs.borderColor,
+      };
+    }),
+  );
+  // Restore the original scheme so any later pass on this page sees light.
+  try { await page.emulateMedia({ colorScheme: 'light' }); } catch { /* ignore */ }
+  if (!Array.isArray(styles) || styles.length === 0) return null;
+  return extractColors(styles);
+}
+
+function colorKey(c) {
+  return (typeof c === 'string' ? c : (c && c.hex) || '').toLowerCase();
+}
+
+// Merge the prefers-color-scheme dark colours into the class/context dark
+// colours. The class-based pass is usually the more deliberate theme, so it
+// wins whenever it already has a value; the media pass only fills the gaps.
+// `all` is unioned so a media-only dark theme still yields a non-empty set.
+export function mergeDarkColors(classBased, media) {
+  if (!media) return classBased || null;
+  if (!classBased) return media;
+  const out = { ...classBased };
+  for (const role of ['primary', 'secondary', 'accent']) {
+    if (!out[role] && media[role]) out[role] = media[role];
+  }
+  for (const key of ['neutrals', 'backgrounds', 'text', 'gradients']) {
+    if (!(classBased[key] || []).length && (media[key] || []).length) out[key] = media[key];
+  }
+  const base = classBased.all || [];
+  const seen = new Set(base.map(colorKey));
+  out.all = [...base, ...(media.all || []).filter(c => !seen.has(colorKey(c)))];
+  return out;
+}
+
 function hexOf(c) {
   if (!c) return null;
   if (typeof c === 'string') return c.toLowerCase();

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ import { extractBackgroundPatterns } from './extractors/background-patterns.js';
 import { extractStackIntel } from './extractors/stack-intel.js';
 import { extractFormStates } from './extractors/form-states.js';
 import { formatDtcgTokens } from './formatters/dtcg-tokens.js';
+import { mergeDarkColors } from './extractors/dark-mode-pair.js';
 
 function safeExtract(fn, ...args) {
   try { return fn(...args); } catch { return null; }
@@ -118,8 +119,11 @@ export async function extractDesignLanguage(url, options = {}) {
   }
 
   if (rawData.dark) {
+    const darkColors = safeExtract(extractColors, rawData.dark.computedStyles) || { primary: null, secondary: null, accent: null, neutrals: [], backgrounds: [], text: [], gradients: [], all: [] };
     design.darkMode = {
-      colors: safeExtract(extractColors, rawData.dark.computedStyles) || { primary: null, secondary: null, accent: null, neutrals: [], backgrounds: [], text: [], gradients: [], all: [] },
+      // Issue #110: fold the prefers-color-scheme media pass into the dark
+      // colours so sites that ship dark mode only via @media still yield a set.
+      colors: mergeDarkColors(darkColors, rawData.dark.mediaColors || null),
       variables: safeExtract(extractVariables, rawData.dark.cssVariables) || {},
     };
   }

--- a/tests/v9-features.test.js
+++ b/tests/v9-features.test.js
@@ -9,6 +9,7 @@ import { extractComponentAnatomy, formatAnatomyStubs } from '../src/extractors/c
 import { extractVoice } from '../src/extractors/voice.js';
 import { lintTokens } from '../src/lint.js';
 import { formatMotionTokens } from '../src/formatters/motion-tokens.js';
+import { extractMediaDarkColors, mergeDarkColors } from '../src/extractors/dark-mode-pair.js';
 
 describe('v9: motion extractor', () => {
   it('buckets durations into named tokens', () => {
@@ -101,3 +102,48 @@ describe('v9: token lint', () => {
     assert.ok(typeof r.score === 'number');
   });
 });
+
+describe('issue #110: prefers-color-scheme dark detection', () => {
+  it('emulates prefers-color-scheme: dark on a fake page and extracts colours', async () => {
+    const media = [];
+    // A fake Playwright page: records emulateMedia() calls and returns the
+    // computed styles a media-query dark theme would expose.
+    const fakePage = {
+      async emulateMedia(opts) { media.push(opts); },
+      async evaluate() {
+        return [
+          { tag: 'body', classList: '', role: '', area: 800000, color: 'rgb(243, 241, 234)', backgroundColor: 'rgb(10, 9, 8)', backgroundImage: 'none', borderColor: 'rgb(10, 9, 8)' },
+          { tag: 'a', classList: 'btn', role: '', area: 4000, color: 'rgb(255, 255, 255)', backgroundColor: 'rgb(77, 155, 255)', backgroundImage: 'none', borderColor: 'rgb(77, 155, 255)' },
+        ];
+      },
+    };
+    const colors = await extractMediaDarkColors(fakePage);
+    assert.ok(media.some(m => m.colorScheme === 'dark'), 'emulated prefers-color-scheme: dark');
+    assert.ok(colors && colors.all.length > 0, 'returns a non-empty dark colour set');
+  });
+
+  it('returns null for a page without emulateMedia support', async () => {
+    assert.equal(await extractMediaDarkColors({}), null);
+    assert.equal(await extractMediaDarkColors(null), null);
+  });
+
+  it('prefers the class-based dark colours but fills gaps from the media pass', () => {
+    const classBased = { primary: { hex: '#111111' }, secondary: null, accent: null, neutrals: [], backgrounds: ['#0a0908'], text: [], gradients: [], all: [{ hex: '#111111' }, { hex: '#0a0908' }] };
+    const mediaColors = { primary: { hex: '#4d9bff' }, secondary: null, accent: null, neutrals: [], backgrounds: [], text: ['#f3f1ea'], gradients: [], all: [{ hex: '#4d9bff' }, { hex: '#f3f1ea' }] };
+    const merged = mergeDarkColors(classBased, mediaColors);
+    assert.equal(merged.primary.hex, '#111111', 'class-based role wins');
+    assert.deepEqual(merged.text, ['#f3f1ea'], 'missing list filled from media pass');
+    assert.ok(merged.all.length >= 3, 'all colours are unioned across both passes');
+  });
+
+  it('falls back to the media pass when the class-based dark set is empty', () => {
+    const mediaColors = { primary: { hex: '#4d9bff' }, all: [{ hex: '#4d9bff' }] };
+    assert.equal(mergeDarkColors(null, mediaColors), mediaColors);
+    assert.equal(mergeDarkColors({ all: [] }, mediaColors).all.length, 1);
+    assert.equal(mergeDarkColors(classOnly(), null).primary.hex, '#111111');
+  });
+});
+
+function classOnly() {
+  return { primary: { hex: '#111111' }, all: [{ hex: '#111111' }] };
+}


### PR DESCRIPTION
Many sites ship dark mode purely through `@media (prefers-color-scheme: dark)` and never toggle a class, so the current class/context dark pass yields no delta for them. Adds a media-emulation pass that flips just the media feature on the already-loaded page (no reload) via `page.emulateMedia({ colorScheme: 'dark' })`, re-reads the computed styles, and extracts the dark colours from them.

Addresses #110 (dark mode was detected by class only). The new pass is merged into the existing dark colours with `mergeDarkColors`: the class-based theme is the more deliberate one so it wins where it has a value, and the media pass only fills gaps (and unions `all`), so media-only dark themes still produce a non-empty set while class-based sites are unchanged.

`node --test`: the new `issue #110: prefers-color-scheme dark detection` suite (4 cases) and the dark-mode pairing regression suite pass, and the full `v9-features` / `v10.2-features` test files are green.