### PR TITLE
fix: resolve #131 (crash) and #135 (narrative bugs) + add test CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+    name: node ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # One test (ci.test.js) exercises the extraction failure path, which
+      # launches Chromium — make sure the browser + system deps are present.
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run tests
+        run: npm test
+
+      - name: Check plugin manifest version sync
+        run: npm run check-plugin

--- a/bin/design-extract.js
+++ b/bin/design-extract.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
-import { mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { mkdirSync, writeFileSync, readFileSync, statSync } from 'fs';
 import { resolve, join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -603,7 +603,15 @@ program
         console.log('');
         console.log(chalk.bold('  Output files:'));
         for (const file of files) {
-          const size = Buffer.byteLength(file.content);
+          // Some entries (brand.html / brand.pdf) are written straight to disk
+          // and pushed without `content`; read their size off disk instead of
+          // calling Buffer.byteLength(undefined), which crashed the run (#131).
+          let size = 0;
+          if (file.content != null) {
+            size = Buffer.byteLength(file.content);
+          } else {
+            try { size = statSync(join(outDir, file.name)).size; } catch { size = 0; }
+          }
           const sizeStr = size > 1024 ? `${(size / 1024).toFixed(1)}KB` : `${size}B`;
           console.log(`  ${chalk.green('✓')} ${chalk.cyan(file.name)} ${chalk.gray(`(${sizeStr})`)} — ${file.label}`);
         }

--- a/src/formatters/markdown.js
+++ b/src/formatters/markdown.js
@@ -168,15 +168,32 @@ export function formatMarkdown(design) {
   }
 
   // ── CSS Variables ──
-  const varCategories = Object.entries(variables).filter(([, v]) => Object.keys(v).length > 0);
+  // Flatten each category to [name, value] leaves. Some categories (e.g.
+  // `semantic`) nest one level deeper — { success: { '--x': '#0a0' } } — so we
+  // render the inner vars, not the group objects (which stringified to
+  // `[object Object]`, #135).
+  const flattenVars = (vars) => {
+    const out = [];
+    for (const [name, value] of Object.entries(vars)) {
+      if (value && typeof value === 'object') {
+        for (const [sub, subVal] of Object.entries(value)) out.push([sub, subVal]);
+      } else {
+        out.push([name, value]);
+      }
+    }
+    return out;
+  };
+  const varCategories = Object.entries(variables)
+    .map(([category, vars]) => [category, flattenVars(vars)])
+    .filter(([, pairs]) => pairs.length > 0);
   if (varCategories.length > 0) {
     lines.push('## CSS Custom Properties');
     lines.push('');
-    for (const [category, vars] of varCategories) {
+    for (const [category, pairs] of varCategories) {
       lines.push(`### ${category.charAt(0).toUpperCase() + category.slice(1)}`);
       lines.push('');
       lines.push('```css');
-      for (const [name, value] of Object.entries(vars)) {
+      for (const [name, value] of pairs) {
         lines.push(`${name}: ${value};`);
       }
       lines.push('```');
@@ -202,7 +219,7 @@ export function formatMarkdown(design) {
     lines.push('');
 
     if (animations.easings.length > 0) {
-      lines.push(`**Easing functions:** ${animations.easings.map(e => `\`${e}\``).join(', ')}`);
+      lines.push(`**Easing functions:** ${animations.easings.map(e => `\`${typeof e === 'string' ? e : e.value}\``).join(', ')}`);
       lines.push('');
     }
     if (animations.durations.length > 0) {
@@ -249,7 +266,7 @@ export function formatMarkdown(design) {
       lines.push(`### ${name.charAt(0).toUpperCase() + name.slice(1)} (${comp.count} instances)`);
       lines.push('');
       lines.push('```css');
-      lines.push(`.${name.slice(0, -1)} {`);
+      lines.push(`.${name} {`);
       for (const [prop, val] of Object.entries(comp.baseStyle)) {
         const cssProp = prop.replace(/([A-Z])/g, '-$1').toLowerCase();
         lines.push(`  ${cssProp}: ${val};`);
@@ -563,7 +580,7 @@ export function formatMarkdown(design) {
     if (design.zIndex.issues.length > 0) {
       lines.push('**Issues:**');
       for (const issue of design.zIndex.issues) {
-        lines.push(`- ${issue}`);
+        lines.push(`- ${typeof issue === 'string' ? issue : issue.message}`);
       }
       lines.push('');
     }

--- a/tests/formatters.test.js
+++ b/tests/formatters.test.js
@@ -191,6 +191,55 @@ describe('formatMarkdown', () => {
     const result = formatMarkdown(mockDesign);
     assert.ok(result.includes('## Layout System'));
   });
+
+  // ── #135: narrative serialization bugs ──
+  describe('issue #135: object stringification + class truncation', () => {
+    const design = {
+      ...mockDesign,
+      components: { navigation: { count: 754, baseStyle: { backgroundColor: 'rgba(29,29,31,0.8)' } } },
+      variables: {
+        colors: { '--brand': '#0066cc' },
+        semantic: {
+          success: { '--color-success': '#0a0' },
+          warning: {}, error: {}, info: {},
+        },
+      },
+      animations: {
+        transitions: ['all 0.2s ease'],
+        keyframes: [],
+        easings: [{ value: 'cubic-bezier(0.4, 0, 0.2, 1)', pattern: 'ease-in-out' }],
+        durations: ['0.2s'],
+      },
+      zIndex: {
+        allValues: [10, 9999],
+        layers: [],
+        issues: [{ type: 'excessive', message: 'Very high z-index values: 9999' }],
+      },
+    };
+
+    it('never emits literal [object Object]', () => {
+      assert.ok(!formatMarkdown(design).includes('[object Object]'));
+    });
+
+    it('renders nested semantic vars as their inner values (1a)', () => {
+      const r = formatMarkdown(design);
+      assert.ok(r.includes('--color-success: #0a0;'), 'semantic leaf rendered');
+    });
+
+    it('renders easing function values, not objects (1b)', () => {
+      assert.ok(formatMarkdown(design).includes('cubic-bezier(0.4, 0, 0.2, 1)'));
+    });
+
+    it('renders z-index issue messages, not objects (1c)', () => {
+      assert.ok(formatMarkdown(design).includes('Very high z-index values: 9999'));
+    });
+
+    it('keeps full component class names (bug 2)', () => {
+      const r = formatMarkdown(design);
+      assert.ok(r.includes('.navigation {'), 'class name not truncated');
+      assert.ok(!r.includes('.navigatio '), 'no off-by-one truncation');
+    });
+  });
 });
 
 // ── formatTokens ────────────────────────────────────────────────


### PR DESCRIPTION
Fixes two reported bugs and adds the missing CI test workflow.

## #131 — every extraction exits 1 after writing all files
The brand-book entry (and `--pdf`) is written straight to disk and pushed to `files` **without a `content` field**, so the summary loop's `Buffer.byteLength(file.content)` threw on `undefined` — crashing the run *after* all artifacts were on disk. Now those entries read their size off disk.

✅ Verified end-to-end: `designlang example.com` now exits **0** and prints `…brand.html (31.1KB)`.

## #135 — narrative `*-design-language.md` bugs
- **`[object Object]`** in three places — semantic CSS vars (nested groups), easing functions (`{value,pattern}`), and z-index issues (`{type,message}`). Now rendered as their real values.
- **Truncated component class names** — `name.slice(0, -1)` dropped the last char (`.navigatio`). Now `.navigation`.

✅ Verified on real output: **0** `[object Object]`, full class names. Regression tests added (`tests/formatters.test.js`).

## CI
Adds `.github/workflows/test.yml` — runs `npm test` on Node 20 + 22 for every push/PR (plus the plugin-version sync check). This gives Dependabot auto-merge something real to gate on.

**Full suite: 490 tests passing.**

Closes #131
Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)