### PR TITLE
fix(crawler): capture prefers-color-scheme colors before the depth crawl

### DIFF
--- a/src/crawler.js
+++ b/src/crawler.js
@@ -133,6 +133,14 @@ export async function crawlPage(url, options = {}) {
       componentScreenshots = await captureComponentScreenshots(page, outDir);
     }
 
+    // Issue #110: capture the prefers-color-scheme dark colours before the depth
+    // crawl below navigates `page` to internal routes. Reading them after the crawl
+    // would sample the last internal page instead of the requested URL.
+    let mediaColors = null;
+    if (dark) {
+      mediaColors = await extractMediaDarkColors(page).catch(() => null);
+    }
+
     // Multi-page crawl: discover internal links and extract from them
     let additionalPages = [];
     const routes = [];
@@ -169,10 +177,6 @@ export async function crawlPage(url, options = {}) {
     // Dark mode extraction
     let darkData = null;
     if (dark) {
-      // Issue #110: capture dark themes shipped purely via
-      // @media (prefers-color-scheme: dark) by flipping just the media feature
-      // on the already-loaded page (no reload) before the class/context pass.
-      const mediaColors = await extractMediaDarkColors(page).catch(() => null);
       await context.close();
       const darkContext = await browser.newContext({
         viewport: { width, height },

--- a/src/extractors/dark-mode-pair.js
+++ b/src/extractors/dark-mode-pair.js
@@ -22,24 +22,29 @@ import { extractColors } from './colors.js';
 export async function extractMediaDarkColors(page) {
   if (!page || typeof page.emulateMedia !== 'function') return null;
   await page.emulateMedia({ colorScheme: 'dark' });
-  const styles = await page.evaluate(() =>
-    Array.from(document.querySelectorAll('*')).slice(0, 5000).map(el => {
-      const cs = getComputedStyle(el);
-      const r = el.getBoundingClientRect();
-      return {
-        tag: el.tagName.toLowerCase(),
-        classList: Array.from(el.classList).join(' '),
-        role: el.getAttribute('role') || '',
-        area: r.width * r.height,
-        color: cs.color,
-        backgroundColor: cs.backgroundColor,
-        backgroundImage: cs.backgroundImage,
-        borderColor: cs.borderColor,
-      };
-    }),
-  );
-  // Restore the original scheme so any later pass on this page sees light.
-  try { await page.emulateMedia({ colorScheme: 'light' }); } catch { /* ignore */ }
+  let styles;
+  try {
+    styles = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('*')).slice(0, 5000).map(el => {
+        const cs = getComputedStyle(el);
+        const r = el.getBoundingClientRect();
+        return {
+          tag: el.tagName.toLowerCase(),
+          classList: Array.from(el.classList).join(' '),
+          role: el.getAttribute('role') || '',
+          area: r.width * r.height,
+          color: cs.color,
+          backgroundColor: cs.backgroundColor,
+          backgroundImage: cs.backgroundImage,
+          borderColor: cs.borderColor,
+        };
+      }),
+    );
+  } finally {
+    // Restore the original scheme so the depth crawl and any later pass on this
+    // page see light, even if the evaluate above throws.
+    try { await page.emulateMedia({ colorScheme: 'light' }); } catch { /* ignore */ }
+  }
   if (!Array.isArray(styles) || styles.length === 0) return null;
   return extractColors(styles);
 }

--- a/tests/v9-features.test.js
+++ b/tests/v9-features.test.js
@@ -142,6 +142,40 @@ describe('issue #110: prefers-color-scheme dark detection', () => {
     assert.equal(mergeDarkColors({ all: [] }, mediaColors).all.length, 1);
     assert.equal(mergeDarkColors(classOnly(), null).primary.hex, '#111111');
   });
+
+  // Regression for #157: the media-dark capture runs on the shared `page`
+  // before the --depth crawl navigates it elsewhere. It MUST restore the
+  // scheme to light afterwards, or the subsequent crawl reads dark colours
+  // off internal pages. These guard the restore invariant the fix relies on.
+  it('restores prefers-color-scheme to light after a successful capture', async () => {
+    const media = [];
+    const fakePage = {
+      async emulateMedia(opts) { media.push(opts); },
+      async evaluate() {
+        return [
+          { tag: 'body', classList: '', role: '', area: 800000, color: 'rgb(243, 241, 234)', backgroundColor: 'rgb(10, 9, 8)', backgroundImage: 'none', borderColor: 'rgb(10, 9, 8)' },
+        ];
+      },
+    };
+    await extractMediaDarkColors(fakePage);
+    assert.equal(media.at(-1)?.colorScheme, 'light', 'page left in light after capture');
+  });
+
+  it('restores prefers-color-scheme to light even if the page evaluate throws', async () => {
+    const media = [];
+    const fakePage = {
+      async emulateMedia(opts) { media.push(opts); },
+      async evaluate() { throw new Error('navigation interrupted the evaluate'); },
+    };
+    let threw = false;
+    try {
+      await extractMediaDarkColors(fakePage);
+    } catch {
+      threw = true;
+    }
+    assert.equal(threw, true, 'the evaluate error propagates');
+    assert.equal(media.at(-1)?.colorScheme, 'light', 'finally still restored light');
+  });
 });
 
 function classOnly() {


### PR DESCRIPTION
Follow-up to #145, fixing an ordering bug I missed in that PR.

The prefers-color-scheme dark pass added there runs after the `--depth` crawl, which navigates the shared `page` object to internal routes first. So with `--dark --depth N` it reads the media colors off the last internal page instead of the requested URL. For sites that ship dark mode only via `@media (prefers-color-scheme: dark)`, that wrong page ends up as the homepage's whole dark palette.

The fix moves the capture to before the depth loop, while `page` is still on the requested URL.

Verified with a two-page fixture where the homepage and an internal page have different prefers-color-scheme colors:
- before: `--depth 1` gives the homepage the internal page's dark colors
- after: `--depth 1` gives the homepage its own colors

This is the issue the Codex review on #145 pointed out. Existing tests still pass.