### PR TITLE
feat(brand): Brand Essence — synthesized archetype chapter for the brand book

### DIFF
--- a/bin/design-extract.js
+++ b/bin/design-extract.js
@@ -17,6 +17,7 @@ import { formatSiteCoverage, formatSiteConsistency } from '../src/formatters/sit
 import { extractLogo } from '../src/extractors/logo.js';
 import { captureComponentScreenshotsV10 } from '../src/extractors/component-screenshots.js';
 import { pairDarkMode } from '../src/extractors/dark-mode-pair.js';
+import { deriveBrandEssence } from '../src/extractors/brand-essence.js';
 import { captureResponsiveScreenshots } from '../src/extractors/responsive-screenshots.js';
 import { captureCoreWebVitals, extractFontLoading } from '../src/extractors/perf.js';
 import { buildPromptPack } from '../src/formatters/prompt-pack.js';
@@ -1641,6 +1642,9 @@ program
         deepInteract: true,
       });
 
+      // Synthesize brand essence once so html, md, and json all share it.
+      design.essence = deriveBrandEssence(design);
+
       const outDir = resolve(opts.out);
       mkdirSync(outDir, { recursive: true });
       const prefix = opts.name || `${nameFromUrl(url)}.brand`;
@@ -1669,6 +1673,7 @@ program
           url: design.meta?.url,
           title: design.meta?.title,
           timestamp: design.meta?.timestamp,
+          essence: design.essence,
           intent: design.pageIntent,
           material: design.materialLanguage,
           imagery: design.imageryStyle,

--- a/commands/brand.md
+++ b/commands/brand.md
@@ -1,5 +1,5 @@
 ---
-description: Generate a full editorial brand-guidelines book for any URL. 13 chapters covering colour, typography, spacing, shape, iconography, motion, components, voice, accessibility, tokens, and how-to-use guidance. Print-ready, dark-mode toggle, hand-off-ready single HTML.
+description: Generate a full editorial brand-guidelines book for any URL. 14 chapters covering brand essence/archetype, colour, typography, spacing, shape, iconography, motion, components, voice, accessibility, tokens, and how-to-use guidance. Print-ready, dark-mode toggle, hand-off-ready single HTML.
 argument-hint: <url> [--open]
 ---
 
@@ -28,6 +28,7 @@ After the run completes:
 
 | § | Chapter | What it documents |
 |---|---|---|
+| 00 | Essence | Synthesized brand personality: positioning statement, archetype (1 of 12 Jungian, with confidence), adjectives, and a four-axis meter (warmth · energy · weight · era) — every call traced to extracted signals |
 | 01 | About | Page intent, material language, imagery style, component library, stack, voice tone |
 | 02 | Logo | Extracted SVG logo + clearspace + dimensions |
 | 03 | Colour | Brand colours with HEX/RGB/HSL/usage, neutrals grid, full palette, A11y callout |

--- a/docs/superpowers/specs/2026-06-20-brand-essence-design.md
+++ b/docs/superpowers/specs/2026-06-20-brand-essence-design.md
@@ -1,0 +1,107 @@
+# Brand Essence — design
+
+**Status:** approved (autopilot)
+**Date:** 2026-06-20
+**Surface:** npm CLI (`designlang brand`) — the editorial brand book
+
+## Problem
+
+The brand book documents *what* a site's design system is (colour, type, motion,
+voice) but never synthesizes *who the brand is*. A reader gets 13 chapters of
+accurate measurements and has to form the gestalt themselves. Every real brand
+book opens with an essence/positioning page — the one paragraph that tells you
+the personality before the spec. We have all the raw signals; we never combine
+them.
+
+## Goal
+
+Add a synthesized **Brand Essence** as the opening chapter (Chapter 00) of the
+book: a positioning statement, 3–5 personality adjectives, and a brand archetype
+— each one **traceable to extracted numbers**, not LLM vibes. The whole tool's
+credibility is "values come from real extraction"; the essence must hold that
+line, so it is deterministic and shows its evidence.
+
+## Non-goals
+
+- No LLM. Derivation is rule-based and reproducible.
+- No new browser extraction. Pure synthesis over the already-assembled `design`.
+- Not a separate command. It rides inside `brand` (html / md / json outputs).
+
+## Architecture
+
+A single pure module, `src/extractors/brand-essence.js`, exporting
+`deriveBrandEssence(design) -> essence`. It follows the existing pure-synthesizer
+pattern (`pairDarkMode(design)` in `dark-mode-pair.js`). No Playwright, no async,
+no I/O — given a `design` object it returns an `essence` object. Missing inputs
+degrade to neutral (axis 0), never throw.
+
+Integration:
+- `formatBrandBook` / `formatBrandBookMarkdown` compute `design.essence ||
+  deriveBrandEssence(design)` so HTML + MD always render it regardless of caller.
+- The `brand` command attaches `design.essence` before writing, and adds it to
+  the `brand.json` payload for programmatic consumers.
+
+## The `essence` object
+
+```js
+{
+  axes: {
+    // each -1..+1, with the human-readable readings that moved it
+    warmth: { value, reading },  // warm (+) ↔ cool (−)
+    energy: { value, reading },  // playful/kinetic (+) ↔ calm/serious (−)
+    weight: { value, reading },  // bold/assertive (+) ↔ subtle/quiet (−)
+    era:    { value, reading },  // modern (+) ↔ classic (−)
+  },
+  archetype: { name, confidence, runnerUp },  // nearest of 12 Jungian archetypes
+  adjectives: [ 'string', ... ],              // 3–5, from axis poles + archetype
+  positioning: 'one sentence with real values filled in',
+  evidence: [ 'Sharp 2px radii + 900-weight display → bold, modern', ... ],
+}
+```
+
+## Axis formulas (deterministic)
+
+All inputs already exist on `design`. Each axis is the mean of its component
+sub-scores, clamped to [-1, 1]. Components default to 0 when their signal is
+absent.
+
+- **warmth** — from the brand hue (primary → accent fallback), weighted by
+  saturation so near-greys read neutral. `cos(hue − 40°)` peaks warm at orange
+  (~40°), coolest at azure (~220°).
+- **energy** — mean of: tempo (faster median motion duration → +), roundness
+  (median border radius: 0px → −1, ≥24px → +1), saturation of brand colours,
+  bounce (spring/bounce/elastic easings or playful `motion.feel` → +).
+- **weight** — mean of: max font weight (≥800 → +1, ≤400 → −1), brand-vs-surface
+  luminance contrast, saturation.
+- **era** — mean of: typeface class (serif → classic, sans → modern, mono/
+  geometric → most modern), `materialLanguage.label` mapping (glass/gradient/
+  aurora → +, editorial/print/vintage → −).
+
+## Archetype selection
+
+12 Jungian archetypes each carry a canonical `[warmth, energy, weight, era]`
+fingerprint. Compute Euclidean distance from the brand's fingerprint to each;
+nearest = `name`, second = `runnerUp`, `confidence = clamp(1 − dist / maxDist)`.
+Deterministic, explainable, and the `evidence[]` array narrates which signals
+pushed which axis.
+
+## Rendering
+
+- **HTML**: `buildEssence(design, accent)` renders Chapter 00 before About —
+  large positioning statement set in the display face, an archetype line with
+  confidence, the adjective set as chips, a four-axis meter strip, and the
+  evidence list. TOC gains a `00 · Essence` entry; chapters 01–13 keep their
+  numbers (no renumber).
+- **Markdown**: a compact essence block at the top of the document.
+- **JSON**: `essence` added to the `brand.json` payload.
+
+## Testing (the gate)
+
+`tests/brand-essence.test.js`, Node's built-in runner, covering:
+1. A warm/playful/bold mock lands warm+, energy+, and a fitting archetype.
+2. A cool/restrained/serif mock lands cool−, era−, low energy.
+3. Archetype selection returns a name from the 12 with a 0..1 confidence.
+4. An empty `{}` design degrades to neutral axes and never throws.
+5. `formatBrandBook` output contains the Essence chapter + positioning text.
+
+Plus the existing `npm test` suite stays green.

--- a/src/extractors/brand-essence.js
+++ b/src/extractors/brand-essence.js
@@ -1,0 +1,344 @@
+// designlang brand-essence — synthesize a brand's personality from the
+// already-extracted design language.
+//
+// Pure function, no browser. Given the assembled `design` object it returns
+// an `essence`: four personality axes, the nearest of twelve Jungian
+// archetypes, a handful of adjectives, a one-line positioning statement, and
+// the evidence behind every call. Every number traces back to a real
+// extracted value — no LLM, no vibes. Missing inputs degrade to neutral.
+//
+// Mirrors the pure-synthesizer pattern of dark-mode-pair.js: design in,
+// derived object out, attached to `design.essence`.
+
+// ── Colour helpers ─────────────────────────────────────────────
+
+function hexToRgb(hex) {
+  if (!hex) return null;
+  const s = String(hex).trim().replace(/^#/, '');
+  const full = s.length === 3 ? s.split('').map(c => c + c).join('') : s.slice(0, 6);
+  if (!/^[0-9a-f]{6}$/i.test(full)) return null;
+  return {
+    r: parseInt(full.slice(0, 2), 16),
+    g: parseInt(full.slice(2, 4), 16),
+    b: parseInt(full.slice(4, 6), 16),
+  };
+}
+
+function rgbToHsl({ r, g, b }) {
+  const rN = r / 255, gN = g / 255, bN = b / 255;
+  const max = Math.max(rN, gN, bN), min = Math.min(rN, gN, bN);
+  let h = 0, s = 0; const l = (max + min) / 2;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rN: h = (gN - bN) / d + (gN < bN ? 6 : 0); break;
+      case gN: h = (bN - rN) / d + 2; break;
+      default: h = (rN - gN) / d + 4; break;
+    }
+    h /= 6;
+  }
+  return { h: Math.round(h * 360), s, l };
+}
+
+function relLum(rgb) {
+  const f = v => { v /= 255; return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4); };
+  return 0.2126 * f(rgb.r) + 0.7152 * f(rgb.g) + 0.0722 * f(rgb.b);
+}
+
+function contrastRatio(a, b) {
+  const la = relLum(a), lb = relLum(b);
+  const hi = Math.max(la, lb), lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+const clamp = (n, lo = -1, hi = 1) => Math.max(lo, Math.min(hi, n));
+const round2 = n => Math.round(n * 100) / 100;
+
+// Average the components that actually had data; null if none did.
+function meanPresent(parts) {
+  const vals = parts.filter(p => p != null && Number.isFinite(p));
+  if (!vals.length) return null;
+  return vals.reduce((a, b) => a + b, 0) / vals.length;
+}
+
+// ── Signal readers ─────────────────────────────────────────────
+
+function familyName(f) {
+  if (!f) return '';
+  if (typeof f === 'string') return f;
+  return f.name || f.family || '';
+}
+
+function brandColors(design) {
+  const c = design.colors || {};
+  return [c.primary, c.secondary, c.accent]
+    .map(x => (x && x.hex) ? hexToRgb(x.hex) : null)
+    .filter(Boolean);
+}
+
+// Hue of the first chromatic brand colour (0..360), or null if all grey.
+function brandHue(design) {
+  for (const rgb of brandColors(design)) {
+    const { h, s } = rgbToHsl(rgb);
+    if (s > 0.15) return h;
+  }
+  return null;
+}
+
+// Mean saturation (0..1) of chromatic brand colours.
+function brandSaturation(design) {
+  const sats = brandColors(design).map(rgb => rgbToHsl(rgb).s).filter(s => s > 0.05);
+  return sats.length ? sats.reduce((a, b) => a + b, 0) / sats.length : null;
+}
+
+function medianRadius(design) {
+  const radii = (design.borders?.radii || [])
+    .map(r => (typeof r === 'object' ? r.value : r))
+    .filter(n => Number.isFinite(n) && n >= 0)
+    .sort((a, b) => a - b);
+  if (!radii.length) return null;
+  return radii[Math.floor(radii.length / 2)];
+}
+
+function medianDurationMs(design) {
+  const ms = (design.motion?.durations || [])
+    .map(d => (typeof d === 'number' ? d : (d?.ms ?? parseDuration(d?.value ?? d))))
+    .filter(n => Number.isFinite(n) && n > 0)
+    .sort((a, b) => a - b);
+  if (!ms.length) return null;
+  return ms[Math.floor(ms.length / 2)];
+}
+
+function parseDuration(v) {
+  if (typeof v !== 'string') return NaN;
+  const m = v.match(/([\d.]+)\s*(ms|s)?/);
+  if (!m) return NaN;
+  const n = parseFloat(m[1]);
+  return m[2] === 's' ? n * 1000 : n;
+}
+
+function maxFontWeight(design) {
+  const ws = (design.typography?.weights || [])
+    .map(w => (typeof w === 'object' ? (w.weight ?? w.value) : w))
+    .map(w => parseInt(w, 10))
+    .filter(n => Number.isFinite(n) && n >= 100);
+  return ws.length ? Math.max(...ws) : null;
+}
+
+function hasBounce(design) {
+  const m = design.motion || {};
+  const feel = String(m.feel || '').toLowerCase();
+  if (/bounc|playful|spring|elastic|snappy/.test(feel)) return true;
+  if (m.spring) return true;
+  const eases = (m.easings || []).map(e => String(typeof e === 'string' ? e : (e?.value || e?.label || '')).toLowerCase());
+  return eases.some(e => /spring|bounce|elastic|back|overshoot/.test(e));
+}
+
+// Classify the display typeface: 'serif' | 'sans' | 'mono' | null.
+function typefaceClass(design) {
+  const name = familyName((design.typography?.families || [])[0]).toLowerCase();
+  if (!name) return null;
+  if (/mono|consol|courier|jetbrains|space mono|plex mono|fira code|menlo/.test(name)) return 'mono';
+  if (/serif|georgia|times|playfair|garamond|merriweather|\blora\b|freight|tiempos|canela|cardo|spectral|recoleta/.test(name)) return 'serif';
+  return 'sans';
+}
+
+function materialEra(design) {
+  const label = String(design.materialLanguage?.label || '').toLowerCase();
+  if (!label) return null;
+  if (/glass|aurora|gradient|holograph|neumorph|frosted/.test(label)) return 0.8;
+  if (/flat|minimal|clean|swiss/.test(label)) return 0.2;
+  if (/material/.test(label)) return 0.3;
+  if (/skeuomorph|textured|emboss/.test(label)) return -0.3;
+  if (/editorial|print|classic|vintage|retro|brutal/.test(label)) return -0.8;
+  return null;
+}
+
+function lightestBg(design) {
+  const bgs = (design.colors?.backgrounds || []).map(hexToRgb).filter(Boolean);
+  if (!bgs.length) return { r: 255, g: 255, b: 255 };
+  return bgs.reduce((best, rgb) => relLum(rgb) > relLum(best) ? rgb : best, bgs[0]);
+}
+
+// ── Axes ───────────────────────────────────────────────────────
+
+function computeAxes(design) {
+  const hue = brandHue(design);
+  const sat = brandSaturation(design);
+  const primaryHex = design.colors?.primary?.hex || design.colors?.accent?.hex || null;
+
+  // warmth — hue position, dampened by saturation so greys stay neutral.
+  let warmth = 0, warmthReading = 'no chromatic brand colour — neutral temperature';
+  if (hue != null) {
+    const raw = Math.cos((hue - 40) * Math.PI / 180);
+    warmth = clamp(raw * Math.min(1, (sat || 0) * 1.5));
+    warmthReading = `${primaryHex || 'brand hue'} at ${hue}° reads ${warmth >= 0 ? 'warm' : 'cool'}`;
+  }
+
+  // energy — tempo, roundness, saturation, bounce.
+  const ms = medianDurationMs(design);
+  const radius = medianRadius(design);
+  const energy = meanPresent([
+    ms != null ? clamp((350 - ms) / 250) : null,            // fast → +
+    radius != null ? clamp((radius - 12) / 12) : null,       // round → +
+    sat != null ? clamp(sat * 2 - 1) : null,                 // saturated → +
+    hasBounce(design) ? 0.6 : null,
+  ]) ?? 0;
+  const energyReading = [
+    radius != null && `${radius}px median radius`,
+    ms != null && `${ms}ms median motion`,
+    hasBounce(design) && 'springy easing',
+  ].filter(Boolean).join(', ') || 'little motion or shape signal';
+
+  // weight — type weight, brand/surface contrast, saturation.
+  const maxW = maxFontWeight(design);
+  const ratio = primaryHex ? contrastRatio(hexToRgb(primaryHex), lightestBg(design)) : null;
+  const weight = meanPresent([
+    maxW != null ? clamp((maxW - 600) / 200) : null,
+    ratio != null ? clamp((Math.min(ratio, 12) - 4) / 4) : null,
+    sat != null ? clamp(sat * 2 - 1) : null,
+  ]) ?? 0;
+  const weightReading = [
+    maxW != null && `heaviest weight ${maxW}`,
+    ratio != null && `${ratio.toFixed(1)}:1 brand contrast`,
+  ].filter(Boolean).join(', ') || 'no strong assertiveness signal';
+
+  // era — typeface class + material language.
+  const tc = typefaceClass(design);
+  const tcVal = tc === 'serif' ? -0.7 : tc === 'mono' ? 0.8 : tc === 'sans' ? 0.4 : null;
+  const era = meanPresent([tcVal, materialEra(design)]) ?? 0;
+  const eraReading = [
+    tc && `${tc} display face`,
+    design.materialLanguage?.label && `${design.materialLanguage.label} material`,
+  ].filter(Boolean).join(', ') || 'no typeface or material signal';
+
+  return {
+    warmth: { value: round2(warmth), reading: warmthReading },
+    energy: { value: round2(energy), reading: energyReading },
+    weight: { value: round2(weight), reading: weightReading },
+    era: { value: round2(era), reading: eraReading },
+  };
+}
+
+// ── Archetypes ─────────────────────────────────────────────────
+
+// [warmth, energy, weight, era] canonical fingerprints + signature words.
+const ARCHETYPES = [
+  { name: 'Innocent', fp: [0.4, 0.2, -0.4, -0.2], words: ['optimistic', 'pure'] },
+  { name: 'Everyman', fp: [0.2, -0.1, -0.3, -0.1], words: ['approachable', 'grounded'] },
+  { name: 'Hero', fp: [0.2, 0.4, 0.8, 0.1], words: ['courageous', 'driven'] },
+  { name: 'Outlaw', fp: [-0.1, 0.5, 0.9, 0.4], words: ['rebellious', 'raw'] },
+  { name: 'Explorer', fp: [-0.1, 0.3, 0.2, 0.3], words: ['adventurous', 'independent'] },
+  { name: 'Creator', fp: [0.3, 0.4, 0.4, 0.6], words: ['imaginative', 'expressive'] },
+  { name: 'Ruler', fp: [-0.2, -0.3, 0.7, -0.1], words: ['authoritative', 'premium'] },
+  { name: 'Magician', fp: [-0.2, 0.4, 0.3, 0.7], words: ['visionary', 'transformative'] },
+  { name: 'Lover', fp: [0.9, 0.1, 0.3, -0.2], words: ['sensual', 'refined'] },
+  { name: 'Caregiver', fp: [0.6, -0.2, -0.2, -0.2], words: ['nurturing', 'reassuring'] },
+  { name: 'Jester', fp: [0.7, 0.9, 0.2, 0.3], words: ['fun', 'irreverent'] },
+  { name: 'Sage', fp: [-0.3, -0.6, -0.2, 0.1], words: ['thoughtful', 'knowledgeable'] },
+];
+
+function dist(a, b) {
+  return Math.sqrt(a.reduce((sum, v, i) => sum + (v - b[i]) ** 2, 0));
+}
+
+function pickArchetype(axes) {
+  const fp = [axes.warmth.value, axes.energy.value, axes.weight.value, axes.era.value];
+  const ranked = ARCHETYPES
+    .map(a => ({ a, d: dist(fp, a.fp) }))
+    .sort((x, y) => x.d - y.d);
+  const top = ranked[0];
+  return {
+    name: top.a.name,
+    confidence: round2(clamp(1 - top.d / 2.5, 0, 1)),
+    runnerUp: ranked[1].a.name,
+    words: top.a.words,
+  };
+}
+
+// ── Adjectives & copy ──────────────────────────────────────────
+
+const POLES = {
+  warmth: { pos: 'warm', neg: 'cool' },
+  energy: { pos: 'kinetic', neg: 'composed' },
+  weight: { pos: 'bold', neg: 'understated' },
+  era: { pos: 'modern', neg: 'timeless' },
+};
+
+function pickAdjectives(axes, archetype) {
+  const out = [];
+  // Strongest-leaning axes first.
+  const ordered = Object.entries(axes).sort((a, b) => Math.abs(b[1].value) - Math.abs(a[1].value));
+  for (const [key, axis] of ordered) {
+    if (Math.abs(axis.value) >= 0.25) out.push(axis.value > 0 ? POLES[key].pos : POLES[key].neg);
+  }
+  for (const w of archetype.words) {
+    if (out.length >= 5) break;
+    if (!out.includes(w)) out.push(w);
+  }
+  return out.slice(0, 5);
+}
+
+function articleFor(word) {
+  return /^[aeiou]/i.test(word) ? 'an' : 'a';
+}
+
+function hostOf(design) {
+  const url = design.meta?.url;
+  try { return new URL(url).hostname.replace(/^www\./, ''); } catch { return String(url || 'This brand'); }
+}
+
+function buildPositioning(design, axes, archetype, adjectives) {
+  const host = hostOf(design);
+  const adjList = adjectives.length >= 2
+    ? `${adjectives.slice(0, -1).join(', ')} and ${adjectives[adjectives.length - 1]}`
+    : (adjectives[0] || 'distinctive');
+  const primary = design.colors?.primary?.hex || design.colors?.accent?.hex;
+  const display = familyName((design.typography?.families || [])[0]);
+  const feel = design.motion?.feel;
+
+  let anchor = '';
+  if (primary && display) anchor = `anchored on ${primary} and ${display}`;
+  else if (primary) anchor = `anchored on ${primary}`;
+  else if (display) anchor = `anchored on ${display}`;
+  const motion = feel ? `${anchor ? '' : 'with '}${feel} motion` : '';
+
+  const art = articleFor(archetype.name);
+  const tailParts = [anchor, motion].filter(Boolean);
+  const tail = tailParts.length ? ` — ${tailParts.join(', ')}.` : '.';
+  return `${host} is ${art} ${archetype.name} brand — ${adjList}${tail}`;
+}
+
+function buildEvidence(axes, archetype) {
+  const ordered = Object.entries(axes)
+    .filter(([, a]) => Math.abs(a.value) >= 0.15)
+    .sort((a, b) => Math.abs(b[1].value) - Math.abs(a[1].value))
+    .slice(0, 3);
+  const lines = ordered.map(([key, a]) => {
+    const pole = a.value > 0 ? POLES[key].pos : POLES[key].neg;
+    return `${a.reading} → ${pole} (${key} ${a.value > 0 ? '+' : ''}${a.value})`;
+  });
+  lines.push(`Axis fingerprint nearest the ${archetype.name} archetype (${Math.round(archetype.confidence * 100)}% fit, vs ${archetype.runnerUp}).`);
+  return lines;
+}
+
+// ── Public API ─────────────────────────────────────────────────
+
+export function deriveBrandEssence(design) {
+  const d = design || {};
+  const axes = computeAxes(d);
+  const archetype = pickArchetype(axes);
+  const adjectives = pickAdjectives(axes, archetype);
+  const positioning = buildPositioning(d, axes, archetype, adjectives);
+  const evidence = buildEvidence(axes, archetype);
+  return {
+    axes,
+    archetype: { name: archetype.name, confidence: archetype.confidence, runnerUp: archetype.runnerUp },
+    adjectives,
+    positioning,
+    evidence,
+  };
+}
+
+export default deriveBrandEssence;

--- a/src/formatters/brand-book.js
+++ b/src/formatters/brand-book.js
@@ -11,6 +11,8 @@
 //   2. Real text from the site whenever possible. The voice extractor
 //      surfaces real headings — use them. No filler aphorisms.
 
+import { deriveBrandEssence } from '../extractors/brand-essence.js';
+
 const FONT_DISPLAY = 'Instrument Serif';
 const FONT_BODY = 'Inter';
 const FONT_MONO = 'JetBrains Mono';
@@ -141,6 +143,7 @@ function buildCover(design, accent) {
 
 function buildToc() {
   const items = [
+    ['essence',       '00', 'Essence'],
     ['about',         '01', 'About'],
     ['logo',          '02', 'Logo'],
     ['color',         '03', 'Colour'],
@@ -170,6 +173,53 @@ function chapterHeader(num, title) {
       <span class="sec-num">Chapter ${num}</span>
       <h2>${esc(title)}</h2>
     </header>`;
+}
+
+function axisRow(label, leftPole, rightPole, value) {
+  const v = Number.isFinite(value) ? value : 0;
+  const pct = ((v + 1) / 2) * 100;
+  return `
+    <div class="axis-row">
+      <span class="axis-pole">${esc(leftPole)}</span>
+      <div class="axis-track" role="img" aria-label="${esc(label)}: ${v}">
+        <span class="axis-dot" style="left:${pct.toFixed(1)}%"></span>
+      </div>
+      <span class="axis-pole r">${esc(rightPole)}</span>
+    </div>`;
+}
+
+function buildEssence(design) {
+  const e = design.essence || deriveBrandEssence(design);
+  const a = e.axes || {};
+  const arch = e.archetype || {};
+  return `
+    <section id="essence">
+      ${chapterHeader('00', 'Essence')}
+      <p class="essence-lede">${esc(e.positioning)}</p>
+
+      <div class="essence-arch">
+        <span class="essence-arch-name">${esc(arch.name || '—')}</span>
+        <span class="essence-arch-meta">archetype · ${Math.round((arch.confidence || 0) * 100)}% fit${arch.runnerUp ? ` · vs ${esc(arch.runnerUp)}` : ''}</span>
+      </div>
+
+      ${(e.adjectives || []).length ? `
+        <h3 class="sub">Adjectives</h3>
+        <ul class="essence-chips">${e.adjectives.map(w => `<li>${esc(w)}</li>`).join('')}</ul>
+      ` : ''}
+
+      <h3 class="sub">Personality axes</h3>
+      <div class="axis-meters">
+        ${axisRow('Warmth', 'Cool', 'Warm', a.warmth?.value)}
+        ${axisRow('Energy', 'Composed', 'Kinetic', a.energy?.value)}
+        ${axisRow('Weight', 'Understated', 'Bold', a.weight?.value)}
+        ${axisRow('Era', 'Timeless', 'Modern', a.era?.value)}
+      </div>
+
+      ${(e.evidence || []).length ? `
+        <h3 class="sub">Evidence</h3>
+        <ul class="essence-evidence">${e.evidence.map(l => `<li>${esc(l)}</li>`).join('')}</ul>
+      ` : ''}
+    </section>`;
 }
 
 function buildAbout(design) {
@@ -818,6 +868,23 @@ export function formatBrandBook(design, opts = {}) {
   }
   [data-theme="dark"] .callout { background: rgba(255,255,255,.04); }
 
+  /* — Essence (ch.00) — */
+  .essence-lede { font-family: var(--display); font-weight: 400; font-size: clamp(24px, 3.2vw, 38px); line-height: 1.22; letter-spacing: -.01em; margin: 0 0 34px; }
+  .essence-arch { display: flex; flex-wrap: wrap; align-items: baseline; gap: 10px 18px; margin: 0 0 28px; padding-bottom: 24px; border-bottom: 1px solid var(--rule); }
+  .essence-arch-name { font-family: var(--display); font-size: 30px; line-height: 1; }
+  .essence-arch-meta { font-family: var(--mono); font-size: 11px; letter-spacing: .08em; color: var(--ink-faint); text-transform: uppercase; }
+  .essence-chips { display: flex; flex-wrap: wrap; gap: 8px; margin: 0; padding: 0; list-style: none; }
+  .essence-chips li { font-family: var(--mono); font-size: 12px; letter-spacing: .04em; text-transform: lowercase; padding: 6px 12px; border: 1px solid var(--rule); border-radius: 999px; }
+  .axis-meters { display: grid; gap: 16px; margin: 0; }
+  .axis-row { display: grid; grid-template-columns: 92px 1fr 92px; align-items: center; gap: 14px; }
+  .axis-pole { font-family: var(--mono); font-size: 10px; text-transform: uppercase; letter-spacing: .1em; color: var(--ink-faint); }
+  .axis-pole.r { text-align: right; }
+  .axis-track { position: relative; height: 4px; background: var(--rule); border-radius: 2px; }
+  .axis-track::before { content: ""; position: absolute; left: 50%; top: -4px; bottom: -4px; width: 1px; background: var(--ink-faint); opacity: .45; }
+  .axis-dot { position: absolute; top: 50%; width: 12px; height: 12px; border-radius: 50%; background: var(--accent); transform: translate(-50%, -50%); box-shadow: 0 0 0 3px var(--paper); }
+  .essence-evidence { list-style: none; padding: 0; margin: 0; display: grid; gap: 8px; }
+  .essence-evidence li { font-family: var(--mono); font-size: 12px; line-height: 1.5; color: var(--ink-soft); padding-left: 14px; border-left: 1px solid var(--rule); }
+
   /* — Logo — */
   .logo-card { display: grid; grid-template-columns: 2fr 1fr; gap: 24px; align-items: center; padding: 24px 0; }
   @media (max-width: 640px) { .logo-card { grid-template-columns: 1fr; } }
@@ -963,6 +1030,7 @@ export function formatBrandBook(design, opts = {}) {
   <main class="wrap">
     ${buildCover(design, accent)}
     ${buildToc()}
+    ${buildEssence(design)}
     ${buildAbout(design)}
     ${buildLogo(design)}
     ${buildColor(design)}
@@ -1011,10 +1079,20 @@ export function formatBrandBookMarkdown(design) {
   const colors = design.colors || {};
   const t = design.typography || {};
   const families = (t.families || []).map(familyName).filter(Boolean);
+  const e = design.essence || deriveBrandEssence(design);
+  const ax = e.axes || {};
   const lines = [
     `# ${hostName} — Brand guidelines`,
     ``,
     `_Generated by designlang on ${date}._`,
+    ``,
+    `## 00 · Essence`,
+    ``,
+    `> ${e.positioning}`,
+    ``,
+    `- Archetype: **${e.archetype?.name || '—'}** (${Math.round((e.archetype?.confidence || 0) * 100)}% fit, vs ${e.archetype?.runnerUp || '—'})`,
+    `- Adjectives: ${(e.adjectives || []).join(', ') || '—'}`,
+    `- Axes: warmth ${ax.warmth?.value ?? 0}, energy ${ax.energy?.value ?? 0}, weight ${ax.weight?.value ?? 0}, era ${ax.era?.value ?? 0}`,
     ``,
     `## 01 · About`,
     ``,

--- a/tests/brand-essence.test.js
+++ b/tests/brand-essence.test.js
@@ -1,0 +1,138 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveBrandEssence } from '../src/extractors/brand-essence.js';
+import { formatBrandBook, formatBrandBookMarkdown } from '../src/formatters/brand-book.js';
+
+const ARCHETYPES = [
+  'Innocent', 'Everyman', 'Hero', 'Outlaw', 'Explorer', 'Creator',
+  'Ruler', 'Magician', 'Lover', 'Caregiver', 'Jester', 'Sage',
+];
+
+// Warm, kinetic, bold, modern: orange brand, round corners, fast springy
+// motion, heavy weights, gradient material.
+const warmDesign = {
+  meta: { url: 'https://example-warm.com', timestamp: Date.now() },
+  colors: { primary: { hex: '#ff5a1f' }, accent: { hex: '#ffb020' }, backgrounds: ['#ffffff'] },
+  typography: { families: [{ name: 'Inter' }], scale: [{ size: 48 }], weights: [{ weight: 400 }, { weight: 900 }] },
+  borders: { radii: [{ value: 20 }, { value: 28 }] },
+  motion: { feel: 'bouncy', durations: [{ ms: 150 }], easings: ['cubic-bezier(.2,1.4,.4,1)'] },
+  materialLanguage: { label: 'gradient' },
+};
+
+// Cool, composed, classic: navy brand, sharp corners, slow motion, serif
+// display, editorial material.
+const coolDesign = {
+  meta: { url: 'https://example-cool.com', timestamp: Date.now() },
+  colors: { primary: { hex: '#13294b' }, backgrounds: ['#fefefe'] },
+  typography: { families: [{ name: 'Playfair Display' }], scale: [{ size: 40 }], weights: [{ weight: 400 }, { weight: 700 }] },
+  borders: { radii: [{ value: 0 }, { value: 2 }] },
+  motion: { feel: 'subtle', durations: [{ ms: 500 }], easings: ['ease'] },
+  materialLanguage: { label: 'editorial' },
+};
+
+describe('deriveBrandEssence — axes', () => {
+  it('reads a warm/kinetic/bold/modern site on the positive poles', () => {
+    const { axes } = deriveBrandEssence(warmDesign);
+    assert.ok(axes.warmth.value > 0.3, `warmth ${axes.warmth.value} should be warm`);
+    assert.ok(axes.energy.value > 0.3, `energy ${axes.energy.value} should be kinetic`);
+    assert.ok(axes.weight.value > 0, `weight ${axes.weight.value} should be bold`);
+    assert.ok(axes.era.value > 0, `era ${axes.era.value} should be modern`);
+  });
+
+  it('reads a cool/serif/editorial site on the negative poles', () => {
+    const { axes } = deriveBrandEssence(coolDesign);
+    assert.ok(axes.warmth.value < -0.3, `warmth ${axes.warmth.value} should be cool`);
+    assert.ok(axes.era.value < 0, `era ${axes.era.value} should be classic`);
+    assert.ok(axes.energy.value < 0.2, `energy ${axes.energy.value} should be composed`);
+  });
+
+  it('clamps every axis to [-1, 1] with a reading string', () => {
+    for (const d of [warmDesign, coolDesign]) {
+      for (const axis of Object.values(deriveBrandEssence(d).axes)) {
+        assert.ok(axis.value >= -1 && axis.value <= 1, `axis ${axis.value} out of range`);
+        assert.equal(typeof axis.reading, 'string');
+        assert.ok(axis.reading.length > 0);
+      }
+    }
+  });
+});
+
+describe('deriveBrandEssence — archetype', () => {
+  it('picks one of the twelve archetypes with a 0..1 confidence and a runner-up', () => {
+    const { archetype } = deriveBrandEssence(warmDesign);
+    assert.ok(ARCHETYPES.includes(archetype.name), `${archetype.name} not a known archetype`);
+    assert.ok(ARCHETYPES.includes(archetype.runnerUp));
+    assert.notEqual(archetype.name, archetype.runnerUp);
+    assert.ok(archetype.confidence >= 0 && archetype.confidence <= 1);
+  });
+
+  it('distinguishes a playful brand from an authoritative one', () => {
+    const warm = deriveBrandEssence(warmDesign).archetype.name;
+    const cool = deriveBrandEssence(coolDesign).archetype.name;
+    assert.notEqual(warm, cool);
+  });
+});
+
+describe('deriveBrandEssence — copy', () => {
+  it('produces 3-5 adjectives, a positioning sentence, and evidence', () => {
+    const e = deriveBrandEssence(warmDesign);
+    assert.ok(e.adjectives.length >= 3 && e.adjectives.length <= 5);
+    assert.ok(e.positioning.includes('example-warm.com'));
+    assert.ok(e.positioning.endsWith('.'));
+    assert.ok(e.evidence.length >= 1);
+  });
+
+  it('does not leave a dangling em-dash when anchors are missing', () => {
+    const e = deriveBrandEssence({ meta: { url: 'https://bare.com' } });
+    assert.ok(!e.positioning.includes('—.'), e.positioning);
+    assert.ok(e.positioning.endsWith('.'));
+  });
+});
+
+describe('deriveBrandEssence — robustness', () => {
+  it('degrades an empty design to neutral axes without throwing', () => {
+    const e = deriveBrandEssence({});
+    for (const axis of Object.values(e.axes)) assert.equal(axis.value, 0);
+    assert.ok(ARCHETYPES.includes(e.archetype.name));
+    assert.equal(typeof e.positioning, 'string');
+  });
+
+  it('handles null/undefined input', () => {
+    assert.doesNotThrow(() => deriveBrandEssence(null));
+    assert.doesNotThrow(() => deriveBrandEssence(undefined));
+  });
+
+  it('tolerates string-form durations and weights', () => {
+    const e = deriveBrandEssence({
+      meta: { url: 'https://x.com' },
+      colors: { primary: { hex: '#cc0000' }, backgrounds: ['#fff'] },
+      typography: { families: [{ name: 'Arial' }], weights: ['400', '700'] },
+      motion: { durations: ['0.2s', '0.4s'] },
+    });
+    assert.ok(Number.isFinite(e.axes.energy.value));
+    assert.ok(Number.isFinite(e.axes.weight.value));
+  });
+});
+
+describe('brand book renders the Essence chapter', () => {
+  it('emits Chapter 00 in the HTML book with the positioning text', () => {
+    const html = formatBrandBook(warmDesign, { version: 'test' });
+    assert.ok(html.includes('id="essence"'));
+    assert.ok(html.includes('Chapter 00'));
+    assert.ok(html.includes('href="#essence"'));
+    assert.ok(html.includes('axis-dot'));
+    assert.ok(html.includes('example-warm.com is'));
+  });
+
+  it('emits a 00 · Essence block in the markdown', () => {
+    const md = formatBrandBookMarkdown(warmDesign);
+    assert.ok(md.includes('## 00 · Essence'));
+    assert.ok(md.includes('- Archetype:'));
+  });
+
+  it('reuses a precomputed design.essence when present', () => {
+    const tagged = { ...warmDesign, essence: { ...deriveBrandEssence(warmDesign), positioning: 'SENTINEL positioning.' } };
+    const html = formatBrandBook(tagged, { version: 'test' });
+    assert.ok(html.includes('SENTINEL positioning.'));
+  });
+});


### PR DESCRIPTION
## Brand Essence — a synthesized opening chapter for the brand book

Adds **Chapter 00 · Essence** to the `/brand` book: the "who is this brand" page every real brand guideline opens with, derived **entirely from already-extracted signals** — deterministic, no LLM, no API key. The tool's credibility is "values come from real extraction," so the essence holds that line: every call traces back to a measured number.

### What it produces
- **Positioning statement** — one editorial sentence with the real primary hex, display face, and motion feel filled in.
- **Archetype** — nearest of the 12 Jungian archetypes (with % fit + runner-up), via Euclidean distance over a 4-axis fingerprint.
- **Four personality axes** — `warmth · energy · weight · era`, each −1…+1 on a meter strip, computed from hue/saturation, motion tempo, border roundness, font weight, brand contrast, typeface class, and material language.
- **Adjectives** + an **evidence list** that narrates which signals moved which axis (e.g. *"28px median radius, 150ms motion, springy easing → kinetic"*).

Renders in all three outputs: HTML book (Chapter 00 + TOC entry), markdown (`00 · Essence` block), and `brand.json` (`essence` field). Chapters 01–13 keep their numbers.

### How it's built
- `src/extractors/brand-essence.js` — pure `deriveBrandEssence(design)` synthesizer, mirroring the existing `pairDarkMode(design)` pattern. Missing inputs degrade to neutral; never throws.
- `buildEssence()` in `brand-book.js` (+ markdown block, + `essence` in the JSON payload via `bin`).
- Design spec in `docs/superpowers/specs/`.

### Tests
`tests/brand-essence.test.js` — 13 tests: warm/cool axis polarity, archetype selection from the twelve, adjective/positioning/evidence shape, dangling-em-dash guard, empty/null robustness, string-form inputs, and the Essence chapter in html + md.

Full suite green: **503 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
