### PR TITLE
feat(theatre): CDP screencast capture util

### DIFF
--- a/website/lib/screencast.js
+++ b/website/lib/screencast.js
@@ -1,0 +1,152 @@
+// Live screencast capture over a Chrome DevTools Protocol session.
+//
+// Wraps `Page.startScreencast` into a throttled, capped frame source for the
+// Extraction Theatre: the browser is already driving the page, this just taps
+// what it renders and hands each JPEG frame to `onFrame`.
+//
+// The CDP client is INJECTED, so this unit-tests with a fake client that emits
+// `Page.screencastFrame` events — no real browser, no Playwright in the test.
+//
+// CDP contract we depend on:
+//   client.send('Page.startScreencast', opts)      -> begins the cast
+//   client.on('Page.screencastFrame', handler)     -> { data, metadata, sessionId }
+//   client.send('Page.screencastFrameAck', {...})  -> MUST ack or Chrome pauses
+//   client.send('Page.stopScreencast')             -> ends the cast
+
+export const SCREENCAST_DEFAULTS = {
+  format: 'jpeg',
+  quality: 50,
+  maxWidth: 1280,
+  maxHeight: 800,
+  everyNthFrame: 1,
+  fps: 6, // throttle: never emit faster than this
+  maxFrames: 240, // hard cap (~40s @ 6fps)
+  maxDurationMs: 45_000,
+};
+
+// Minimal interval (ms) between emitted frames for a target fps.
+function frameInterval(fps) {
+  return fps > 0 ? Math.floor(1000 / fps) : 0;
+}
+
+/**
+ * Start a throttled screencast. Returns `{ stop }`.
+ *
+ * @param {{ send:Function, on:Function, off?:Function, removeListener?:Function }} client
+ *        an injected CDP session
+ * @param {(frame:{seq:number,t:number,data:string,width?:number,height?:number})=>void} onFrame
+ * @param {object} [opts] overrides for SCREENCAST_DEFAULTS, plus optional `now`
+ * @returns {Promise<{stop:()=>Promise<void>}>}
+ */
+export async function startScreencast(client, onFrame, opts = {}) {
+  if (!client || typeof client.send !== 'function' || typeof client.on !== 'function') {
+    throw new TypeError('startScreencast requires a CDP client with send() and on()');
+  }
+  if (typeof onFrame !== 'function') {
+    throw new TypeError('startScreencast requires an onFrame callback');
+  }
+
+  const cfg = { ...SCREENCAST_DEFAULTS, ...opts };
+  const now = typeof cfg.now === 'function' ? cfg.now : Date.now;
+  const minGap = frameInterval(cfg.fps);
+
+  const startedAt = now();
+  let seq = 0;
+  let emitted = 0;
+  let lastEmit = -Infinity;
+  let stopped = false;
+
+  const stop = makeStopper(client, () => {
+    stopped = true;
+  });
+
+  const onScreencastFrame = async (params = {}) => {
+    if (stopped) return;
+    const { data, metadata, sessionId } = params;
+
+    // Ack FIRST and ALWAYS — even for frames we drop — or Chrome stalls the cast.
+    if (sessionId != null) {
+      try {
+        await client.send('Page.screencastFrameAck', { sessionId });
+      } catch {
+        // A failed ack just means the cast is ending; nothing to recover.
+      }
+    }
+
+    const t = now() - startedAt;
+
+    // Throttle to the target fps.
+    if (now() - lastEmit < minGap) return;
+    lastEmit = now();
+
+    if (typeof data === 'string' && data.length) {
+      onFrame({
+        seq: seq++,
+        t,
+        data,
+        width: metadata?.deviceWidth,
+        height: metadata?.deviceHeight,
+      });
+      emitted++;
+    }
+
+    // Enforce the caps.
+    if (emitted >= cfg.maxFrames || t >= cfg.maxDurationMs) {
+      await stop();
+    }
+  };
+
+  client.on('Page.screencastFrame', onScreencastFrame);
+  stop._detach = () => detach(client, 'Page.screencastFrame', onScreencastFrame);
+
+  try {
+    await client.send('Page.startScreencast', {
+      format: cfg.format,
+      quality: cfg.quality,
+      maxWidth: cfg.maxWidth,
+      maxHeight: cfg.maxHeight,
+      everyNthFrame: cfg.everyNthFrame,
+    });
+  } catch (err) {
+    // Could not even start — clean up the listener and surface failure so the
+    // caller degrades to a token-only stream.
+    detach(client, 'Page.screencastFrame', onScreencastFrame);
+    throw err;
+  }
+
+  return { stop };
+}
+
+// Build a stop() that is idempotent: detaches the listener, stops the cast, and
+// flips the caller's `stopped` flag exactly once.
+function makeStopper(client, markStopped) {
+  let done = false;
+  const stop = async () => {
+    if (done) return;
+    done = true;
+    markStopped();
+    if (typeof stop._detach === 'function') stop._detach();
+    try {
+      await client.send('Page.stopScreencast');
+    } catch {
+      // Session may already be gone — fine.
+    }
+  };
+  return stop;
+}
+
+function detach(client, event, handler) {
+  if (typeof client.off === 'function') client.off(event, handler);
+  else if (typeof client.removeListener === 'function') client.removeListener(event, handler);
+}
+
+/**
+ * Glue: derive a CDP session from a Playwright page. Kept separate from the
+ * pure core above so the core stays browser-free for tests.
+ * @param {import('playwright-core').Page} page
+ * @returns {Promise<object>} a CDP session
+ */
+export async function cdpClientForPage(page) {
+  const context = page.context();
+  return context.newCDPSession(page);
+}

--- a/website/lib/screencast.test.js
+++ b/website/lib/screencast.test.js
@@ -1,0 +1,124 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startScreencast, SCREENCAST_DEFAULTS } from './screencast.js';
+
+// A fake CDP session: records sent methods, lets the test emit frames, and can
+// be told to fail on startScreencast.
+class FakeCDP {
+  constructor({ failStart = false } = {}) {
+    this.handlers = {};
+    this.sent = [];
+    this.failStart = failStart;
+  }
+  on(ev, fn) {
+    (this.handlers[ev] ||= []).push(fn);
+  }
+  off(ev, fn) {
+    this.handlers[ev] = (this.handlers[ev] || []).filter((h) => h !== fn);
+  }
+  async send(method, params) {
+    this.sent.push({ method, params });
+    if (method === 'Page.startScreencast' && this.failStart) throw new Error('cannot start cast');
+    return {};
+  }
+  async emitFrame(params) {
+    for (const h of this.handlers['Page.screencastFrame'] || []) await h(params);
+  }
+  count(method) {
+    return this.sent.filter((s) => s.method === method).length;
+  }
+}
+
+const frame = (sessionId, data = 'AAAA') => ({
+  data,
+  metadata: { deviceWidth: 200, deviceHeight: 120 },
+  sessionId,
+});
+
+test('starts the cast with jpeg + downscale options', async () => {
+  const cdp = new FakeCDP();
+  await startScreencast(cdp, () => {}, { now: () => 0 });
+  const start = cdp.sent.find((s) => s.method === 'Page.startScreencast');
+  assert.ok(start, 'sent Page.startScreencast');
+  assert.equal(start.params.format, 'jpeg');
+  assert.equal(start.params.maxWidth, SCREENCAST_DEFAULTS.maxWidth);
+});
+
+test('acks every frame even when throttled, emits at most one per interval', async () => {
+  const cdp = new FakeCDP();
+  let clock = 0;
+  const frames = [];
+  await startScreencast(cdp, (f) => frames.push(f), { fps: 10, now: () => clock });
+
+  await cdp.emitFrame(frame(1)); // t=0   -> emit
+  clock = 50;
+  await cdp.emitFrame(frame(2)); // +50ms -> within 100ms gap, dropped
+  clock = 120;
+  await cdp.emitFrame(frame(3)); // +120  -> emit
+
+  assert.equal(frames.length, 2, 'two frames emitted');
+  assert.equal(cdp.count('Page.screencastFrameAck'), 3, 'all three acked');
+  assert.deepEqual(
+    frames.map((f) => f.seq),
+    [0, 1],
+    'seq increments only on emitted frames',
+  );
+  assert.equal(frames[0].width, 200);
+});
+
+test('stops after maxFrames and ignores later frames', async () => {
+  const cdp = new FakeCDP();
+  const frames = [];
+  await startScreencast(cdp, (f) => frames.push(f), { fps: 0, maxFrames: 2, now: () => 0 });
+
+  await cdp.emitFrame(frame(1));
+  await cdp.emitFrame(frame(2)); // hits cap -> stop()
+  await cdp.emitFrame(frame(3)); // ignored
+
+  assert.equal(frames.length, 2);
+  assert.equal(cdp.count('Page.stopScreencast'), 1, 'stopped exactly once');
+});
+
+test('stops after maxDurationMs', async () => {
+  const cdp = new FakeCDP();
+  let clock = 0;
+  const frames = [];
+  await startScreencast(cdp, (f) => frames.push(f), {
+    fps: 0,
+    maxDurationMs: 100,
+    now: () => clock,
+  });
+
+  await cdp.emitFrame(frame(1)); // t=0
+  clock = 150;
+  await cdp.emitFrame(frame(2)); // t=150 >= 100 -> emit then stop
+  await cdp.emitFrame(frame(3)); // ignored
+
+  assert.equal(frames.length, 2);
+  assert.equal(cdp.count('Page.stopScreencast'), 1);
+});
+
+test('stop() detaches the listener and is idempotent', async () => {
+  const cdp = new FakeCDP();
+  const frames = [];
+  const { stop } = await startScreencast(cdp, (f) => frames.push(f), { fps: 0, now: () => 0 });
+
+  await stop();
+  await stop(); // second call is a no-op
+  await cdp.emitFrame(frame(1)); // detached -> nothing
+
+  assert.equal(frames.length, 0);
+  assert.equal(cdp.count('Page.stopScreencast'), 1, 'stopScreencast sent once');
+  assert.equal((cdp.handlers['Page.screencastFrame'] || []).length, 0, 'listener removed');
+});
+
+test('a startScreencast failure throws and removes the listener', async () => {
+  const cdp = new FakeCDP({ failStart: true });
+  await assert.rejects(() => startScreencast(cdp, () => {}, { now: () => 0 }));
+  assert.equal((cdp.handlers['Page.screencastFrame'] || []).length, 0, 'no dangling listener');
+});
+
+test('rejects bad arguments', async () => {
+  await assert.rejects(() => startScreencast(null, () => {}));
+  await assert.rejects(() => startScreencast(new FakeCDP(), 'not-a-fn'));
+});


### PR DESCRIPTION
PR1 of the 13.0.0 Extraction Theatre series.

Adds `website/lib/screencast.js` — a throttled, capped wrapper over Chrome
DevTools Protocol `Page.startScreencast`. The CDP client is injected, so it
unit-tests with a fake client (no real browser).

- Acks every frame (even dropped ones) so Chrome never stalls the cast.
- Throttles to a target fps; caps total frames + duration; idempotent `stop()`.
- `cdpClientForPage()` glue derives a session from a Playwright page (used by PR2).

7 unit tests, all green via `node --test website/lib/screencast.test.js`.