### PR TITLE
feat(theatre): record screencast reels + replay on cache hits

### DIFF
--- a/website/app/api/extract/route.js
+++ b/website/app/api/extract/route.js
@@ -14,6 +14,7 @@ import { checkRate, checkRateBlob } from '../../../../website/lib/rate-limit.js'
 import { cacheKey, getCached, putCached } from '../../../../website/lib/cache.js';
 import { buildFiles, buildSummary } from '../../../../website/lib/build-files.js';
 import { wantsTheatre, frameEvent, THEATRE_SCREENCAST_OPTS } from '../../../../website/lib/theatre.js';
+import { recordReel, loadReel, buildReplayTimeline } from '../../../../website/lib/reel.js';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -98,23 +99,41 @@ function extractIp(request) {
 }
 
 // Emit cached payload as a simulated stream so the hero paints consistently.
-async function streamCached(controller, cached, targetUrl, hash) {
+// With `theatre` on and a recorded reel present, replays the real screencast
+// (frames merged with the token paint) so a cache hit still looks live.
+async function streamCached(controller, cached, targetUrl, hash, theatre = false) {
   controller.enqueue(ndjson({ type: 'cache', cached: true }));
   // Permalink up front — the client can rewrite the URL bar to /x/<hash>
   // before any heavy paint, so refresh-and-share works during the stream.
   controller.enqueue(ndjson({ type: 'permalink', hash }));
+
+  // Re-derive DTCG tokens from the cached design so the token-by-token paint
+  // still happens on a cache hit.
+  const { files, dtcg } = buildFiles(cached.design, targetUrl);
+  const tokens = [];
+  for (const { path, value, $type } of walkDtcgTokens(dtcg)) {
+    tokens.push({ category: path.split('.')[1] || 'misc', path, value, $type });
+  }
+  const summary = buildSummary(cached.design);
+
+  if (theatre) {
+    const reel = await loadReel(hash);
+    if (reel) {
+      const { steps } = buildReplayTimeline({ frames: reel.frames, tokens, stages: STAGES, summary, files });
+      for (const { delayMs, event } of steps) {
+        if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
+        controller.enqueue(ndjson(event));
+      }
+      return;
+    }
+  }
+
   for (const stage of STAGES) {
     controller.enqueue(ndjson({ type: 'stage', name: stage }));
     await new Promise((r) => setTimeout(r, 40));
   }
-  // Re-derive DTCG tokens from the cached design so the token-by-token paint
-  // still happens on a cache hit.
-  const { files, dtcg } = buildFiles(cached.design, targetUrl);
-  for (const { path, value, $type } of walkDtcgTokens(dtcg)) {
-    const category = path.split('.')[1] || 'misc';
-    controller.enqueue(ndjson({ type: 'token', category, path, value, $type }));
-  }
-  controller.enqueue(ndjson({ type: 'summary', summary: buildSummary(cached.design) }));
+  for (const tok of tokens) controller.enqueue(ndjson({ type: 'token', ...tok }));
+  controller.enqueue(ndjson({ type: 'summary', summary }));
   controller.enqueue(ndjson({ type: 'files', files }));
 }
 
@@ -168,7 +187,7 @@ export async function POST(request) {
     async start(controller) {
       try {
         if (cached) {
-          await streamCached(controller, cached, targetUrl, key);
+          await streamCached(controller, cached, targetUrl, key, theatre);
           controller.close();
           return;
         }
@@ -184,8 +203,10 @@ export async function POST(request) {
         // Theatre: a frame sink that streams what Chromium paints, live, into
         // the same NDJSON response. Opt-in only — undefined otherwise, so the
         // crawler skips the screencast entirely.
+        const reelFrames = [];
         const onScreencastFrame = theatre
           ? (frame) => {
+              reelFrames.push(frame); // captured once, replayed on cache hits
               try { controller.enqueue(ndjson(frameEvent(frame))); } catch { /* stream closed */ }
             }
           : undefined;
@@ -230,6 +251,11 @@ export async function POST(request) {
         // killed mid-flight — leaving /x/<hash> and /api/pdf/<hash> with no
         // cached design to render (the source of "downloaded PDF won't open").
         await putCached(key, { design });
+
+        // Record the screencast reel so cache hits can replay this exact run.
+        if (theatre && reelFrames.length) {
+          await recordReel(key, reelFrames);
+        }
       } catch (err) {
         console.error('[extract] failed', { url: targetUrl, ip, message: err?.message });
         controller.enqueue(ndjson({ type: 'error', error: err?.message || 'Extraction failed' }));

--- a/website/lib/reel.js
+++ b/website/lib/reel.js
@@ -1,0 +1,137 @@
+// Theatre reels — record the live screencast once, replay it forever.
+//
+// A fresh extraction is the only time a real browser runs. We capture its
+// frames into a "reel" and persist it to Blob keyed by the same URL hash the
+// design cache uses. Cached runs then REPLAY the reel (frames merged with the
+// token paint, timed) so /watch and /x/<hash> still look live without paying
+// for another browser.
+//
+// Storage is best-effort and degrades to no-op without a Blob token (local dev).
+
+import { frameEvent } from './theatre.js';
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_REEL_FRAMES = 150; // bound the stored payload size
+
+function hasBlob() {
+  return !!process.env.BLOB_READ_WRITE_TOKEN;
+}
+
+function reelPath(hash) {
+  return `theatre-reel/${hash}.json`;
+}
+
+/**
+ * Persist a reel of captured frames for a URL hash. Best-effort.
+ * @param {string} hash
+ * @param {Array<{seq:number,t:number,data:string,w?:number,h?:number}>} frames
+ */
+export async function recordReel(hash, frames) {
+  if (!hasBlob() || !Array.isArray(frames) || frames.length === 0) return;
+  try {
+    const { put } = await import('@vercel/blob');
+    const trimmed = capFrames(frames, MAX_REEL_FRAMES);
+    const payload = {
+      generatedAt: Date.now(),
+      durationMs: trimmed.length ? trimmed[trimmed.length - 1].t : 0,
+      frameCount: trimmed.length,
+      frames: trimmed,
+    };
+    await put(reelPath(hash), JSON.stringify(payload), {
+      access: 'public',
+      contentType: 'application/json',
+      addRandomSuffix: false,
+      allowOverwrite: true,
+    });
+  } catch (err) {
+    console.error('[reel] write failed', err?.message);
+  }
+}
+
+/**
+ * Load a reel's frames for a URL hash, or null if none / expired.
+ * @param {string} hash
+ * @returns {Promise<null|{frames:Array, durationMs:number}>}
+ */
+export async function loadReel(hash) {
+  if (!hasBlob() || !/^[a-f0-9]{64}$/.test(hash)) return null;
+  try {
+    const { list } = await import('@vercel/blob');
+    const path = reelPath(hash);
+    const result = await list({ prefix: path, limit: 1 });
+    const blob = result.blobs?.find((b) => b.pathname === path);
+    if (!blob) return null;
+    const res = await fetch(blob.url, { cache: 'no-store' });
+    if (!res.ok) return null;
+    const payload = await res.json();
+    if (Date.now() - (payload?.generatedAt || 0) > TTL_MS) return null;
+    if (!Array.isArray(payload?.frames) || payload.frames.length === 0) return null;
+    return { frames: payload.frames, durationMs: payload.durationMs || 0 };
+  } catch (err) {
+    console.error('[reel] read failed', err?.message);
+    return null;
+  }
+}
+
+// Evenly subsample frames down to a cap, always keeping the first and last so
+// the reel still spans the full load.
+export function capFrames(frames, cap) {
+  if (frames.length <= cap) return frames;
+  const step = frames.length / cap;
+  const out = [];
+  for (let i = 0; i < cap; i++) out.push(frames[Math.floor(i * step)]);
+  out[out.length - 1] = frames[frames.length - 1];
+  return out;
+}
+
+/**
+ * Merge captured frames with the token paint into a single, sorted, delay-
+ * annotated timeline a replayer can stream. Pure — no Blob, no clock.
+ *
+ * Frames keep their real `t`. Stages land in the first third, tokens spread
+ * across most of the span so the system rail fills while the browser plays.
+ * The whole thing is optionally compressed to `maxDurationMs` so a cached hit
+ * doesn't tie the function up for the full original capture length.
+ *
+ * @returns {{steps:Array<{delayMs:number,event:object}>, durationMs:number}}
+ */
+export function buildReplayTimeline({
+  frames = [],
+  tokens = [],
+  stages = [],
+  summary,
+  files,
+  maxDurationMs = 12_000,
+} = {}) {
+  const rawSpan = frames.length
+    ? Math.max(...frames.map((f) => f.t || 0))
+    : Math.max(tokens.length * 40, 1);
+  const factor = rawSpan > maxDurationMs ? maxDurationMs / rawSpan : 1;
+  const at = (t) => Math.round(t * factor);
+
+  const timed = [];
+  for (const f of frames) {
+    timed.push({ t: at(f.t || 0), event: frameEvent(f) });
+  }
+  stages.forEach((name, i) => {
+    const frac = stages.length > 1 ? i / (stages.length - 1) : 0;
+    timed.push({ t: Math.round(rawSpan * factor * 0.3 * frac), event: { type: 'stage', name } });
+  });
+  tokens.forEach((tok, i) => {
+    const frac = tokens.length > 1 ? i / (tokens.length - 1) : 0;
+    timed.push({ t: Math.round(rawSpan * factor * (0.15 + 0.8 * frac)), event: { type: 'token', ...tok } });
+  });
+
+  timed.sort((a, b) => a.t - b.t);
+
+  const steps = [];
+  let prev = 0;
+  for (const { t, event } of timed) {
+    steps.push({ delayMs: Math.max(0, t - prev), event });
+    prev = t;
+  }
+  if (summary !== undefined) steps.push({ delayMs: 30, event: { type: 'summary', summary } });
+  if (files !== undefined) steps.push({ delayMs: 30, event: { type: 'files', files } });
+
+  return { steps, durationMs: prev };
+}

--- a/website/lib/reel.test.js
+++ b/website/lib/reel.test.js
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { capFrames, buildReplayTimeline } from './reel.js';
+
+const mkFrames = (n, span) =>
+  Array.from({ length: n }, (_, i) => ({ seq: i, t: Math.round((i / (n - 1)) * span), data: `f${i}` }));
+
+test('capFrames keeps first and last and subsamples the middle', () => {
+  const frames = mkFrames(100, 10000);
+  const capped = capFrames(frames, 10);
+  assert.equal(capped.length, 10);
+  assert.equal(capped[0].seq, 0);
+  assert.equal(capped[capped.length - 1].seq, 99);
+});
+
+test('capFrames is a no-op under the cap', () => {
+  const frames = mkFrames(5, 1000);
+  assert.equal(capFrames(frames, 10), frames);
+});
+
+test('buildReplayTimeline sorts events by time and emits non-negative delays', () => {
+  const { steps } = buildReplayTimeline({
+    frames: mkFrames(5, 5000),
+    tokens: [{ category: 'color', path: 'color.primary', value: '#000', $type: 'color' }],
+    stages: ['crawl', 'colors'],
+  });
+  assert.ok(steps.length >= 6);
+  assert.ok(steps.every((s) => s.delayMs >= 0));
+  const frameSteps = steps.filter((s) => s.event.type === 'frame');
+  assert.equal(frameSteps.length, 5);
+});
+
+test('buildReplayTimeline compresses to maxDurationMs', () => {
+  const { durationMs } = buildReplayTimeline({
+    frames: mkFrames(20, 40_000),
+    maxDurationMs: 10_000,
+  });
+  assert.ok(durationMs <= 10_000, `expected <= 10000, got ${durationMs}`);
+});
+
+test('buildReplayTimeline appends summary and files at the end', () => {
+  const { steps } = buildReplayTimeline({
+    frames: mkFrames(3, 3000),
+    summary: { colors: 4 },
+    files: { 'a.json': '{}' },
+  });
+  const last = steps[steps.length - 1];
+  const penultimate = steps[steps.length - 2];
+  assert.equal(penultimate.event.type, 'summary');
+  assert.equal(last.event.type, 'files');
+});
+
+test('buildReplayTimeline tolerates an empty reel', () => {
+  const { steps, durationMs } = buildReplayTimeline({});
+  assert.deepEqual(steps, []);
+  assert.equal(durationMs, 0);
+});


### PR DESCRIPTION
PR3 of the 13.0.0 Extraction Theatre series.

- `website/lib/reel.js` — records the screencast frames captured on a fresh run to Blob (keyed by the same URL hash as the design cache), loads them back, and a pure `buildReplayTimeline()` that merges frames + token paint into a sorted, delay-annotated timeline (compressed to a max duration so a cache hit doesn't tie the function up).
- `/api/extract` now collects frames on fresh theatre runs and `recordReel()`s them; cached theatre runs `loadReel()` + replay so a cache hit still looks live. Falls back to the existing simulated paint when no reel exists.

Tests: 600/600 across root + website suites. New reel tests cover subsample, sort, compress, summary/files ordering, empty reel.