### PR TITLE
feat(theatre): Theatre UI — split stage + assembling system rail

### DIFF
--- a/website/app/components/theatre/BrowserStage.js
+++ b/website/app/components/theatre/BrowserStage.js
@@ -1,0 +1,57 @@
+'use client';
+
+// The left half of the stage: a faux browser chrome wrapping the live frame.
+// `frame.data` is a base64 JPEG straight off the CDP screencast, so it paints
+// with a plain data: URL — no canvas, no decode dance.
+
+export default function BrowserStage({ url, frame, status, cached, stageLabel }) {
+  const streaming = status === 'streaming';
+  const host = safeHost(url);
+
+  return (
+    <div className={`thtr-stage ${streaming ? 'is-live' : ''}`}>
+      <div className="thtr-chrome">
+        <span className="thtr-dot" />
+        <span className="thtr-dot" />
+        <span className="thtr-dot" />
+        <div className="thtr-omnibox">
+          <span className="thtr-omnibox-lock" aria-hidden>▲</span>
+          <span className="thtr-omnibox-host">{host || 'paste a url to begin'}</span>
+          {cached && <span className="thtr-omnibox-tag">replay</span>}
+        </div>
+      </div>
+
+      <div className="thtr-viewport">
+        {frame ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img className="thtr-frame" alt="" src={`data:image/jpeg;base64,${frame.data}`} />
+        ) : (
+          <div className="thtr-skeleton" aria-hidden>
+            <div className="thtr-skeleton-bar" style={{ width: '60%' }} />
+            <div className="thtr-skeleton-bar" style={{ width: '85%' }} />
+            <div className="thtr-skeleton-bar" style={{ width: '40%' }} />
+            <div className="thtr-skeleton-block" />
+          </div>
+        )}
+
+        {streaming && <div className="thtr-scan" aria-hidden />}
+
+        {streaming && stageLabel && (
+          <div className="thtr-readout">
+            <span className="thtr-readout-pulse" aria-hidden />
+            reading · {stageLabel}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function safeHost(url) {
+  if (!url) return '';
+  try {
+    return new URL(url.startsWith('http') ? url : `https://${url}`).hostname.replace(/^www\./, '');
+  } catch {
+    return '';
+  }
+}

--- a/website/app/components/theatre/StageTicker.js
+++ b/website/app/components/theatre/StageTicker.js
@@ -1,0 +1,39 @@
+'use client';
+
+// The pipeline read-out under the stage: every extraction phase, with the
+// current one lit and finished ones checked. Order matches /api/extract STAGES.
+
+const STAGES = [
+  ['crawl', 'walk DOM'],
+  ['colors', 'palette'],
+  ['typography', 'type'],
+  ['spacing', 'rhythm'],
+  ['shadows', 'shadows'],
+  ['borders', 'radii'],
+  ['components', 'components'],
+  ['regions', 'regions'],
+  ['a11y', 'contrast'],
+  ['score', 'score'],
+];
+
+export default function StageTicker({ stage, stagesSeen = [] }) {
+  const currentIdx = STAGES.findIndex(([key]) => key === stage);
+  return (
+    <ol className="thtr-ticker" aria-label="extraction pipeline">
+      {STAGES.map(([key, label], i) => {
+        const seen = stagesSeen.includes(key);
+        const active = key === stage;
+        const done = seen && !active && (currentIdx === -1 || i < currentIdx);
+        return (
+          <li
+            key={key}
+            className={`thtr-tick ${active ? 'is-active' : ''} ${done ? 'is-done' : ''}`}
+          >
+            <span className="thtr-tick-dot" aria-hidden />
+            {label}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/website/app/components/theatre/SystemRail.js
+++ b/website/app/components/theatre/SystemRail.js
@@ -1,0 +1,98 @@
+'use client';
+
+// The right half of the stage: the design system assembling itself from the
+// real token stream. Each swatch/specimen animates in (CSS, reduced-motion
+// safe) as its token lands — the "tokens flying off the page" payoff.
+
+export default function SystemRail({ swatches, fontSample, dimensions, summary }) {
+  return (
+    <div className="thtr-rail">
+      <Block label="palette" count={swatches.length}>
+        <div className="thtr-wells">
+          {swatches.length === 0 && <Empty>colours land here</Empty>}
+          {swatches.map((s) => (
+            <span
+              key={s.path}
+              className="thtr-well thtr-pop"
+              style={{ background: s.hex }}
+              title={`${s.path} · ${s.hex}`}
+            />
+          ))}
+        </div>
+      </Block>
+
+      <Block label="type">
+        {fontSample ? (
+          <div className="thtr-specimen thtr-pop" style={{ fontFamily: fontSample }}>
+            <span className="thtr-specimen-big">Ag</span>
+            <span className="thtr-specimen-name">{cleanFont(fontSample)}</span>
+          </div>
+        ) : (
+          <Empty>the typeface lands here</Empty>
+        )}
+      </Block>
+
+      <Block label="spacing" count={dimensions.length}>
+        {dimensions.length ? (
+          <div className="thtr-scale">
+            {dimensions.slice(0, 8).map((d) => (
+              <span
+                key={d.path}
+                className="thtr-scale-bar thtr-pop"
+                style={{ height: `${Math.max(4, Math.min(48, d.px))}px` }}
+                title={`${d.path} · ${d.raw}`}
+              />
+            ))}
+          </div>
+        ) : (
+          <Empty>the rhythm lands here</Empty>
+        )}
+      </Block>
+
+      {summary && (
+        <div className="thtr-summary thtr-pop">
+          {summaryStats(summary).map((s) => (
+            <span key={s.label} className="thtr-stat">
+              <strong>{s.value}</strong> {s.label}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Block({ label, count, children }) {
+  return (
+    <section className="thtr-block">
+      <header className="thtr-block-head">
+        <span className="thtr-block-label">{label}</span>
+        {count != null && <span className="thtr-block-count">{count}</span>}
+      </header>
+      {children}
+    </section>
+  );
+}
+
+function Empty({ children }) {
+  return <p className="thtr-empty">{children}</p>;
+}
+
+function cleanFont(f) {
+  return String(f).split(',')[0].replace(/["']/g, '').trim();
+}
+
+// `summary` shape comes from buildSummary() — pull a few headline counts.
+function summaryStats(summary) {
+  const out = [];
+  const push = (value, label) => {
+    if (value != null && value !== 0) out.push({ value, label });
+  };
+  push(summary.colors, 'colours');
+  push(summary.componentCount, 'components');
+  push(summary.spacingCount, 'spaces');
+  const grade = summary.score?.grade;
+  if (grade) out.push({ value: grade, label: 'grade' });
+  else push(summary.cssVarCount, 'vars');
+  return out.slice(0, 4);
+}

--- a/website/app/components/theatre/Theatre.js
+++ b/website/app/components/theatre/Theatre.js
@@ -1,0 +1,178 @@
+'use client';
+
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
+import { theatreReducer, initialTheatreState } from '../../../lib/theatre-reducer.js';
+import BrowserStage from './BrowserStage.js';
+import SystemRail from './SystemRail.js';
+import StageTicker from './StageTicker.js';
+
+const STAGE_LABEL = {
+  crawl: 'walking the DOM',
+  colors: 'resolving palette',
+  typography: 'reading type',
+  spacing: 'measuring rhythm',
+  shadows: 'catching shadows',
+  borders: 'tracing radii',
+  components: 'clustering components',
+  regions: 'naming regions',
+  a11y: 'auditing contrast',
+  score: 'scoring system',
+};
+
+const SUGGESTIONS = ['stripe.com', 'linear.app', 'vercel.com', 'notion.so', 'figma.com'];
+
+export default function Theatre({ autoStart = null, compact = false }) {
+  const [state, dispatch] = useReducer(theatreReducer, initialTheatreState);
+  const [activeUrl, setActiveUrl] = useState(autoStart || '');
+  const [rateLimitMsg, setRateLimitMsg] = useState(null);
+  const inputRef = useRef(null);
+  const runningRef = useRef(false);
+
+  const run = useCallback(async (rawUrl) => {
+    const url = (rawUrl || '').trim();
+    if (!url || runningRef.current) return;
+    runningRef.current = true;
+    setRateLimitMsg(null);
+    setActiveUrl(url.startsWith('http') ? url : `https://${url}`);
+    dispatch({ type: 'start' });
+
+    let res;
+    try {
+      res = await fetch('/api/extract?theatre=1', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url, theatre: true }),
+      });
+    } catch {
+      dispatch({ type: 'error', error: 'Network error — check your connection.' });
+      runningRef.current = false;
+      return;
+    }
+
+    if (!res.ok) {
+      let body = null;
+      try { body = await res.json(); } catch {}
+      if (res.status === 429) setRateLimitMsg(body?.error || 'Free demo limit reached. Use the CLI for unlimited.');
+      dispatch({ type: 'error', error: body?.error || 'Could not read that site. Try another URL.' });
+      runningRef.current = false;
+      return;
+    }
+    if (!res.body) {
+      dispatch({ type: 'error', error: 'Your browser does not support streaming.' });
+      runningRef.current = false;
+      return;
+    }
+
+    const reader = res.body.pipeThrough(new TextDecoderStream()).getReader();
+    let buffer = '';
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += value;
+        let nl;
+        while ((nl = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, nl).trim();
+          buffer = buffer.slice(nl + 1);
+          if (line) {
+            try { dispatch(JSON.parse(line)); } catch { /* partial line */ }
+          }
+        }
+      }
+      if (buffer.trim()) {
+        try { dispatch(JSON.parse(buffer.trim())); } catch {}
+      }
+    } catch {
+      dispatch({ type: 'error', error: 'Stream interrupted. Try another URL.' });
+    } finally {
+      runningRef.current = false;
+    }
+  }, []);
+
+  // Autoplay a flagship reel on mount (homepage hero).
+  useEffect(() => {
+    if (autoStart) run(autoStart);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoStart]);
+
+  const onSubmit = useCallback((e) => {
+    e.preventDefault();
+    run(inputRef.current?.value || '');
+  }, [run]);
+
+  const streaming = state.status === 'streaming';
+  const stageLabel = state.stage ? STAGE_LABEL[state.stage] || state.stage : null;
+
+  return (
+    <div className={`thtr ${compact ? 'is-compact' : ''}`}>
+      <form className="thtr-form" onSubmit={onSubmit}>
+        <span className="thtr-form-prefix">https://</span>
+        <input
+          ref={inputRef}
+          className="thtr-form-input"
+          type="text"
+          inputMode="url"
+          placeholder="any-website.com"
+          aria-label="Website URL to read"
+          defaultValue=""
+          disabled={streaming}
+        />
+        <button className="thtr-form-go" type="submit" disabled={streaming}>
+          {streaming ? 'reading…' : 'watch it read'}
+        </button>
+      </form>
+
+      <div className="thtr-suggest">
+        {SUGGESTIONS.map((h) => (
+          <button key={h} type="button" className="thtr-chip" disabled={streaming} onClick={() => run(h)}>
+            {h}
+          </button>
+        ))}
+      </div>
+
+      {rateLimitMsg && <p className="thtr-note">{rateLimitMsg}</p>}
+      {state.status === 'error' && !rateLimitMsg && <p className="thtr-note">{state.error}</p>}
+
+      <div className="thtr-split">
+        <BrowserStage
+          url={activeUrl}
+          frame={state.frame}
+          status={state.status}
+          cached={state.cached}
+          stageLabel={stageLabel}
+        />
+        <SystemRail
+          swatches={state.swatches}
+          fontSample={state.fontSample}
+          dimensions={state.dimensions}
+          summary={state.summary}
+        />
+      </div>
+
+      <StageTicker stage={state.stage} stagesSeen={state.stagesSeen} />
+
+      {state.status === 'done' && state.hash && (
+        <div className="thtr-actions">
+          <a className="thtr-action" href={`/x/${state.hash}`}>open the full brand book →</a>
+          <ShareLink hash={state.hash} url={activeUrl} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ShareLink({ hash, url }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = useCallback(() => {
+    const link = `${window.location.origin}/x/${hash}`;
+    navigator.clipboard?.writeText(link).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    });
+  }, [hash]);
+  return (
+    <button type="button" className="thtr-action thtr-action-ghost" onClick={onCopy}>
+      {copied ? 'link copied ✓' : 'copy share link'}
+    </button>
+  );
+}

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -1758,3 +1758,97 @@ table.cmp tr:hover td { background: rgba(255,255,255,0.02); }
 .prose pre { background: rgba(0,0,0,0.5); border: 1px solid var(--hairline); padding: 16px; border-radius: 10px; overflow-x: auto; color: var(--fg); }
 .prose a { color: var(--red-3); border-bottom: 1px solid rgba(255,128,128,0.3); }
 .prose a:hover { color: #fff; border-bottom-color: rgba(255,255,255,0.5); }
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Extraction Theatre — watch the real browser read a site, live.
+   Split stage: live browser (left) + design system assembling (right).
+   ───────────────────────────────────────────────────────────────────────── */
+.thtr { width: 100%; max-width: 1100px; margin: 0 auto; }
+
+.thtr-form {
+  display: flex; align-items: stretch; gap: 0;
+  border: 1px solid var(--hairline-2); border-radius: var(--radius);
+  background: var(--surface-2); overflow: hidden; max-width: 640px;
+}
+.thtr-form:focus-within { border-color: var(--red-glow); box-shadow: 0 0 0 4px rgba(239,68,68,0.12); }
+.thtr-form-prefix { display: flex; align-items: center; padding: 0 6px 0 16px; color: var(--fg-3); font: 13px/1 var(--ff-mono); }
+.thtr-form-input { flex: 1 1 auto; min-width: 0; border: 0; background: transparent; color: var(--fg); font: 16px/1 var(--ff-mono); padding: 15px 12px; outline: none; }
+.thtr-form-input::placeholder { color: var(--fg-3); }
+.thtr-form-go { border: 0; cursor: pointer; padding: 0 20px; font: 600 14px/1 var(--ff-sans); color: #fff; background: var(--grad-cta); background-size: 200% 100%; transition: background-position .3s; }
+.thtr-form-go:hover:not(:disabled) { background-position: 100% 0; }
+.thtr-form-go:disabled { opacity: .6; cursor: default; }
+
+.thtr-suggest { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 12px; }
+.thtr-chip { border: 1px solid var(--hairline); background: transparent; color: var(--fg-2); font: 12px/1 var(--ff-mono); padding: 6px 10px; border-radius: 999px; cursor: pointer; transition: border-color .2s, color .2s; }
+.thtr-chip:hover:not(:disabled) { border-color: var(--red-glow); color: var(--fg); }
+.thtr-chip:disabled { opacity: .5; cursor: default; }
+.thtr-note { margin-top: 12px; color: var(--red-3); font: 13px/1.5 var(--ff-mono); }
+
+.thtr-split { display: grid; grid-template-columns: 1.85fr 1fr; gap: 16px; margin-top: 20px; align-items: stretch; }
+@media (max-width: 760px) { .thtr-split { grid-template-columns: 1fr; } }
+
+/* ── Browser stage ── */
+.thtr-stage { border: 1px solid var(--hairline-2); border-radius: var(--radius); overflow: hidden; background: #000; box-shadow: 0 24px 60px -30px rgba(0,0,0,0.8); }
+.thtr-stage.is-live { border-color: var(--red-glow); }
+.thtr-chrome { display: flex; align-items: center; gap: 8px; padding: 10px 12px; background: var(--bg-2); border-bottom: 1px solid var(--hairline); }
+.thtr-dot { width: 10px; height: 10px; border-radius: 999px; background: var(--hairline-2); }
+.thtr-dot:nth-child(1) { background: #ff5f57; } .thtr-dot:nth-child(2) { background: #febc2e; } .thtr-dot:nth-child(3) { background: #28c840; }
+.thtr-omnibox { flex: 1 1 auto; display: flex; align-items: center; gap: 8px; margin-left: 6px; padding: 6px 12px; background: rgba(0,0,0,0.4); border: 1px solid var(--hairline); border-radius: 999px; min-width: 0; }
+.thtr-omnibox-lock { color: var(--fg-3); font-size: 9px; }
+.thtr-omnibox-host { color: var(--fg-2); font: 12px/1 var(--ff-mono); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.thtr-omnibox-tag { margin-left: auto; color: var(--red-3); font: 10px/1 var(--ff-mono); border: 1px solid var(--red-glow); padding: 3px 7px; border-radius: 999px; }
+.thtr-viewport { position: relative; aspect-ratio: 11 / 7; background: #0a0a0a; overflow: hidden; }
+.thtr-frame { width: 100%; height: 100%; object-fit: cover; object-position: top center; display: block; }
+
+.thtr-skeleton { position: absolute; inset: 0; padding: 28px; display: flex; flex-direction: column; gap: 14px; }
+.thtr-skeleton-bar { height: 12px; border-radius: 6px; background: linear-gradient(90deg, rgba(255,255,255,0.04), rgba(255,255,255,0.10), rgba(255,255,255,0.04)); background-size: 200% 100%; animation: thtrShimmer 1.4s linear infinite; }
+.thtr-skeleton-block { flex: 1; border-radius: 10px; background: rgba(255,255,255,0.03); margin-top: 8px; }
+@keyframes thtrShimmer { to { background-position: -200% 0; } }
+
+.thtr-scan { position: absolute; left: 0; right: 0; height: 28%; top: -28%; background: linear-gradient(180deg, transparent, rgba(239,68,68,0.18), rgba(255,128,128,0.45), rgba(239,68,68,0.18), transparent); animation: thtrScan 2.4s cubic-bezier(.4,0,.2,1) infinite; pointer-events: none; }
+@keyframes thtrScan { 0% { top: -28%; } 100% { top: 100%; } }
+.thtr-readout { position: absolute; left: 12px; bottom: 12px; display: flex; align-items: center; gap: 8px; padding: 6px 12px; background: rgba(0,0,0,0.66); border: 1px solid var(--hairline-2); border-radius: 999px; color: var(--fg); font: 12px/1 var(--ff-mono); backdrop-filter: blur(6px); }
+.thtr-readout-pulse { width: 8px; height: 8px; border-radius: 999px; background: var(--red-2); animation: thtrPulse 1.1s ease-in-out infinite; }
+@keyframes thtrPulse { 0%,100% { opacity: 1; box-shadow: 0 0 0 0 var(--red-glow); } 50% { opacity: .5; box-shadow: 0 0 0 5px transparent; } }
+
+/* ── System rail ── */
+.thtr-rail { display: flex; flex-direction: column; gap: 12px; }
+.thtr-block { border: 1px solid var(--hairline); border-radius: var(--radius); padding: 12px 14px; background: var(--surface); }
+.thtr-block-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 10px; }
+.thtr-block-label { color: var(--fg-3); font: 11px/1 var(--ff-mono); text-transform: uppercase; letter-spacing: .08em; }
+.thtr-block-count { color: var(--fg-2); font: 12px/1 var(--ff-mono); }
+.thtr-empty { color: var(--fg-3); font: 12px/1.4 var(--ff-mono); margin: 0; }
+.thtr-wells { display: flex; flex-wrap: wrap; gap: 5px; }
+.thtr-well { width: 24px; height: 24px; border-radius: 6px; border: 1px solid rgba(255,255,255,0.12); }
+.thtr-specimen { display: flex; align-items: baseline; gap: 12px; }
+.thtr-specimen-big { font-size: 38px; line-height: 1; color: var(--fg); }
+.thtr-specimen-name { color: var(--fg-2); font: 12px/1 var(--ff-mono); }
+.thtr-scale { display: flex; align-items: flex-end; gap: 5px; height: 52px; }
+.thtr-scale-bar { width: 12px; border-radius: 3px 3px 0 0; background: linear-gradient(180deg, var(--red-3), var(--red-1)); }
+.thtr-summary { display: flex; flex-wrap: wrap; gap: 14px; padding: 12px 14px; border: 1px dashed var(--hairline-2); border-radius: var(--radius); }
+.thtr-stat { color: var(--fg-2); font: 12px/1 var(--ff-mono); }
+.thtr-stat strong { color: var(--fg); font-size: 16px; }
+
+.thtr-pop { animation: thtrPop .32s cubic-bezier(.34,1.56,.64,1) both; }
+@keyframes thtrPop { from { opacity: 0; transform: scale(.6) translateY(6px); } to { opacity: 1; transform: none; } }
+
+/* ── Pipeline ticker ── */
+.thtr-ticker { display: flex; flex-wrap: wrap; gap: 6px 14px; list-style: none; margin: 18px 0 0; padding: 0; }
+.thtr-tick { display: flex; align-items: center; gap: 6px; color: var(--fg-3); font: 11px/1 var(--ff-mono); }
+.thtr-tick-dot { width: 6px; height: 6px; border-radius: 999px; background: var(--hairline-2); }
+.thtr-tick.is-done { color: var(--fg-2); } .thtr-tick.is-done .thtr-tick-dot { background: #28c840; }
+.thtr-tick.is-active { color: var(--fg); } .thtr-tick.is-active .thtr-tick-dot { background: var(--red-2); animation: thtrPulse 1.1s ease-in-out infinite; }
+
+/* ── Done actions ── */
+.thtr-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 18px; }
+.thtr-action { font: 600 13px/1 var(--ff-sans); color: #fff; background: var(--grad-cta); padding: 11px 16px; border-radius: 10px; text-decoration: none; border: 0; cursor: pointer; }
+.thtr-action-ghost { background: transparent; color: var(--fg-2); border: 1px solid var(--hairline-2); }
+.thtr-action-ghost:hover { color: var(--fg); border-color: var(--red-glow); }
+
+.thtr.is-compact .thtr-viewport { aspect-ratio: 16 / 9; }
+
+@media (prefers-reduced-motion: reduce) {
+  .thtr-scan, .thtr-skeleton-bar, .thtr-readout-pulse, .thtr-tick.is-active .thtr-tick-dot { animation: none; }
+  .thtr-pop { animation: none; }
+  .thtr-scan { display: none; }
+}

--- a/website/lib/theatre-reducer.js
+++ b/website/lib/theatre-reducer.js
@@ -1,0 +1,102 @@
+// Pure reducer behind the Extraction Theatre UI.
+//
+// The component is a thin `useReducer` shell over this — keeping all the event
+// folding here means the tricky parts (out-of-order frames, dropped frames, a
+// terminal error mid-stream) are testable without React or a browser.
+
+export const MAX_SWATCHES = 28;
+export const MAX_DIMENSIONS = 12;
+
+export const initialTheatreState = {
+  status: 'idle', // idle | streaming | done | error
+  cached: false,
+  hash: null,
+  stage: null,
+  stagesSeen: [],
+  frame: null, // { seq, data, w, h } — latest painted frame
+  frameCount: 0, // frames received (for the progress read-out)
+  swatches: [], // { path, hex }
+  fontSample: null,
+  dimensions: [], // { path, px, raw }
+  summary: null,
+  files: null,
+  error: null,
+};
+
+export function theatreReducer(state, action) {
+  switch (action.type) {
+    case 'start':
+      // Fresh run — clear everything but stay mounted.
+      return { ...initialTheatreState, status: 'streaming' };
+
+    case 'cache':
+      return { ...state, cached: true };
+
+    case 'permalink':
+      return action.hash ? { ...state, hash: action.hash } : state;
+
+    case 'stage':
+      return {
+        ...state,
+        stage: action.name,
+        stagesSeen: state.stagesSeen.includes(action.name)
+          ? state.stagesSeen
+          : [...state.stagesSeen, action.name],
+      };
+
+    case 'frame': {
+      // Only advance the displayed frame forward — a late/out-of-order frame
+      // never rewinds the picture. Still count it so the read-out is honest.
+      const prevSeq = state.frame ? state.frame.seq : -1;
+      const isNewer = action.seq == null || action.seq >= prevSeq;
+      return {
+        ...state,
+        frame: isNewer
+          ? { seq: action.seq ?? prevSeq + 1, data: action.data, w: action.w, h: action.h }
+          : state.frame,
+        frameCount: state.frameCount + 1,
+      };
+    }
+
+    case 'token':
+      return foldToken(state, action);
+
+    case 'summary':
+      return { ...state, summary: action.summary };
+
+    case 'files':
+      return { ...state, files: action.files, status: 'done' };
+
+    case 'error':
+      return { ...state, error: action.error || 'Extraction failed', status: 'error' };
+
+    default:
+      return state;
+  }
+}
+
+function foldToken(state, action) {
+  const { $type, value, path } = action;
+  if ($type === 'color' && typeof value === 'string' && value.startsWith('#')) {
+    if (state.swatches.length >= MAX_SWATCHES) return state;
+    if (state.swatches.some((s) => s.path === path)) return state;
+    return { ...state, swatches: [...state.swatches, { path, hex: value }] };
+  }
+  if ($type === 'fontFamily' && typeof value === 'string' && !state.fontSample) {
+    return { ...state, fontSample: value };
+  }
+  if ($type === 'dimension' && typeof value === 'string') {
+    const px = parseFloat(value);
+    if (Number.isNaN(px) || state.dimensions.length >= MAX_DIMENSIONS) return state;
+    return { ...state, dimensions: [...state.dimensions, { path, px, raw: value }] };
+  }
+  return state;
+}
+
+/**
+ * Reduce a whole event list in order — handy for tests and for replaying a
+ * buffered timeline. `events` are raw NDJSON objects ({type, ...}).
+ */
+export function reduceEvents(events, from = initialTheatreState) {
+  return events.reduce((s, ev) => theatreReducer(s, ev), from);
+}

--- a/website/lib/theatre-reducer.test.js
+++ b/website/lib/theatre-reducer.test.js
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  theatreReducer,
+  reduceEvents,
+  initialTheatreState,
+  MAX_SWATCHES,
+} from './theatre-reducer.js';
+
+test('start resets state and marks streaming', () => {
+  const dirty = { ...initialTheatreState, swatches: [{ path: 'a', hex: '#fff' }], status: 'done' };
+  const s = theatreReducer(dirty, { type: 'start' });
+  assert.equal(s.status, 'streaming');
+  assert.deepEqual(s.swatches, []);
+});
+
+test('frames only advance forward but every frame is counted', () => {
+  let s = reduceEvents([
+    { type: 'frame', seq: 0, data: 'a' },
+    { type: 'frame', seq: 2, data: 'c' },
+    { type: 'frame', seq: 1, data: 'b' }, // out of order — ignored for display
+  ]);
+  assert.equal(s.frame.seq, 2);
+  assert.equal(s.frame.data, 'c');
+  assert.equal(s.frameCount, 3);
+});
+
+test('a missing seq frame still paints', () => {
+  const s = reduceEvents([{ type: 'frame', data: 'x' }]);
+  assert.equal(s.frame.data, 'x');
+  assert.equal(s.frameCount, 1);
+});
+
+test('color tokens dedupe by path and cap', () => {
+  const events = [];
+  for (let i = 0; i < MAX_SWATCHES + 10; i++) {
+    events.push({ type: 'token', $type: 'color', value: `#0000${(i % 90) + 10}`, path: `c${i}` });
+  }
+  events.push({ type: 'token', $type: 'color', value: '#abcabc', path: 'c0' }); // dup path
+  const s = reduceEvents(events);
+  assert.equal(s.swatches.length, MAX_SWATCHES);
+});
+
+test('font + dimension tokens fold', () => {
+  const s = reduceEvents([
+    { type: 'token', $type: 'fontFamily', value: 'Inter' },
+    { type: 'token', $type: 'fontFamily', value: 'Other' }, // first wins
+    { type: 'token', $type: 'dimension', value: '16px', path: 'space.4' },
+    { type: 'token', $type: 'dimension', value: 'not-a-number', path: 'space.x' },
+  ]);
+  assert.equal(s.fontSample, 'Inter');
+  assert.equal(s.dimensions.length, 1);
+  assert.equal(s.dimensions[0].px, 16);
+});
+
+test('stages are tracked uniquely and in order', () => {
+  const s = reduceEvents([
+    { type: 'stage', name: 'crawl' },
+    { type: 'stage', name: 'colors' },
+    { type: 'stage', name: 'crawl' },
+  ]);
+  assert.deepEqual(s.stagesSeen, ['crawl', 'colors']);
+  assert.equal(s.stage, 'crawl');
+});
+
+test('files marks done; a later error after files still flips to error', () => {
+  const done = reduceEvents([{ type: 'files', files: { 'a.json': '{}' } }]);
+  assert.equal(done.status, 'done');
+  const err = theatreReducer(done, { type: 'error', error: 'boom' });
+  assert.equal(err.status, 'error');
+  assert.equal(err.error, 'boom');
+});
+
+test('cache + permalink fold', () => {
+  const s = reduceEvents([
+    { type: 'cache', cached: true },
+    { type: 'permalink', hash: 'deadbeef' },
+  ]);
+  assert.equal(s.cached, true);
+  assert.equal(s.hash, 'deadbeef');
+});


### PR DESCRIPTION
PR4 of the 13.0.0 Extraction Theatre series — the visible part.

- **Pure reducer** (`website/lib/theatre-reducer.js`) folds the NDJSON event stream into UI state: frames are forward-only (late/dropped frames never rewind the picture), tokens dedupe + cap, terminal `files`/`error` states. 8 unit tests.
- **Components** (`app/components/theatre/`): `BrowserStage` (faux browser chrome + live JPEG frame + scan glow), `SystemRail` (palette / type / spacing assembling from real tokens, pop-in animated), `StageTicker` (pipeline read-out), `Theatre` (stream reader over the reducer, autoplay-on-mount, share link).
- **Styling**: split-stage CSS in `globals.css`, `prefers-reduced-motion` safe (scan line + pop-ins disabled).

Logic verified by unit tests (19/19 across theatre libs). JSX render verified by the Vercel PR preview build.