### PR TITLE
feat(theatre): homepage hero becomes the live Theatre

### DIFF
--- a/website/app/api/extract/route.js
+++ b/website/app/api/extract/route.js
@@ -151,10 +151,25 @@ export async function POST(request) {
 
   const ip = extractIp(request);
   const theatre = wantsTheatre(body, request.url);
+  // Autoplay: replay a recorded reel if one exists, but NEVER launch a browser.
+  // Keeps the homepage hero free to loop without burning compute per visitor.
+  const replayOnly = body?.replayOnly === true;
 
   // Cache hit serves free — no rate-limit accounting, repeats cost nothing.
   const key = cacheKey(targetUrl);
   const cached = await getCached(key);
+
+  if (!cached && replayOnly) {
+    const idle = new ReadableStream({
+      start(controller) {
+        controller.enqueue(ndjson({ type: 'idle' }));
+        controller.close();
+      },
+    });
+    return new Response(idle, {
+      headers: { 'content-type': 'application/x-ndjson; charset=utf-8', 'cache-control': 'no-store' },
+    });
+  }
 
   if (!cached) {
     // First-line per-instance memory guard (cheap, blunts hammering within an instance).

--- a/website/app/components/theatre/Theatre.js
+++ b/website/app/components/theatre/Theatre.js
@@ -28,7 +28,7 @@ export default function Theatre({ autoStart = null, compact = false }) {
   const inputRef = useRef(null);
   const runningRef = useRef(false);
 
-  const run = useCallback(async (rawUrl) => {
+  const run = useCallback(async (rawUrl, { replayOnly = false } = {}) => {
     const url = (rawUrl || '').trim();
     if (!url || runningRef.current) return;
     runningRef.current = true;
@@ -41,7 +41,7 @@ export default function Theatre({ autoStart = null, compact = false }) {
       res = await fetch('/api/extract?theatre=1', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ url, theatre: true }),
+        body: JSON.stringify({ url, theatre: true, replayOnly }),
       });
     } catch {
       dispatch({ type: 'error', error: 'Network error — check your connection.' });
@@ -89,9 +89,10 @@ export default function Theatre({ autoStart = null, compact = false }) {
     }
   }, []);
 
-  // Autoplay a flagship reel on mount (homepage hero).
+  // Autoplay a flagship reel on mount (homepage hero) — replay-only, so it
+  // never launches a browser; if no reel exists yet it just stays idle.
   useEffect(() => {
-    if (autoStart) run(autoStart);
+    if (autoStart) run(autoStart, { replayOnly: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoStart]);
 

--- a/website/app/page.js
+++ b/website/app/page.js
@@ -1,4 +1,4 @@
-import HeroExtractor from './components/HeroExtractor';
+import Theatre from './components/theatre/Theatre';
 import Grainient from './components/Grainient';
 import RedditMarquee from './components/RedditMarquee';
 import CopyCmd from './components/CopyCmd';
@@ -82,7 +82,7 @@ function Hero() {
               WordPress, plus a stdio MCP for Claude Code and Cursor — back in seconds.
             </p>
             <div className="hero-cta">
-              <a href="#extract" className="btn btn-primary">Run extraction</a>
+              <a href="#extract" className="btn btn-primary">Watch it read a site</a>
               <a href="https://github.com/Manavarya09/design-extract" className="btn btn-ghost" target="_blank" rel="noreferrer">View source</a>
             </div>
             <div style={{ marginTop: 26 }}>
@@ -120,11 +120,11 @@ function ExtractSection() {
       <div className="wrap dx-section-wrap">
         <header className="dx-section-head">
           <p className="eyebrow" style={{ marginBottom: 14 }}>try it now</p>
-          <h2 className="dx-section-title">See it work.</h2>
-          <p className="dx-section-tag">Paste a URL. Watch the system land.</p>
+          <h2 className="dx-section-title">Watch it read a site.</h2>
+          <p className="dx-section-tag">Paste a URL. The real browser opens and reads the design system, live.</p>
         </header>
         <div className="dx-stage">
-          <HeroExtractor />
+          <Theatre autoStart="stripe.com" />
         </div>
       </div>
     </section>

--- a/website/lib/theatre-reducer.js
+++ b/website/lib/theatre-reducer.js
@@ -29,6 +29,10 @@ export function theatreReducer(state, action) {
       // Fresh run — clear everything but stay mounted.
       return { ...initialTheatreState, status: 'streaming' };
 
+    case 'idle':
+      // Autoplay found no recorded reel — settle back to idle, not stuck loading.
+      return { ...state, status: 'idle' };
+
     case 'cache':
       return { ...state, cached: true };
 

--- a/website/lib/theatre-reducer.test.js
+++ b/website/lib/theatre-reducer.test.js
@@ -71,6 +71,13 @@ test('files marks done; a later error after files still flips to error', () => {
   assert.equal(err.error, 'boom');
 });
 
+test('idle settles a started run back to idle', () => {
+  const started = theatreReducer(initialTheatreState, { type: 'start' });
+  assert.equal(started.status, 'streaming');
+  const idle = theatreReducer(started, { type: 'idle' });
+  assert.equal(idle.status, 'idle');
+});
+
 test('cache + permalink fold', () => {
   const s = reduceEvents([
     { type: 'cache', cached: true },


### PR DESCRIPTION
PR5 of the 13.0.0 Extraction Theatre series.

- The "try it now" section is now the live **Theatre** (`<Theatre autoStart="stripe.com" />`) instead of the old token-only `HeroExtractor`.
- **Autoplay is cost-safe**: a new `replayOnly` flag on `/api/extract` replays a recorded reel if one exists but **never launches a browser**; if no reel exists yet it streams `{type:'idle'}` and the stage settles to idle. The reducer handles `idle`.
- Top hero CTA copy updated to "Watch it read a site".

`HeroExtractor` is now unused (import removed); left in place rather than deleted.

Tests: reducer suite 9/9 (added an `idle` case test); route syntax-checked.