### PR TITLE
feat(watch): /watch page + share/OG + permalink hook

### DIFF
--- a/website/app/components/theatre/Theatre.js
+++ b/website/app/components/theatre/Theatre.js
@@ -21,7 +21,7 @@ const STAGE_LABEL = {
 
 const SUGGESTIONS = ['stripe.com', 'linear.app', 'vercel.com', 'notion.so', 'figma.com'];
 
-export default function Theatre({ autoStart = null, compact = false }) {
+export default function Theatre({ autoStart = null, live = false, compact = false }) {
   const [state, dispatch] = useReducer(theatreReducer, initialTheatreState);
   const [activeUrl, setActiveUrl] = useState(autoStart || '');
   const [rateLimitMsg, setRateLimitMsg] = useState(null);
@@ -89,12 +89,12 @@ export default function Theatre({ autoStart = null, compact = false }) {
     }
   }, []);
 
-  // Autoplay a flagship reel on mount (homepage hero) — replay-only, so it
-  // never launches a browser; if no reel exists yet it just stays idle.
+  // Autoplay on mount. The homepage hero is replay-only (never launches a
+  // browser); /watch passes `live` so a shared ?u= link runs a real extraction.
   useEffect(() => {
-    if (autoStart) run(autoStart, { replayOnly: true });
+    if (autoStart) run(autoStart, { replayOnly: !live });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoStart]);
+  }, [autoStart, live]);
 
   const onSubmit = useCallback((e) => {
     e.preventDefault();

--- a/website/app/layout.js
+++ b/website/app/layout.js
@@ -110,6 +110,7 @@ async function Nav() {
         </a>
 
         <nav className="nav-pillnav" aria-label="primary">
+          <a href="/watch"><span>Watch</span></a>
           <a href="/features"><span>Features</span></a>
           <a href="/gallery"><span>Gallery</span></a>
           <a href="/studio"><span>Studio</span></a>
@@ -165,6 +166,7 @@ function Footer() {
         <div className="ftr-cols">
           <div className="ftr-col">
             <span className="ftr-title">Product</span>
+            <a href="/watch">Watch it read</a>
             <a href="/features">Features</a>
             <a href="/gallery">Gallery</a>
             <a href="/spec">DESIGN.md spec</a>

--- a/website/app/watch/opengraph-image.js
+++ b/website/app/watch/opengraph-image.js
@@ -1,0 +1,62 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'nodejs';
+export const alt = 'designlang — watch a real browser read any website’s design system, live.';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+const BG = '#050505';
+const FG = '#ffffff';
+const FG2 = 'rgba(255,255,255,0.62)';
+const RED = '#ff5757';
+const SWATCHES = ['#635BFF', '#ff5757', '#1ed760', '#0071e3', '#d97757'];
+
+export default function WatchOg() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          background: BG,
+          color: FG,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: 64,
+          fontFamily: 'Georgia, serif',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            fontFamily: 'ui-monospace, Menlo, monospace',
+            fontSize: 18,
+            color: FG2,
+            letterSpacing: 2,
+          }}
+        >
+          <span>designlang · watch</span>
+          <span>● live</span>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+          <div style={{ fontSize: 76, lineHeight: 1.02, fontWeight: 600, maxWidth: 900 }}>
+            Watch the browser <span style={{ color: RED }}>read</span> a site.
+          </div>
+          <div style={{ fontSize: 28, color: FG2, fontFamily: 'ui-monospace, Menlo, monospace' }}>
+            real Chromium · palette · type · spacing · motion → a design system, live
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 12 }}>
+          {SWATCHES.map((c) => (
+            <div key={c} style={{ width: 96, height: 40, borderRadius: 8, background: c }} />
+          ))}
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/website/app/watch/page.js
+++ b/website/app/watch/page.js
@@ -1,0 +1,56 @@
+import { SITE_URL } from '../seo-config';
+import Theatre from '../components/theatre/Theatre';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Watch — see designlang read a website, live',
+  description:
+    'Paste any URL and watch a real headless browser open the page and read its whole design system in real time — palette, type, spacing and motion lifting off the page into a design system as it goes. Share the result; the link unfurls the number.',
+  alternates: { canonical: `${SITE_URL}/watch` },
+  openGraph: {
+    title: 'designlang · watch it read a site',
+    description: 'A real browser opens any URL and reads its design system, live. Then share it.',
+    url: `${SITE_URL}/watch`,
+  },
+};
+
+export default async function WatchPage({ searchParams }) {
+  const sp = (await searchParams) || {};
+  const raw = typeof sp.u === 'string' ? sp.u : '';
+  const initial = sanitize(raw);
+
+  return (
+    <main>
+      <section className="section" style={{ paddingTop: 72, paddingBottom: 24 }}>
+        <div className="wrap">
+          <p className="eyebrow">watch · live</p>
+          <h1 className="h1" style={{ fontSize: 'clamp(38px, 6vw, 68px)', maxWidth: '16ch' }}>
+            Watch the browser <em style={{ fontStyle: 'normal', color: 'var(--red-3)' }}>read</em> a site.
+          </h1>
+          <p className="lede" style={{ marginTop: 18, maxWidth: '52ch' }}>
+            Real headless Chromium opens the page and reads its design system in real time. No
+            install, no account. Then share the result.
+          </p>
+        </div>
+      </section>
+
+      <section className="section" style={{ paddingTop: 8 }}>
+        <div className="wrap">
+          <Theatre autoStart={initial || null} live />
+        </div>
+      </section>
+    </main>
+  );
+}
+
+// Only let http(s) URLs through to autoplay; anything else falls back to idle.
+function sanitize(raw) {
+  if (!raw) return '';
+  try {
+    const u = new URL(raw.startsWith('http') ? raw : `https://${raw}`);
+    return u.protocol === 'http:' || u.protocol === 'https:' ? u.toString() : '';
+  } catch {
+    return '';
+  }
+}

--- a/website/app/x/[hash]/PermalinkViewer.js
+++ b/website/app/x/[hash]/PermalinkViewer.js
@@ -80,6 +80,9 @@ export default function PermalinkViewer({ hash, url, title, summary, files }) {
           >
             {shareCopied ? 'Link copied' : 'Copy permalink'}
           </button>
+          <a className="cta" href={`/watch?u=${encodeURIComponent(url)}`} style={{ background: 'transparent', color: 'var(--ink)', border: '1px solid var(--ink)', boxShadow: 'none', borderBottom: 'none' }}>
+            ▶ Watch it extract
+          </a>
           <a className="cta" href="/" style={{ background: 'transparent', color: 'var(--ink)', border: '1px solid var(--ink)', boxShadow: 'none', borderBottom: 'none' }}>
             Extract another →
           </a>


### PR DESCRIPTION
PR6 of the 13.0.0 Extraction Theatre series.

- **`/watch`** — full-bleed Theatre tuned for recording/sharing. Accepts `?u=<url>` (sanitized to http/https) and runs a real extraction on mount via the new Theatre `live` prop.
- **OG card** for `/watch` so shared links unfurl with the pitch.
- **Nav + footer** now surface "Watch".
- Permalink pages (`/x/<hash>`) get a **▶ Watch it extract** link into `/watch?u=`.

Tests: 609/609 across root + website suites. Page render verified by the Vercel PR preview.