### PR TITLE
fix(watch): OG image build error — explicit flex on headline

### DIFF
--- a/website/app/watch/opengraph-image.js
+++ b/website/app/watch/opengraph-image.js
@@ -42,8 +42,10 @@ export default function WatchOg() {
         </div>
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
-          <div style={{ fontSize: 76, lineHeight: 1.02, fontWeight: 600, maxWidth: 900 }}>
-            Watch the browser <span style={{ color: RED }}>read</span> a site.
+          <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'baseline', fontSize: 76, lineHeight: 1.02, fontWeight: 600, maxWidth: 900 }}>
+            <span>Watch the browser&nbsp;</span>
+            <span style={{ color: RED }}>read</span>
+            <span>&nbsp;a site.</span>
           </div>
           <div style={{ fontSize: 28, color: FG2, fontFamily: 'ui-monospace, Menlo, monospace' }}>
             real Chromium · palette · type · spacing · motion → a design system, live


### PR DESCRIPTION
The `/watch` OG image failed the production build: `next/og` (Satori) requires any <div> with more than one child to set an explicit `display`. The headline div mixed a text node with a <span>. Wrapped the parts in spans inside a flex container. Unblocks the 13.0.0 release build (PR #174).