### PR TITLE
feat(cli): add `designlang doctor` health-check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ designlang drift https://yourapp.com --tokens ./src/tokens.json
 designlang lint ./src/tokens/design-tokens.json     # CI-ready linter
 designlang visual-diff https://staging.app https://app   # single-file HTML diff
 designlang mcp                              # stdio MCP server for Cursor / Claude Code
+designlang doctor                           # sanity-check the local install
 ```
 
 ## All features
@@ -399,6 +400,7 @@ designlang ships surfaces beyond the CLI:
 | **Figma plugin** | [`figma-plugin/`](figma-plugin/) | Paste a URL inside Figma, get a full Variables collection. |
 | **GitHub Action** | [`github-action/`](github-action/) | "Design regression guard" — diffs tokens on every PR and comments. |
 | **Chrome extension** | [`chrome-extension/`](chrome-extension/) | One-click handoff from any tab (MV3, `activeTab` only). |
+| **Doctor** | `designlang doctor` | One-screen health check of the local install — Node, playwright, Chromium binary, output dir, network. Exits `1` if anything fails. |
 | **MCP server** | `npx designlang mcp` | Exposes the extracted design as MCP resources + tools for Cursor, Claude Code, Windsurf, etc. See [`docs/MCP-REGISTRY.md`](docs/MCP-REGISTRY.md). |
 | **Claude Code plugin** | [`.claude-plugin/`](.claude-plugin/) | Five slash commands inside Claude Code — `/extract`, `/grade`, `/battle`, `/remix`, `/pack`. |
 

--- a/bin/design-extract.js
+++ b/bin/design-extract.js
@@ -2322,6 +2322,72 @@ program
     }
   });
 
+// ── Doctor — sanity-check the local install ────────────────
+program
+  .command('doctor')
+  .description('Print a one-screen health check of the local designlang install')
+  .action(async () => {
+    const { existsSync, accessSync, constants } = await import('fs');
+    const { createRequire } = await import('module');
+    const require = createRequire(import.meta.url);
+    const pkg = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf-8'));
+    const checks = [];
+    const add = (label, value, status, fix) => checks.push({ label, value, status, fix });
+
+    const nodeMajor = Number(process.versions.node.split('.')[0]);
+    const minNode = Number((pkg.engines?.node || '>=20').replace(/\D+/g, ''));
+    add('Node', process.version, nodeMajor >= minNode ? 'OK' : 'FAIL', `upgrade to Node ${minNode} or newer`);
+
+    add('designlang', `v${PKG_VERSION}`, 'OK');
+
+    try {
+      const pwPkg = JSON.parse(readFileSync(require.resolve('playwright/package.json'), 'utf-8'));
+      add('playwright', pwPkg.version, 'OK');
+    } catch {
+      add('playwright', 'not installed', 'FAIL', 'npm install');
+    }
+
+    try {
+      const { chromium } = await import('playwright');
+      const bin = chromium.executablePath();
+      if (existsSync(bin)) add('Chromium binary', bin, 'OK');
+      else add('Chromium binary', 'not installed', 'FAIL', 'npx playwright install chromium');
+    } catch {
+      add('Chromium binary', 'not resolvable', 'FAIL', 'npx playwright install chromium');
+    }
+
+    const outDir = resolve('./design-extract-output');
+    try {
+      accessSync(existsSync(outDir) ? outDir : dirname(outDir), constants.W_OK);
+      add('Output dir', `${outDir} writable`, 'OK');
+    } catch {
+      add('Output dir', `${outDir} not writable`, 'FAIL', 'check directory permissions, or pass -o <dir>');
+    }
+
+    try {
+      const res = await fetch('https://api.github.com', { signal: AbortSignal.timeout(3000) });
+      add('Network', `api.github.com reachable (${res.status})`, 'OK');
+    } catch {
+      add('Network', 'api.github.com unreachable', 'WARN', 'only needed for remote features — extraction of local URLs still works');
+    }
+
+    const pad = Math.max(...checks.map(c => c.label.length)) + 2;
+    const paint = { OK: chalk.green, WARN: chalk.yellow, FAIL: chalk.red };
+    console.log('');
+    console.log(chalk.bold('  designlang doctor'));
+    console.log('');
+    for (const c of checks) {
+      console.log(`  ${c.label.padEnd(pad)}${c.value}  ${paint[c.status](c.status)}`);
+      if (c.status !== 'OK' && c.fix) console.log(`  ${''.padEnd(pad)}${chalk.dim('fix: ' + c.fix)}`);
+    }
+    console.log('');
+    const failed = checks.filter(c => c.status === 'FAIL');
+    if (failed.length) console.log(chalk.red(`  ${failed.length} check${failed.length > 1 ? 's' : ''} failed.`));
+    else console.log(chalk.green('  All checks passed.'));
+    console.log('');
+    process.exit(failed.length ? 1 : 0);
+  });
+
 // ── MCP server command ─────────────────────────────────────
 program
   .command('mcp')

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,8 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { readFileSync, openSync, closeSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
 import { parsePlatforms, mergeConfig } from '../src/config.js';
 
 const CLI_PATH = resolve(import.meta.dirname, '..', 'bin', 'design-extract.js');
@@ -119,5 +120,59 @@ describe('mergeConfig platforms', () => {
   it('defaults to [web] when neither CLI nor config provides platforms', () => {
     const merged = mergeConfig({}, {});
     assert.deepEqual(merged.platforms, ['web']);
+  });
+});
+
+describe('doctor command', () => {
+  const runDoctor = (args = []) => {
+    try {
+      return { status: 0, output: execFileSync('node', [CLI_PATH, 'doctor', ...args], { encoding: 'utf-8', stdio: 'pipe' }) };
+    } catch (err) {
+      return { status: err.status, output: (err.stdout || '') + (err.stderr || '') };
+    }
+  };
+
+  it('registers the doctor command in help output', () => {
+    // Redirect to a file rather than a pipe: commander exits before a piped
+    // stdout flushes, which truncates the tail of the command list.
+    const tmp = join(tmpdir(), `designlang-help-${process.pid}.txt`);
+    const fd = openSync(tmp, 'w');
+    try {
+      execFileSync('node', [CLI_PATH, '--help'], { stdio: ['ignore', fd, 'ignore'] });
+    } finally {
+      closeSync(fd);
+    }
+    const output = readFileSync(tmp, 'utf-8');
+    rmSync(tmp, { force: true });
+    assert.ok(output.includes('doctor'));
+  });
+
+  it('describes itself under doctor --help', () => {
+    const output = execFileSync('node', [CLI_PATH, 'doctor', '--help'], { encoding: 'utf-8' });
+    assert.ok(output.includes('health check'));
+  });
+
+  it('prints a row for every environment check', () => {
+    const { output } = runDoctor();
+    for (const label of ['Node', 'designlang', 'playwright', 'Chromium binary', 'Output dir', 'Network']) {
+      assert.ok(output.includes(label), `missing check row: ${label}`);
+    }
+  });
+
+  it('reports the running designlang version', () => {
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
+    const { output } = runDoctor();
+    assert.ok(output.includes(pkg.version));
+  });
+
+  it('exits 0 if and only if every check passed', () => {
+    const { status, output } = runDoctor();
+    assert.equal(status === 0, output.includes('All checks passed'));
+  });
+
+  it('prints a fix hint for each failing check', () => {
+    const { output } = runDoctor();
+    const failed = output.split('\n').filter(l => /\bFAIL\b/.test(l));
+    if (failed.length) assert.ok(output.includes('fix:'), 'a failing check must print a fix hint');
   });
 });


### PR DESCRIPTION
Closes #107.

Adds a `designlang doctor` subcommand that prints a one-screen health check of the local install, so a failing extraction can be diagnosed without opening an issue.

```
  designlang doctor

  Node             v22.16.0  OK
  designlang       v13.0.0  OK
  playwright       1.61.0  OK
  Chromium binary  not installed  FAIL
                   fix: npx playwright install chromium
  Output dir       /path/to/design-extract-output writable  OK
  Network          api.github.com reachable (200)  OK

  1 check failed.
```

Exits `0` when every check passes, `1` when any check fails. No new dependencies — `fs`, `module`, and `fetch` only. ~66 lines in `bin/design-extract.js`, no extraction logic touched.

### Two deliberate deviations from the issue

- **No `playwright-core` row.** This repo depends on full `playwright@^1.61.0`; `playwright-core` is not a direct dependency, so the row reports `playwright` instead.
- **No `Browserless token` row.** There is no browserless integration anywhere in `src/` or `bin/` — the only env var the codebase reads is `GITHUB_STEP_SUMMARY`. Checking for a `BROWSERLESS_TOKEN` would advertise a feature that doesn't exist. Adding real browserless fallback is a separate, much larger change.

The network probe uses a 3s `AbortSignal.timeout` and reports `WARN` rather than `FAIL`, so working offline doesn't produce a misleading exit code 1.

### Tests

Six new cases in `tests/cli.test.js`. Suite goes 550 → 556 passing; the 3 pre-existing `pdf renderer` failures are unchanged on this branch and on a clean tree.

### Latent bug found, not fixed here

`designlang --help` **truncates when piped** — commander calls `process.exit()` before a piped stdout flushes, so the tail of the command list is lost (8175 of 8636 chars). Redirected to a file the output is complete. Adding one more command pushed it past the threshold, which is how it surfaced. The new help test writes to a file rather than a pipe to stay deterministic. Worth its own issue and fix rather than smuggling a `process.exit` change into this PR.